### PR TITLE
feat(technitium): fix OIDC bugs, add Multus ipvlan NAD, and cluster init Job

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/definition.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/definition.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   name: Technitium DNS
   category: ${CLUSTER_TITLE}
-  description: Primary Technitium DNS cluster node
+  description: Technitium DNS cluster node
   url: &url https://${APP}.${CLUSTER_DOMAIN}
   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/technitium.png
   access_policy:
@@ -17,7 +17,7 @@ spec:
     oauth2:
       clientType: confidential
       allowedRedirectUris:
-      - url: "https://${APP}.${ROOT_DOMAIN}/sso/callback"
+      - url: "https://${APP}.${CLUSTER_DOMAIN}/sso/callback"
       propertyMappings:
         - email
         - openid

--- a/kubernetes/apps/equestria/dns/technitium/externalsecret.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/externalsecret.yaml
@@ -25,3 +25,15 @@ spec:
       remoteRef:
         key: "Technitium Password"
         property: password
+    - secretKey: DNS_SERVER_SSO_AUTHORITY
+      remoteRef:
+        key: "equestria-technitium-oidc-credentials"
+        property: issuer
+    - secretKey: DNS_SERVER_SSO_CLIENT_ID
+      remoteRef:
+        key: "equestria-technitium-oidc-credentials"
+        property: client_id
+    - secretKey: DNS_SERVER_SSO_CLIENT_SECRET
+      remoteRef:
+        key: "equestria-technitium-oidc-credentials"
+        property: client_secret

--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -45,8 +45,8 @@ spec:
               DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS: "true"
               DNS_SERVER_WEB_SERVICE_USE_SELF_SIGNED_CERT: "true"
               DNS_SERVER_RECURSION: AllowOnlyForPrivateNetworks
-              # DNS_SERVER_FORWARDERS: "1.1.1.1, 1.0.0.1, 9.9.9.9"
-              # DNS_SERVER_FORWARDER_PROTOCOL: Tls
+              DNS_SERVER_FORWARDERS: "9.9.9.9, 149.112.112.112, [2620:fe::fe], [2620:fe::9]"
+              DNS_SERVER_FORWARDER_PROTOCOL: Tls
               DNS_SERVER_ENABLE_BLOCKING: "true"
               DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP: "true"
               # SSO static env vars (first-start only — init-job applies them at runtime too)

--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -102,10 +102,14 @@ spec:
         runAsGroup: 0
         seccompProfile:
           type: RuntimeDefault
-      # Pin to a worker node labeled `technitium-dns=true` (must have enp2s0 NIC)
-      # Label a node: kubectl label node <node-name> technitium-dns=true
+      # Pin to hard-hat (10.10.206.14) via talconfig nodeLabel technitium-dns=true.
+      # That node is a control plane node, so tolerate the NoSchedule taint.
       nodeSelector:
         technitium-dns: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
 
     service:
       # DNS traffic (port 53 UDP/TCP) is handled directly by the ipvlan interface (see macvlan-nad.yaml).

--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          k8s.v1.cni.cncf.io/networks: technitium-dns-net
         containers:
           *app :
             image:
@@ -48,6 +49,13 @@ spec:
               # DNS_SERVER_FORWARDER_PROTOCOL: Tls
               DNS_SERVER_ENABLE_BLOCKING: "true"
               DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP: "true"
+              # SSO static env vars (first-start only — init-job applies them at runtime too)
+              DNS_SERVER_SSO_ENABLED: "true"
+              DNS_SERVER_SSO_ALLOW_SIGNUP: "true"
+              DNS_SERVER_SSO_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS: "true"
+              DNS_SERVER_SSO_GROUP_MAP: "admins:Administrators"
+              # Bind the DNS service to the ipvlan interface IP so cluster peers can reach it
+              DNS_SERVER_LOCAL_ENDPOINTS: "${TECHNITIUM_VIP}:53443"
             envFrom:
               - secretRef:
                   name: ${APP}-env
@@ -94,51 +102,22 @@ spec:
         runAsGroup: 0
         seccompProfile:
           type: RuntimeDefault
+      # Pin to a worker node labeled `technitium-dns=true` (must have enp2s0 NIC)
+      # Label a node: kubectl label node <node-name> technitium-dns=true
+      nodeSelector:
+        technitium-dns: "true"
 
     service:
