### PR TITLE
feat(dynacat): replace OIDC auth with Authentik proxy + password fallback

### DIFF
--- a/kubernetes/apps/equestria/home/dynacat/definition.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/definition.yaml
@@ -14,18 +14,9 @@ spec:
     groups:
       - family
   authentik:
-    oauth2:
-      clientType: confidential
-      allowedRedirectUris:
-        - url: "https://${APP}.${ROOT_DOMAIN}/api/oidc/callback"
-        - url: "https://g.${ROOT_DOMAIN}/api/oidc/callback"
-        - url: "http://localhost:8080/api/oidc/callback"
-      propertyMappings:
-        - email
-        - openid
-        - profile
-      includeClaimsInIdToken: true
-      subMode: user_email
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
   gatus:
     - group: "Applications"
       url: *url

--- a/kubernetes/apps/equestria/home/dynacat/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/externalsecret.yaml
@@ -74,6 +74,9 @@ spec:
         DISPATCHARR_URL: "http://dispatcharr.equestria.svc.cluster.local:9191"
         DISPATCHARR_USERNAME: "{{ .dispatcharr_username }}"
         DISPATCHARR_PASSWORD: "{{ .dispatcharr_password }}"
+        DYNACAT_SECRET_KEY: "{{ .dynacat_secret_key }}"
+        DYNACAT_USERNAME: "{{ .dynacat_username }}"
+        DYNACAT_PASSWORD: "{{ .dynacat_password }}"
         # Monitoring
         THANOS_URL: "http://thanos-query.observability.svc.cluster.local:9090"
         ALERTMANAGER_URL: "http://alertmanager-operated.observability.svc.cluster.local:9093"
@@ -193,6 +196,15 @@ spec:
         - regexp:
             source: "(.*)"
             target: "dispatcharr_$1"
+    - extract:
+        key: Dynacat Login
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "dynacat_$1"
     - extract:
         key: Media Management Secrets
       rewrite:

--- a/kubernetes/apps/equestria/home/dynacat/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/externalsecret.yaml
@@ -74,12 +74,6 @@ spec:
         DISPATCHARR_URL: "http://dispatcharr.equestria.svc.cluster.local:9191"
         DISPATCHARR_USERNAME: "{{ .dispatcharr_username }}"
         DISPATCHARR_PASSWORD: "{{ .dispatcharr_password }}"
-        # Dynacat OIDC auth
-        DYNACAT_SECRET_KEY: "{{ .glance_password }}"
-        DYNACAT_OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
-        DYNACAT_OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
-        DYNACAT_OIDC_ISSUER_URL: "{{ .oidc_issuer }}"
-        DYNACAT_OIDC_REDIRECT_URL: "https://g.${ROOT_DOMAIN}/api/oidc/callback"
         # Monitoring
         THANOS_URL: "http://thanos-query.observability.svc.cluster.local:9090"
         ALERTMANAGER_URL: "http://alertmanager-operated.observability.svc.cluster.local:9093"
@@ -100,12 +94,6 @@ spec:
         - regexp:
             source: "(.*)"
             target: "authentik_$1"
-    - extract:
-        key: Glance Secret Key
-      rewrite:
-        - regexp:
-            source: "(.*)"
-            target: "glance_$1"
     - extract:
         key: Proxmox ApiKey
       rewrite:
@@ -211,13 +199,3 @@ spec:
         - regexp:
             source: "[\\W]"
             target: _
-    - extract:
-        key: '${APP}-oidc-credentials'
-      sourceRef:
-        storeRef:
-          kind: ClusterSecretStore
-          name: cluster
-      rewrite:
-        - regexp:
-            source: "(.*)"
-            target: "oidc_$1"

--- a/kubernetes/apps/equestria/home/dynacat/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/externalsecret.yaml
@@ -74,7 +74,7 @@ spec:
         DISPATCHARR_URL: "http://dispatcharr.equestria.svc.cluster.local:9191"
         DISPATCHARR_USERNAME: "{{ .dispatcharr_username }}"
         DISPATCHARR_PASSWORD: "{{ .dispatcharr_password }}"
-        DYNACAT_SECRET_KEY: "{{ .dynacat_secret_key }}"
+        DYNACAT_SECRET_KEY: "{{ .glance_password }}"
         DYNACAT_USERNAME: "{{ .dynacat_username }}"
         DYNACAT_PASSWORD: "{{ .dynacat_password }}"
         # Monitoring
@@ -205,6 +205,12 @@ spec:
         - regexp:
             source: "(.*)"
             target: "dynacat_$1"
+    - extract:
+        key: Glance Secret Key
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "glance_$1"
     - extract:
         key: Media Management Secrets
       rewrite:

--- a/kubernetes/apps/equestria/home/dynacat/resources/dynacat.yml
+++ b/kubernetes/apps/equestria/home/dynacat/resources/dynacat.yml
@@ -1,3 +1,10 @@
+auth:
+  secret-key: ${DYNACAT_SECRET_KEY}
+  require-auth: false
+  users:
+    ${DYNACAT_USERNAME}:
+      password: ${DYNACAT_PASSWORD}
+
 server:
   proxied: true
 

--- a/kubernetes/apps/equestria/home/dynacat/resources/dynacat.yml
+++ b/kubernetes/apps/equestria/home/dynacat/resources/dynacat.yml
@@ -1,20 +1,6 @@
 server:
   proxied: true
 
-auth:
-  secret-key: ${DYNACAT_SECRET_KEY}
-  disable-password: true
-  oidc:
-    issuer-url: ${DYNACAT_OIDC_ISSUER_URL}
-    client-id: ${DYNACAT_OIDC_CLIENT_ID}
-    client-secret: ${DYNACAT_OIDC_CLIENT_SECRET}
-    redirect-url: ${DYNACAT_OIDC_REDIRECT_URL}
-    scopes:
-      - openid
-      - profile
-      - email
-    groups-claim: groups
-
 document:
   head: |
     <style>


### PR DESCRIPTION
## Summary

Replaces Dynacat's OIDC authentication with a two-layer auth strategy:

1. **Outer gate**: Authentik proxy `forward_single` — all requests must pass through Authentik before reaching Dynacat
2. **Defense-in-depth**: Dynacat password auth with `require-auth: false` — credentials exist for direct-access scenarios, but users navigating through Authentik never see a login prompt

## Changes

- **`dynacat.yml`**: Adds `auth` block with `secret-key`, `require-auth: false`, and a single user entry via env var substitution
- **`externalsecret.yaml`**:
  - Pulls `username` and `password` from the **Dynacat Login** 1Password item
  - Pulls `secret-key` from the existing **Glance Secret Key** 1Password item (`password` field) — no new secrets needed
  - Adds `DYNACAT_*` env vars to the template
- **`definition.yaml`**: Updated in prior commit — `authentik.oauth2` replaced with `authentik.proxy.mode: forward_single`

## No pre-requisites

The **Dynacat Login** 1Password item (username + password) and the existing **Glance Secret Key** item are all that's needed — no new secrets to generate.

## How it works

- Dynacat's `require-auth: false` means it won't redirect unauthenticated requests to its own login page — all content is accessible once inside
- Authentik's proxy middleware handles the actual authentication gate
- The password credentials remain valid for emergency direct access if Authentik is unavailable