### PR TITLE
fix(super-productivity): add CHOWN, SETUID, SETGID capabilities for nginx

### DIFF
--- a/kubernetes/apps/equestria/home/super-productivity/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
               readOnlyRootFilesystem: false
               capabilities:
                 drop: ["ALL"]
-                add: ["NET_BIND_SERVICE"]
+                add: ["NET_BIND_SERVICE", "CHOWN", "SETUID", "SETGID"]
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
## Problem

The `super-productivity` pod has been in `CrashLoopBackOff` for 20h (240+ restarts) with this error:

```
chown("/var/cache/nginx/client_temp", 101) failed (1: Operation not permitted)
nginx: [emerg] chown(...) failed (1: Operation not permitted)
```

## Root Cause

The container security context drops **ALL** Linux capabilities and only adds `NET_BIND_SERVICE`. The nginx process (running as root/uid 0) needs:

- **`CHOWN`** — to set ownership of its cache directories to the nginx user (uid 101) at startup
- **`SETUID`/`SETGID`** — to spawn worker processes as the nginx user

Without these, nginx immediately crashes on every start.

## Fix

Added the three missing capabilities nginx requires:

```yaml
capabilities:
  drop: ["ALL"]
  add: ["NET_BIND_SERVICE", "CHOWN", "SETUID", "SETGID"]
```

This matches the pattern used by other nginx-based containers in the cluster (e.g., n8n uses `CHOWN` + `FOWNER`).

## Validation

- ✅ `flux-local test` — 246 tests passed