### PR TITLE
fix: use namespace in OIDC ExternalSecret key pattern

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/externalsecret.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/externalsecret.yaml
@@ -27,13 +27,13 @@ spec:
         property: password
     - secretKey: DNS_SERVER_SSO_AUTHORITY
       remoteRef:
-        key: "equestria-technitium-oidc-credentials"
+        key: "${CLUSTER_CNAME}-${NAMESPACE}-${APP}-oidc-credentials"
         property: issuer
     - secretKey: DNS_SERVER_SSO_CLIENT_ID
       remoteRef:
-        key: "equestria-technitium-oidc-credentials"
+        key: "${CLUSTER_CNAME}-${NAMESPACE}-${APP}-oidc-credentials"
         property: client_id
     - secretKey: DNS_SERVER_SSO_CLIENT_SECRET
       remoteRef:
-        key: "equestria-technitium-oidc-credentials"
+        key: "${CLUSTER_CNAME}-${NAMESPACE}-${APP}-oidc-credentials"
         property: client_secret

--- a/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
@@ -27,7 +27,7 @@ spec:
         OIDC_SCOPES: "openid profile email"
   dataFrom:
     - extract:
-        key: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        key: '${CLUSTER_CNAME}-${NAMESPACE}-${APP}-oidc-credentials'
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/observability/grafana/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/externalsecret.yaml
@@ -38,7 +38,7 @@ spec:
         GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'admins') && 'GrafanaAdmin' || contains(groups[*], 'media-managers') && 'Editor' || 'Viewer'"
   dataFrom:
     - extract:
-        key: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        key: '${CLUSTER_CNAME}-${NAMESPACE}-${APP}-oidc-credentials'
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
## Problem

Three ExternalSecrets were failing to sync their OIDC credentials because the 1Password item key pattern didn't match the actual item names in the Eris vault.

- `observability/grafana-secret` — failing since 2026-05-24 (6+ days)
- `kube-system/headlamp-oidc` — failing, blocking Headlamp SSO
- `network/technitium-env` — failing, blocking Technitium init-job (causing `CreateContainerConfigError` on init pod)

## Root Cause

The ExternalSecrets were looking up:
```
${CLUSTER_CNAME}-${APP}-oidc-credentials
# e.g. equestria-grafana-oidc-credentials
```

But the 1Password items in vault Eris are named with the namespace included:
```
equestria-observability-grafana-oidc-credentials
equestria-kube-system-headlamp-oidc-credentials
equestria-network-technitium-oidc-credentials
```

## Fix

Update the key pattern to include `${NAMESPACE}`:
```
${CLUSTER_CNAME}-${NAMESPACE}-${APP}-oidc-credentials
```

The `NAMESPACE` variable is already defined in each app's `ks.yaml` `postBuild.substitute` block.

## Impact

| App | Secret | Expected Effect |
|-----|--------|-----------------|
| `observability/grafana` | `grafana-secret` | Grafana OIDC auth restored |
| `kube-system/headlamp` | `headlamp-oidc` | Headlamp OIDC auth restored |
| `network/technitium` | `technitium-env` | Init job can start, Technitium SSO + cluster join configured |

## Verification

After merging, force-sync the ExternalSecrets:
```bash
EQ=/path/to/equestria-cluster/kubeconfig
kubectl --kubeconfig $EQ annotate externalsecret grafana-secret -n observability force-sync="$(date +%s)" --overwrite
kubectl --kubeconfig $EQ annotate externalsecret headlamp-oidc -n kube-system force-sync="$(date +%s)" --overwrite
kubectl --kubeconfig $EQ annotate externalsecret technitium-env -n network force-sync="$(date +%s)" --overwrite
```

Also delete the stuck technitium init-job pod so it reschedules with the now-populated secret:
```bash
kubectl --kubeconfig $EQ delete job -n network technitium-init
```