### PR TITLE
fix: resolve three stuck Flux Kustomizations found in alert triage

### DIFF
--- a/kubernetes/apps/equestria/home/obsidian-sync/post-install-hook.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/post-install-hook.yaml
@@ -29,9 +29,9 @@ spec:
               echo "Creating initial databases..."
 
               # Use environment variables with curl to avoid exposing credentials in process list
-              curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_users || true
-              curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_replicator || true
-              curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_global_changes || true
+              curl -X PUT -u "$${COUCHDB_USER}:$${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_users || true
+              curl -X PUT -u "$${COUCHDB_USER}:$${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_replicator || true
+              curl -X PUT -u "$${COUCHDB_USER}:$${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_global_changes || true
 
               echo "Initial setup complete!"
           env:

--- a/kubernetes/apps/equestria/shared/secrets/ks.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/ks.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app equestria-secrets
-  namespace: &namespace secret-store
+  namespace: &namespace equestria
   labels:
     app.kubernetes.io/name: *app
     driscoll.dev/name: *app

--- a/kubernetes/apps/observability/grafana/dashboards/flux.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/flux.yaml
@@ -64,7 +64,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -134,7 +134,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -200,7 +200,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -270,7 +270,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -334,7 +334,7 @@ spec:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "$${DS_PROMETHEUS}",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -397,7 +397,7 @@ spec:
           "type": "bargauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "$${DS_PROMETHEUS}",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -461,7 +461,7 @@ spec:
         },
         {
           "collapsed": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "$${DS_PROMETHEUS}",
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -476,7 +476,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -652,7 +652,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -850,7 +850,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -1009,7 +1009,7 @@ spec:
         },
         {
           "collapsed": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "$${DS_PROMETHEUS}",
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1022,7 +1022,7 @@ spec:
           "type": "row"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "$${DS_PROMETHEUS}",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1154,7 +1154,7 @@ spec:
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "$${DS_PROMETHEUS}",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1469,7 +1469,7 @@ spec:
       "panels": [
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -1519,7 +1519,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(go_info{namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
               "interval": "",
@@ -1532,7 +1532,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -1585,7 +1585,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "max(workqueue_longest_running_processor_seconds{namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
               "hide": false,
@@ -1599,7 +1599,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -1650,7 +1650,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(go_memstats_alloc_bytes{namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
               "interval": "",
@@ -1663,7 +1663,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -1715,7 +1715,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[$__range]))",
               "interval": "",
@@ -1728,7 +1728,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -1810,7 +1810,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\"}[$__range]))",
               "hide": false,
@@ -1820,7 +1820,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\",code!~\"2..\"}[$__range]))",
               "hide": false,
@@ -1835,7 +1835,7 @@ spec:
         {
           "collapsed": false,
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 1,
@@ -1848,7 +1848,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "refId": "A"
             }
@@ -1858,7 +1858,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1939,7 +1939,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[$__range])",
               "interval": "",
@@ -1952,7 +1952,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2034,7 +2034,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container!=\"POD\",container!=\"\",pod=~\".*-controller-.*\"}) by (pod)",
               "hide": false,
@@ -2049,7 +2049,7 @@ spec:
         {
           "collapsed": false,
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 1,
@@ -2062,7 +2062,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "refId": "A"
             }
@@ -2072,7 +2072,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2153,7 +2153,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "workqueue_longest_running_processor_seconds{name=\"kustomization\"}",
               "hide": false,
@@ -2167,7 +2167,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -2249,7 +2249,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"kustomization\",result!=\"error\"}[$__range])) by (controller)",
               "format": "time_series",
@@ -2259,7 +2259,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"kustomization\",result=\"error\"}[$__range])) by (controller)",
               "format": "time_series",
@@ -2274,7 +2274,7 @@ spec:
         {
           "collapsed": false,
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 1,
@@ -2287,7 +2287,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "refId": "A"
             }
@@ -2297,7 +2297,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -2379,7 +2379,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"gitrepository\",result!=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2389,7 +2389,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"gitrepository\",result=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2403,7 +2403,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -2485,7 +2485,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"ocirepository\",result!=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2495,7 +2495,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"ocirepository\",result=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2509,7 +2509,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -2591,7 +2591,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmrepository\",result!=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2601,7 +2601,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmrepository\",result=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2615,7 +2615,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -2697,7 +2697,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"bucket\",result!=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2707,7 +2707,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"bucket\",result=\"error\"}[$__range]))",
               "format": "time_series",
@@ -2722,7 +2722,7 @@ spec:
         {
           "collapsed": false,
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 1,
@@ -2735,7 +2735,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "refId": "A"
             }
@@ -2745,7 +2745,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2826,7 +2826,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\"}[5m])) by (le))",
               "hide": true,
@@ -2836,7 +2836,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "histogram_quantile(0.90, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\"}[5m])) by (le))",
               "hide": true,
@@ -2846,7 +2846,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\"}[5m])) by (le))",
               "hide": false,
@@ -2860,7 +2860,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -2942,7 +2942,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmrelease\",result!=\"error\"}[$__range])) by (controller)",
               "format": "time_series",
@@ -2952,7 +2952,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmrelease\",result=\"error\"}[$__range])) by (controller)",
               "format": "time_series",
@@ -2966,7 +2966,7 @@ spec:
         },
         {
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -3048,7 +3048,7 @@ spec:
           "targets": [
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmchart\",result!=\"error\"}[$__range])) by (controller)",
               "format": "time_series",
@@ -3058,7 +3058,7 @@ spec:
             },
             {
               "datasource": {
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmchart\",result=\"error\"}[$__range])) by (controller)",
               "format": "time_series",
@@ -3104,7 +3104,7 @@ spec:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "$${DS_PROMETHEUS}"
             },
             "definition": "workqueue_work_duration_seconds_count",
             "hide": 0,


### PR DESCRIPTION
## Summary
- `equestria-secrets`: revert namespace `secret-store` → `equestria` (commit c537940f moved it to a namespace that doesn't exist, breaking OnePasswordItem sync for all equestria-namespace secrets)
- `obsidian-sync`: escape `${COUCHDB_USER}`/`${COUCHDB_PASSWORD}` in the post-install Job's shell script as `$${...}` so Flux's `postBuild` envsubst doesn't try to resolve them as substitution variables
- grafana `flux` dashboard: escape the 64 `${DS_PROMETHEUS}` datasource template references the same way — Grafana dashboard input variables, not Flux substitution variables

Found via automated `/triage-alerts` loop. See [equestria-cluster#2707](https://github.com/david-driscoll/equestria-cluster/issues/2707) for full triage details.

## Test plan
- [ ] `flux get kustomization equestria-secrets -n equestria` shows `Ready: True`
- [ ] `flux get kustomization obsidian-sync -n equestria` shows `Ready: True`
- [ ] `flux get kustomization grafana -n observability` shows `Ready: True`
- [ ] Grafana flux dashboard renders with datasource resolved correctly

Do not merge — for review only.

🤖 Generated with a recurring `/triage-alerts` Claude Code loop.