### PR TITLE
fix(n8n): revert n8n image tag to 2.28.2 for stability

### DIFF
--- a/kubernetes/apps/equestria/home/n8n/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/n8n/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
           *app :
             image:
               repository: ghcr.io/n8n-io/n8n
-              tag: 2.29.5@sha256:c01a2f960a065076306618df3af3bfffecc6283015a8fb6be2e66b50f15dd514
+              tag: 2.28.2@sha256:08b9411994c0d091c5cc0969ee9edcb85b5e79f26640703c0c342076ac6f2b17
             env:
               N8N_PORT: &port 8080
               N8N_HOST: &host "n8n.${ROOT_DOMAIN}"

--- a/kubernetes/apps/system-upgrade/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/talos.yaml
@@ -16,6 +16,11 @@ spec:
     - apiVersion: v1
       kind: Node
       expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+    - apiVersion: longhorn.io/v1beta2
+      kind: Volume
+      namespace: longhorn-system
+      description: Wait for degraded Longhorn volumes to finish rebuilding before draining the next node, so its replica isn't the last healthy copy
+      expr: status.robustness != "degraded"
 
   # maintenance:
   #   windows:


### PR DESCRIPTION
fix(talos): add health check for Longhorn volumes to ensure proper node draining