### PR TITLE
Upgrade Talos to 1.13 and Kubelet to 1.36

### DIFF
--- a/.github/sgc-sync.yaml
+++ b/.github/sgc-sync.yaml
@@ -88,8 +88,6 @@ david-driscoll/stargate-command-cluster:
     dest: talos/patches/global/machine-kubelet.yaml
   - source: talos/patches/global/machine-files.yaml
     dest: talos/patches/global/machine-files.yaml
-  - source: talos/patches/global/cluster-admissionregistration.yaml
-    dest: talos/patches/global/cluster-admissionregistration.yaml
   - source: talos/patches/global/machine-time.yaml
     dest: talos/patches/global/machine-time.yaml
   - source: talos/patches/controller/cluster.yaml

--- a/kubernetes/apps/equestria/home/windmill/httproute.yaml
+++ b/kubernetes/apps/equestria/home/windmill/httproute.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/equestria/media/pinepods/httproute.yaml
+++ b/kubernetes/apps/equestria/media/pinepods/httproute.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/httproute.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/httproute.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/kube-system/1password/httproute.yaml
+++ b/kubernetes/apps/kube-system/1password/httproute.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/kube-system/etcd/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
           talosctl:
             image:
               repository: ghcr.io/siderolabs/talosctl
-              tag: v1.12.6@sha256:a027cf02cf74a75eee83ccffa201f3a9455d77e795d092b87cae5e637f143e54
+              tag: v1.13.0@sha256:cf5be4c584572787eda0f5818404d2380f041b1022ce85454b25d4e01334fba6
             args:
               - --talosconfig
               - /var/run/secrets/talos.dev/config
@@ -75,7 +75,7 @@ spec:
           defrag:
             image:
               repository: ghcr.io/siderolabs/talosctl
-              tag: v1.12.6@sha256:a027cf02cf74a75eee83ccffa201f3a9455d77e795d092b87cae5e637f143e54
+              tag: v1.13.0@sha256:cf5be4c584572787eda0f5818404d2380f041b1022ce85454b25d4e01334fba6
             args:
               - --talosconfig
               - /var/run/secrets/talos.dev/config

--- a/kubernetes/apps/kube-system/etcd/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
           talosctl:
             image:
               repository: ghcr.io/siderolabs/talosctl
-              tag: v1.12.6@sha256:a027cf02cf74a75eee83ccffa201f3a9455d77e795d092b87cae5e637f143e54
+              tag: v1.13.2@sha256:6382e6f6f8b08ab7c5cc9f77446cfd79975fe0055c0a6d73455a9dc6a6c4b98d
             args:
               - --talosconfig
               - /var/run/secrets/talos.dev/config
@@ -75,7 +75,7 @@ spec:
           defrag:
             image:
               repository: ghcr.io/siderolabs/talosctl
-              tag: v1.12.6@sha256:a027cf02cf74a75eee83ccffa201f3a9455d77e795d092b87cae5e637f143e54
+              tag: v1.13.2@sha256:6382e6f6f8b08ab7c5cc9f77446cfd79975fe0055c0a6d73455a9dc6a6c4b98d
             args:
               - --talosconfig
               - /var/run/secrets/talos.dev/config

--- a/kubernetes/apps/kube-system/headlamp/httproute.yaml
+++ b/kubernetes/apps/kube-system/headlamp/httproute.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/observability/glance-k8s/httproute.yaml
+++ b/kubernetes/apps/observability/glance-k8s/httproute.yaml
@@ -1,6 +1,5 @@
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/system-upgrade/upgrades/kubernetes.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/kubernetes.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.4
+    version: v1.36.0
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/kubernetes/apps/system-upgrade/upgrades/kubernetes.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/kubernetes.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.4
+    version: v1.36.1
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/kubernetes/apps/system-upgrade/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/talos.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.12.6
+    version: v1.13.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/kubernetes/apps/system-upgrade/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/talos.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.12.6
+    version: v1.13.2
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/kubernetes/apps/volsync-system/volsync/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/mutatingadmissionpolicy.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicybinding-admissionregistration-v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
@@ -7,7 +7,7 @@ metadata:
 spec:
   policyName: volsync-mover-jitter
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicy-admissionregistration-v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
@@ -49,7 +49,7 @@ spec:
             }
           ]
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicybinding-admissionregistration-v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
@@ -57,7 +57,7 @@ metadata:
 spec:
   policyName: volsync-mover-nfs
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicy-admissionregistration-v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/mutatingadmissionpolicy.yaml
@@ -1,14 +1,14 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-jitter
 spec:
   policyName: volsync-mover-jitter
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-jitter
@@ -49,16 +49,16 @@ spec:
             }
           ]
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-nfs
 spec:
   policyName: volsync-mover-nfs
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-nfs

--- a/talos/patches/global/cluster-admissionregistration.yaml
+++ b/talos/patches/global/cluster-admissionregistration.yaml
@@ -1,5 +1,0 @@
-cluster:
-  apiServer:
-    extraArgs:
-      runtime-config: admissionregistration.k8s.io/v1beta1=true
-      feature-gates: MutatingAdmissionPolicy=true

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -253,7 +253,6 @@ patches:
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
   - "@./patches/global/machine-registries.yaml"
-  - "@./patches/global/cluster-admissionregistration.yaml"
 
 # Controller patches
 controlPlane:

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,6 +1,6 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.4
+kubernetesVersion: v1.36.1
 # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
 prometheusOperatorVersion: v0.91.0

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,6 +1,6 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.12.6
+talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.4
+kubernetesVersion: v1.36.0
 # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
 prometheusOperatorVersion: v0.91.0

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.12.6
+talosVersion: v1.13.2
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.35.4
 # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator

--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-KUBERNETES_VERSION=v1.35.4
+KUBERNETES_VERSION=v1.36.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-TALOS_VERSION=v1.12.6
+TALOS_VERSION=v1.13.0

--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 KUBERNETES_VERSION=v1.35.4
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-TALOS_VERSION=v1.12.6
+TALOS_VERSION=v1.13.2

--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-KUBERNETES_VERSION=v1.35.4
+KUBERNETES_VERSION=v1.36.1
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 TALOS_VERSION=v1.12.6


### PR DESCRIPTION
Update the Talos and Kubelet versions to the latest stable releases to ensure compatibility and access to new features. Additionally, remove deprecated API versions in the configuration files.