### PR TITLE
fix(glance): mount dynacat config as glance.yml

### DIFF
--- a/kubernetes/apps/equestria/home/glance/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/glance/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 configMapGenerator:
 - name: glance-config
   files:
-  - ./resources/dynacat.yml
+  - glance.yml=./resources/dynacat.yml
   - ./resources/home.yaml
   - ./resources/homelab.yaml
   - ./resources/high-seas.yaml


### PR DESCRIPTION
## Problem

Glance is in CrashLoopBackOff (484 restarts) with:

```
parsing config: reading /app/config/glance.yml: open /app/config/glance.yml: no such file or directory
```

## Root Cause

Commit `4b18cb84c` switched the image from `glanceapp/glance` to `ghcr.io/panonim/dynacat` and added `resources/dynacat.yml` as the config file. However, the kustomize `configMapGenerator` was referencing the file as `./resources/dynacat.yml`, which means the ConfigMap key (and therefore the mounted filename) became `dynacat.yml`. The dynacat image (a Glance fork) still looks for `/app/config/glance.yml` by default.

## Fix

Use the `key=file` syntax in the configMapGenerator so the entry is named `glance.yml` regardless of the source filename:

```yaml
- glance.yml=./resources/dynacat.yml
```

This is a one-line change.