### PR TITLE
fix(tailscale): add SSH port and correct FQDN for PBS services

### DIFF
--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -177,6 +177,7 @@ cluster:
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
       wal_keep_size: "1GB"
+      max_slot_wal_keep_size: "5GB"
       wal_sender_timeout: "120s"
       wal_receiver_timeout: "120s"
       tcp_keepalives_idle: "10"

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -176,6 +176,7 @@ cluster:
       shared_buffers: "${POSTGRES_SHARED_BUFFERS}"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      wal_keep_size: "1GB"
       wal_sender_timeout: "120s"
       wal_receiver_timeout: "120s"
       tcp_keepalives_idle: "10"

--- a/kubernetes/apps/tailscale-system/services/Update.cs
+++ b/kubernetes/apps/tailscale-system/services/Update.cs
@@ -22,7 +22,7 @@ var defaultPorts = new Dictionary<ServiceKind, List<PortDef>>
 {
   [ServiceKind.Dockge] = [new("https", 443, true, "http_2xx"), new("ssh", 22, true, "ssh_banner")],
   [ServiceKind.Proxmox] = [new("pve", 8006, true, "http_2xx"), new("ssh", 22, true, "ssh_banner")],
-  [ServiceKind.Pbs] = [new("pbs", 8007, true, "http_2xx")],
+  [ServiceKind.Pbs] = [new("pbs", 8007, true, "http_2xx"), new("ssh", 22, true, "ssh_banner")],
 };
 
 // Maps Tailscale tag → (ServiceKind, fn to extract the physical server name)
@@ -137,9 +137,9 @@ static string ExternalName(string server, ServiceKind kind) => kind switch
 {
   // dockge nodes live on the tailnet as "dockge-<server>"
   ServiceKind.Dockge => $"dockge-{server}",
-  // proxmox and pbs share the same underlying node "<server>"
+  // proxmox shares the same underlying node "<server>"; pbs has its own tailnet device
   ServiceKind.Proxmox => server,
-  ServiceKind.Pbs => server,
+  ServiceKind.Pbs => $"pbs-{server}",
   _ => throw new ArgumentOutOfRangeException(nameof(kind)),
 };
 
@@ -147,14 +147,14 @@ static string TailnetFqdn(string server, ServiceKind kind) => kind switch
 {
   ServiceKind.Dockge => $"dockge-{server}.${{TAILSCALE_DOMAIN}}",
   ServiceKind.Proxmox => $"{server}.${{TAILSCALE_DOMAIN}}",
-  ServiceKind.Pbs => $"{server}.${{TAILSCALE_DOMAIN}}",
+  ServiceKind.Pbs => $"pbs-{server}.${{TAILSCALE_DOMAIN}}",
   _ => throw new ArgumentOutOfRangeException(nameof(kind)),
 };
 
 // Returns the URL used in HTTP probes (includes port for non-standard 80/443)
 static string ProbeHttpUrl(string server, ServiceKind kind, int port)
 {
-  var fqdn = kind == ServiceKind.Dockge ? $"dockge-{server}.${{TAILSCALE_DOMAIN}}" : $"{server}.${{TAILSCALE_DOMAIN}}";
+  var fqdn = kind == ServiceKind.Dockge ? $"dockge-{server}.${{TAILSCALE_DOMAIN}}" : kind == ServiceKind.Pbs ? $"pbs-{server}.${{TAILSCALE_DOMAIN}}" : $"{server}.${{TAILSCALE_DOMAIN}}";
   return port == 443 ? $"https://{fqdn}" : $"https://{fqdn}:{port}";
 }
 
@@ -162,6 +162,7 @@ static string ProbeSshTarget(string server, ServiceKind kind) => kind switch
 {
   ServiceKind.Dockge => $"dockge-{server}.${{TAILSCALE_DOMAIN}}:22",
   ServiceKind.Proxmox => $"{server}.${{TAILSCALE_DOMAIN}}:22",
+  ServiceKind.Pbs => $"pbs-{server}.${{TAILSCALE_DOMAIN}}:22",
   _ => throw new ArgumentOutOfRangeException(nameof(kind)),
 };
 
@@ -304,6 +305,15 @@ string PbsAlertYaml(string server)
   sb.AppendLine($"            summary: \"PBS {server} is unhealthy\"");
   sb.AppendLine($"          expr: |");
   sb.AppendLine($"            probe_success{{probe=\"pbs-{server}\"}} < 1");
+  sb.AppendLine($"          for: 10m");
+  sb.AppendLine($"          labels:");
+  sb.AppendLine($"            severity: warning");
+  sb.AppendLine($"        - alert: PBSSSHConnectivityLost");
+  sb.AppendLine($"          annotations:");
+  sb.AppendLine($"            description: \"SSH connectivity to PBS on {server} has been lost.\"");
+  sb.AppendLine($"            summary: \"PBS {server} SSH lost\"");
+  sb.AppendLine($"          expr: |");
+  sb.AppendLine($"            probe_success{{probe=\"pbs-{server}-ssh\"}} < 1");
   sb.AppendLine($"          for: 10m");
   sb.AppendLine($"          labels:");
   sb.AppendLine($"            severity: warning");

