### PR TITLE
feat(observability): deploy Grafana Tempo and add OTLP pipeline to Alloy

### DIFF
--- a/kubernetes/apps/observability/alloy/helmrelease.yaml
+++ b/kubernetes/apps/observability/alloy/helmrelease.yaml
@@ -38,6 +38,15 @@ spec:
         name: &app alloy-configmap
         key: config.alloy
       enableReporting: false
+      extraPorts:
+        - name: otlp-grpc
+          port: 4317
+          targetPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          port: 4318
+          targetPort: 4318
+          protocol: TCP
 
     controller:
       podAnnotations:

--- a/kubernetes/apps/observability/alloy/resources/config.alloy
+++ b/kubernetes/apps/observability/alloy/resources/config.alloy
@@ -151,3 +151,87 @@ loki.write "default" {
     url = "http://loki-headless.observability.svc.cluster.local:3100/loki/api/v1/push"
   }
 }
+
+// ── OpenTelemetry Pipeline ──────────────────────────────────────────────────
+
+// Receive OTLP signals from pods in-cluster
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    metrics = [otelcol.processor.attributes.default.input]
+    logs    = [otelcol.processor.attributes.default.input]
+    traces  = [otelcol.processor.attributes.default.input]
+  }
+}
+
+// Inject cluster/environment labels onto all signals
+otelcol.processor.attributes "default" {
+  action {
+    key    = "cluster"
+    value  = "${CLUSTER_CNAME}"
+    action = "insert"
+  }
+  action {
+    key    = "environment"
+    value  = "homelab"
+    action = "insert"
+  }
+  action {
+    key    = "region"
+    value  = "home"
+    action = "insert"
+  }
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Batch signals before forwarding
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+    logs    = [otelcol.exporter.loki.default.input]
+    traces  = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+
+// OTLP metrics → Prometheus remote_write → Thanos
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.thanos.receiver]
+}
+
+prometheus.remote_write "thanos" {
+  endpoint {
+    url = "http://thanos-receive.observability.svc.cluster.local:19291/api/v1/receive"
+    queue_config {
+      max_samples_per_send = 10000
+    }
+  }
+  external_labels = {
+    cluster     = "${CLUSTER_CNAME}",
+    environment = "homelab",
+    region      = "home",
+  }
+}
+
+// OTLP logs → Loki (reuse existing loki.write.default)
+otelcol.exporter.loki "default" {
+  forward_to = [loki.write.default.receiver]
+}
+
+// OTLP traces → Grafana Tempo (in-cluster)
+otelcol.exporter.otlphttp "tempo" {
+  client {
+    endpoint = "http://tempo.observability.svc.cluster.local:4318"
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/kubernetes/apps/observability/grafana/datasources.yaml
+++ b/kubernetes/apps/observability/grafana/datasources.yaml
@@ -53,3 +53,32 @@ spec:
     url: http://alertmanager-operated.observability.svc.cluster.local:9093
     jsonData:
       implementation: prometheus
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: tempo
+  labels:
+    dashboards: "grafana"
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  datasource:
+    name: "Tempo"
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo.observability.svc.cluster.local:3200
+    isDefault: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: '-1h'
+        spanEndTimeShift: '1h'
+      tracesToMetrics:
+        datasourceUid: prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - ./speedtest-exporter/ks.yaml
   - ./unpoller/ks.yaml
   - ./glance-k8s/ks.yaml
+  - ./tempo/ks.yaml

--- a/kubernetes/apps/observability/tempo/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/helmrelease.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tempo
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.14.0
+  url: oci://ghcr.io/grafana/helm-charts/tempo
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tempo
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: tempo
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: tempo
+    tempo:
+      reportingEnabled: false
+      storage:
+        trace:
+          backend: local
+          local:
+            path: /var/tempo/traces
+      server:
+        http_listen_port: 3200
+      distributor:
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+                endpoint: "0.0.0.0:4317"
+              http:
+                endpoint: "0.0.0.0:4318"
+    persistence:
+      enabled: true
+      size: 10Gi
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/observability/tempo/ks.yaml
+++ b/kubernetes/apps/observability/tempo/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tempo
+  namespace: &namespace observability
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/observability/tempo
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/observability/tempo/kustomization.yaml
+++ b/kubernetes/apps/observability/tempo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

### Grafana Tempo
- New app at `kubernetes/apps/observability/tempo/`
- Chart: `oci://ghcr.io/grafana/helm-charts/tempo:1.14.0` (monolithic mode, 10Gi PVC)
- OTLP receivers on gRPC 4317 / HTTP 4318, ServiceMonitor enabled

### Alloy OTLP Pipeline
- Append OTLP pipeline to Alloy config: receiver → attributes processor → batch → Thanos/Loki/Tempo
- Expose OTLP ports 4317/4318 on Alloy HelmRelease service

### Grafana Datasource
- Add Tempo GrafanaDatasource with trace→logs and trace→metrics correlation

## Merge Order
This should merge before stargate-command-cluster PR (SGC forwards traces here).