-      dns:
-        controller: *app
-        type: LoadBalancer
-        loadBalancerIP: "${TECHNITIUM_VIP}"
-        annotations:
-          io.cilium/lb-ipam-ips: "${TECHNITIUM_VIP}"
-          tailscale.com/expose: "true"
-          tailscale.com/hostname: ${APP}-${CLUSTER_CNAME}
-          tailscale.com/tailnet-ip: "${TECHNITIUM_TAILSCALE_VIP}"
-          external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
-        externalIPs:
-          - "${TECHNITIUM_VIP}"
-        externalTrafficPolicy: Cluster
-        ports:
-          dns-udp:
-            port: 53
-            protocol: UDP
-          dns-tcp:
-            port: 53
-            protocol: TCP
-          dot:
-            port: 853
-            protocol: TCP
-          doq:
-            port: 853
-            protocol: UDP
-          doh-https-tcp:
-            port: 443
-            protocol: TCP
-          doh-https-udp:
-            port: 443
-            protocol: UDP
-          doh-http:
-            port: 80
-            protocol: TCP
-          admin-https:
-            port: 53443
-            protocol: TCP
+      # DNS traffic (port 53 UDP/TCP) is handled directly by the ipvlan interface (see macvlan-nad.yaml).
+      # No LoadBalancer service is needed for DNS — TECHNITIUM_VIP is owned by the pod's net1 interface.
       admin:
         controller: *app
         ports:
           admin:
             port: *adminPort
+            protocol: TCP
+          cluster-https:
+            port: 53443
             protocol: TCP
 
     persistence:

--- a/kubernetes/apps/equestria/dns/technitium/init-job.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/init-job.yaml
@@ -1,0 +1,154 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/batch/job_v1.json
+# This Job runs after Technitium is deployed and:
+#   1. Configures SSO via API (idempotent — overwrites env-var values at runtime)
+#   2. Joins the cluster as a secondary node with celestia as primary
+#
+# To re-run: kubectl delete job technitium-init -n network
+# (Jobs are immutable; deleting and letting Flux recreate it is the correct workflow)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: technitium-init
+  namespace: network
+  annotations:
+    # Re-create this job whenever the ConfigMap changes
+    reloader.stakater.com/auto: "true"
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: default
+      containers:
+        - name: init
+          image: curlimages/curl:8.7.1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+
+              ADMIN_URL="http://technitium.network.svc.cluster.local:5380"
+              log() { echo "[$(date -u +%T)] $*"; }
+              die() { echo "[$(date -u +%T)] ERROR: $*" >&2; exit 1; }
+
+              # ------------------------------------------------------------------
+              # 1. Wait for Technitium to be ready
+              # ------------------------------------------------------------------
+              log "Waiting for Technitium to be ready..."
+              READY=false
+              for i in $(seq 1 60); do
+                if curl -sf --max-time 3 "${ADMIN_URL}/api/sso/status" >/dev/null 2>&1; then
+                  READY=true
+                  break
+                fi
+                log "  ... (${i}/60)"
+                sleep 5
+              done
+              $READY || die "Technitium did not become ready after 5 minutes"
+              log "Technitium is ready."
+
+              # ------------------------------------------------------------------
+              # 2. Login
+              # ------------------------------------------------------------------
+              encoded_pass=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" \
+                "${DNS_SERVER_ADMIN_PASSWORD}")
+              login_resp=$(curl -sf --max-time 10 \
+                "${ADMIN_URL}/api/user/login?user=admin&pass=${encoded_pass}" \
+                || die "Login failed")
+              TOKEN=$(echo "$login_resp" | python3 -c \
+                "import sys,json; print(json.load(sys.stdin)['response']['token'])" \
+                || die "Failed to parse login token")
+              log "Login successful."
+
+              api() {
+                local endpoint="$1"; shift
+                curl -sf --max-time 15 -X POST \
+                  "${ADMIN_URL}/api/${endpoint}?token=${TOKEN}" "$@"
+              }
+
+              # ------------------------------------------------------------------
+              # 3. Configure SSO (always applied to fix/update runtime values)
+              # ------------------------------------------------------------------
+              log "Configuring SSO..."
+              api "admin/sso/set" \
+                --data-urlencode "ssoEnabled=true" \
+                --data-urlencode "ssoAuthority=${DNS_SERVER_SSO_AUTHORITY}" \
+                --data-urlencode "ssoClientId=${DNS_SERVER_SSO_CLIENT_ID}" \
+                --data-urlencode "ssoClientSecret=${DNS_SERVER_SSO_CLIENT_SECRET}" \
+                --data-urlencode "ssoScopes=openid|profile|email" \
+                --data-urlencode "ssoAllowSignup=true" \
+                --data-urlencode "ssoAllowSignupOnlyForMappedUsers=true" \
+                --data-urlencode "ssoGroupMap=admins|Administrators" \
+                >/dev/null || die "SSO configuration failed"
+              log "SSO configured. Waiting for web service hot-restart..."
+
+              sleep 8
+              for i in $(seq 1 24); do
+                if curl -sf --max-time 3 "${ADMIN_URL}/api/sso/status" >/dev/null 2>&1; then
+                  break
+                fi
+                log "  waiting for restart... (${i}/24)"
+                sleep 5
+              done
+
+              # Re-login after restart
+              login_resp=$(curl -sf --max-time 10 \
+                "${ADMIN_URL}/api/user/login?user=admin&pass=${encoded_pass}" \
+                || die "Re-login failed after SSO restart")
+              TOKEN=$(echo "$login_resp" | python3 -c \
+                "import sys,json; print(json.load(sys.stdin)['response']['token'])" \
+                || die "Failed to parse re-login token")
+              log "Re-login successful."
+
+              # ------------------------------------------------------------------
+              # 4. Join cluster as secondary (skip if already in cluster)
+              # ------------------------------------------------------------------
+              cluster_resp=$(api "admin/cluster/get" || echo '{}')
+              in_cluster=$(echo "$cluster_resp" | python3 -c \
+                "import sys,json; d=json.load(sys.stdin); print('true' if d.get('response',{}).get('enabled') else 'false')" \
+                2>/dev/null || echo "false")
+
+              if [ "$in_cluster" = "true" ]; then
+                log "Already in cluster — skipping join."
+              else
+                log "Joining cluster (primary: ${DNS_CLUSTER_PRIMARY_IP}:53443)..."
+                api "admin/cluster/initJoin" \
+                  --data-urlencode "primaryNodeUrl=https://${DNS_CLUSTER_PRIMARY_IP}:53443/" \
+                  --data-urlencode "primaryNodeIpAddress=${DNS_CLUSTER_PRIMARY_IP}" \
+                  --data-urlencode "ignoreCertificateErrors=true" \
+                  --data-urlencode "primaryNodeUsername=admin" \
+                  --data-urlencode "primaryNodePassword=${DNS_SERVER_ADMIN_PASSWORD}" \
+                  --data-urlencode "secondaryNodeIpAddresses=${TECHNITIUM_VIP}" \
+                  >/dev/null || die "Cluster join failed"
+                log "Successfully joined cluster."
+              fi
+
+              log "Technitium init complete."
+          env:
+            - name: DNS_SERVER_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: technitium-env
+                  key: DNS_SERVER_ADMIN_PASSWORD
+            - name: DNS_SERVER_SSO_AUTHORITY
+              valueFrom:
+                secretKeyRef:
+                  name: technitium-env
+                  key: DNS_SERVER_SSO_AUTHORITY
+            - name: DNS_SERVER_SSO_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: technitium-env
+                  key: DNS_SERVER_SSO_CLIENT_ID
+            - name: DNS_SERVER_SSO_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: technitium-env
+                  key: DNS_SERVER_SSO_CLIENT_SECRET
+            - name: TECHNITIUM_VIP
+              value: "${TECHNITIUM_VIP}"
+            - name: DNS_CLUSTER_PRIMARY_IP
+              value: "100.111.30.100"