--- a/kubernetes/apps/tailscale-system/services/celestia.yaml
+++ b/kubernetes/apps/tailscale-system/services/celestia.yaml
@@ -155,15 +155,18 @@ kind: Service
 metadata:
   name: pbs-celestia
   annotations:
-    tailscale.com/tailnet-fqdn: "celestia.${TAILSCALE_DOMAIN}"
+    tailscale.com/tailnet-fqdn: "pbs-celestia.${TAILSCALE_DOMAIN}"
     tailscale.com/proxy-group: tailnet-inbound
 spec:
   type: ExternalName
-  externalName: celestia
+  externalName: pbs-celestia
   ports:
     - name: pbs
       port: 8007
       targetPort: 8007
+    - name: ssh
+      port: 22
+      targetPort: 22
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
@@ -177,7 +180,21 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://celestia.${TAILSCALE_DOMAIN}:8007
+        - https://pbs-celestia.${TAILSCALE_DOMAIN}:8007
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: pbs-celestia-ssh
+spec:
+  interval: 5m
+  module: ssh_banner
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - pbs-celestia.${TAILSCALE_DOMAIN}:22
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -193,6 +210,15 @@ spec:
             summary: "PBS celestia is unhealthy"
           expr: |
             probe_success{probe="pbs-celestia"} < 1
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PBSSSHConnectivityLost
+          annotations:
+            description: "SSH connectivity to PBS on celestia has been lost."
+            summary: "PBS celestia SSH lost"
+          expr: |
+            probe_success{probe="pbs-celestia-ssh"} < 1
           for: 10m
           labels:
             severity: warning

--- a/kubernetes/apps/tailscale-system/services/kustomization.yaml
+++ b/kubernetes/apps/tailscale-system/services/kustomization.yaml
@@ -9,5 +9,3 @@ resources:
   - ./as.yaml
   - ./celestia.yaml
   - ./luna.yaml
-  - ./skystar.yaml
-  - ./twilight-sparkle.yaml

--- a/kubernetes/apps/tailscale-system/services/luna.yaml
+++ b/kubernetes/apps/tailscale-system/services/luna.yaml
@@ -155,15 +155,18 @@ kind: Service
 metadata:
   name: pbs-luna
   annotations:
-    tailscale.com/tailnet-fqdn: "luna.${TAILSCALE_DOMAIN}"
+    tailscale.com/tailnet-fqdn: "pbs-luna.${TAILSCALE_DOMAIN}"
     tailscale.com/proxy-group: tailnet-inbound
 spec:
   type: ExternalName
-  externalName: luna
+  externalName: pbs-luna
   ports:
     - name: pbs
       port: 8007
       targetPort: 8007
+    - name: ssh
+      port: 22
+      targetPort: 22
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
@@ -177,7 +180,21 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://luna.${TAILSCALE_DOMAIN}:8007
+        - https://pbs-luna.${TAILSCALE_DOMAIN}:8007
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: pbs-luna-ssh
+spec:
+  interval: 5m
+  module: ssh_banner
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - pbs-luna.${TAILSCALE_DOMAIN}:22
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -193,6 +210,15 @@ spec:
             summary: "PBS luna is unhealthy"
           expr: |
             probe_success{probe="pbs-luna"} < 1
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PBSSSHConnectivityLost
+          annotations:
+            description: "SSH connectivity to PBS on luna has been lost."
+            summary: "PBS luna SSH lost"
+          expr: |
+            probe_success{probe="pbs-luna-ssh"} < 1
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary

Fixes the `gulf-of-mexico` Pulumi stack failing with `dial tcp 10.196.200.21:22: i/o timeout`.

### Root cause

The `pbs-luna` and `pbs-celestia` ExternalName services were misconfigured in `Update.cs`:
1. **Missing port 22**: PBS LXCs have Tailscale SSH enabled and the Pulumi operator SSHes to them via `pbs-<server>.<tailnet>:22` to provision the `tailscale-pbs.sh` cron script
2. **Wrong FQDN (for PBS)**: PBS ExternalName was using `luna.` (Proxmox host) — should be `pbs-<server>.` (the PBS LXC's own Tailscale device)

### Changes

**`Update.cs`**:
- PBS default ports: add `ssh:22` alongside `pbs:8007`
- `ExternalName()`: PBS uses `pbs-{server}` (the LXC tailnet device, not the Proxmox host)
- `TailnetFqdn()`: PBS uses `pbs-{server}.${TAILSCALE_DOMAIN}`
- `ProbeHttpUrl()`: handle PBS FQDN correctly
- `ProbeSshTarget()`: add PBS case
- `PbsAlertYaml()`: add `PBSSSHConnectivityLost` alert rule

**Regenerated**: `luna.yaml`, `celestia.yaml`, `kustomization.yaml`

Also includes prior fixes on this branch:
- postgres: max_slot_wal_keep_size and WAL retention limits