### PR TITLE
fix(technitium): correct admin service URL in init-job

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/init-job.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/init-job.yaml
@@ -30,7 +30,7 @@ spec:
             - |
               set -euo pipefail
 
-              ADMIN_URL="http://technitium.network.svc.cluster.local:5380"
+              ADMIN_URL="http://technitium-admin.network.svc.cluster.local:5380"
               log() { echo "[$(date -u +%T)] $*"; }
               die() { echo "[$(date -u +%T)] ERROR: $*" >&2; exit 1; }
 


### PR DESCRIPTION
## Problem

The `technitium-init` job was looping indefinitely, unable to reach Technitium. The script set:

```bash
ADMIN_URL="http://technitium.network.svc.cluster.local:5380"
```

But the Helm chart creates the admin service as **`technitium-admin`** (not `technitium`), so DNS resolution failed silently and the job spent 5 minutes waiting before failing.

## Fix

Correct the service name in the `ADMIN_URL`:

```bash
ADMIN_URL="http://technitium-admin.network.svc.cluster.local:5380"
```

## Verification

After applying this fix operationally (suspended Flux kustomization + patched the ExternalSecret key to `equestria-network-technitium-oidc-credentials`), both the ExternalSecret synced and the init-job was able to proceed past the readiness check.

## Related

- Part of alert triage: `CreateContainerConfigError` on `technitium-init` due to ExternalSecret sync failure (fixed in PR #2387)
- The ExternalSecret key fix (namespace pattern) is in PR #2387