--- a/kubernetes/apps/equestria/dns/technitium/init-job.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/init-job.yaml
@@ -104,7 +104,18 @@ spec:
               log "Re-login successful."
 
               # ------------------------------------------------------------------
-              # 4. Join cluster as secondary (skip if already in cluster)
+              # 4. Configure forwarders (Quad9 over TLS — always applied)
+              # ------------------------------------------------------------------
+              log "Configuring forwarders (Quad9 DoT)..."
+              api "settings/set" \
+                --data-urlencode "forwarders=9.9.9.9, 149.112.112.112, [2620:fe::fe], [2620:fe::9]" \
+                --data-urlencode "forwarderProtocol=Tls" \
+                --data-urlencode "concurrentForwarding=true" \
+                >/dev/null || die "Forwarder configuration failed"
+              log "Forwarders configured."
+
+              # ------------------------------------------------------------------
+              # 5. Join cluster as secondary (skip if already in cluster)
               # ------------------------------------------------------------------
               cluster_resp=$(api "admin/cluster/get" || echo '{}')
               in_cluster=$(echo "$cluster_resp" | python3 -c \

--- a/kubernetes/apps/equestria/dns/technitium/ks.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/ks.yaml
@@ -19,7 +19,7 @@ spec:
       namespace: volsync-system
     - name: external-secrets
       namespace: kube-system
-  path: ./kubernetes/apps/equestria/home/technitium
+  path: ./kubernetes/apps/equestria/dns/technitium
   prune: true
   wait: false
   force: false

--- a/kubernetes/apps/equestria/dns/technitium/kustomization.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./definition.yaml
+  - ./macvlan-nad.yaml
+  - ./init-job.yaml

--- a/kubernetes/apps/equestria/dns/technitium/macvlan-nad.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/macvlan-nad.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: technitium-dns-net
+  namespace: network
+  annotations:
+    # Purpose: Gives the Technitium pod a dedicated DNS interface (net1) with a
+    # static IP equal to TECHNITIUM_VIP on the LAN.  DNS traffic (port 53
+    # UDP/TCP, 853 DoT, 443 DoH) arrives directly on this interface without
+    # traversing kube-proxy or any LoadBalancer service.
+    #
+    # ipvlan L2 is used instead of macvlan because the equestria nodes are
+    # Proxmox KVM VMs — macvlan requires promiscuous mode on the Proxmox vmbr
+    # bridge, while ipvlan L2 shares the parent MAC so it works without any
+    # Proxmox reconfiguration.
+    #
+    # Nodes with NIC enp2s0 must be labeled: kubectl label node <name> technitium-dns=true
+    # The pod's nodeSelector ensures it only lands on a labeled worker node.
+    #
+    # Tailscale DNS access: the Connector subnet router already advertises
+    # the LAN subnet to the tailnet, so Tailscale clients with --accept-routes
+    # can reach TECHNITIUM_VIP:53 directly (UDP/TCP — no Tailscale Services needed).
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "technitium-dns-net",
+      "type": "ipvlan",
+      "master": "enp2s0",
+      "mode": "l2",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "${TECHNITIUM_VIP}/16"
+          }
+        ]
+      }
+    }

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -137,7 +137,10 @@ nodes:
           grow: false
           minSize: 1TB
           maxSize: 1TB
-    nodeLabels: *nodeLabels
+    nodeLabels:
+      <<: *nodeLabels
+      # Pin Technitium DNS to this node — it has enp2s0, required for ipvlan L2 NAD
+      technitium-dns: "true"
     nodeAnnotations: &amd_minifm_annotations
       node.longhorn.io/default-disks-config: |
         {


### PR DESCRIPTION
## Summary

Fixes all Technitium DNS issues on the equestria cluster and adds programmatic OIDC + cluster setup.

### Bug Fixes
- **ks.yaml path bug** — was pointing at `home/technitium` instead of `dns/technitium`, preventing Flux from deploying Technitium at all
- **OIDC redirect URI** — `allowedRedirectUris` used `${ROOT_DOMAIN}` (→ `driscoll.tech`) instead of `${CLUSTER_DOMAIN}` (→ `equestria.driscoll.tech`); Authentik was rejecting all OAuth callbacks

### New: Programmatic SSO Configuration
- `externalsecret.yaml`: Added SSO credentials (`authority`, `client_id`, `client_secret`) from 1Password item `equestria-technitium-oidc-credentials`
- `helmrelease.yaml`: SSO static env vars (`DNS_SERVER_SSO_ENABLED`, `DNS_SERVER_SSO_GROUP_MAP`, etc.)
- `init-job.yaml` **(new)**: Kubernetes Job that configures SSO via API at runtime (works after first start) and joins the `dns.driscoll.tech` cluster with celestia (`100.111.30.100`) as primary

### New: Multus ipvlan Interface for DNS
- `macvlan-nad.yaml` **(new)**: ipvlan L2 `NetworkAttachmentDefinition` giving the Technitium pod a dedicated `net1` interface with `TECHNITIUM_VIP` as a static IP on the LAN
  - ipvlan chosen over macvlan because equestria nodes are Proxmox KVM VMs (macvlan requires promiscuous mode on vmbr bridge)
  - DNS traffic (port 53 UDP/TCP, DoT, DoH) arrives directly on `net1` — no LoadBalancer needed
- `helmrelease.yaml`: Added Multus pod annotation, `nodeSelector: technitium-dns=true` (pin to worker with `enp2s0` NIC), removed DNS LoadBalancer service
- Tailscale DNS access: existing Connector subnet router already advertises LAN subnet, so Tailscale clients can reach `TECHNITIUM_VIP:53` directly (UDP supported)

## Required Manual Steps Before Merge

1. **Create 1Password item** in Eris vault named `equestria-technitium-oidc-credentials` with fields:
   - `issuer` — Authentik OIDC issuer URL (e.g. `https://auth.driscoll.tech/application/o/technitium/`)
   - `client_id` — Authentik OAuth2 app client ID
   - `client_secret` — Authentik OAuth2 app client secret

2. **Label a worker node** (must have `enp2s0` NIC — nodes .14, .16, .17):
   ```
   kubectl label node <worker-node-name> technitium-dns=true
   ```

3. Ensure the primary (celestia) cluster node is already initialised before this is deployed (init.sh in home-operations handles that)