### PR TITLE
fix(dns): technitium tailscale service had no endpoints

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -33,27 +33,36 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
-          k8s.v1.cni.cncf.io/networks: technitium-dns-net
+        pod:
+          annotations:
+            k8s.v1.cni.cncf.io/networks: technitium-dns-net
         containers:
           *app :
             image:
               repository: technitium/dns-server
               tag: 15.4.0@sha256:df7d90ef0f7b6fff6916d291a7022cd902290cc31c3141d4158b6c375a641b41
             env:
-              # These are applied on first start only (ignored if /etc/dns config already exists)
+              # First-start only (ignored once /etc/dns config exists) — kept in
+              # lockstep with docker/_common/technitium/.env in home-operations.
+              # After the node joins the Technitium cluster, cluster sync owns
+              # most of these settings.
               DNS_SERVER_DOMAIN: dns.${ROOT_DOMAIN}
               DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS: "true"
               DNS_SERVER_WEB_SERVICE_USE_SELF_SIGNED_CERT: "true"
               DNS_SERVER_RECURSION: AllowOnlyForPrivateNetworks
-              DNS_SERVER_FORWARDERS: "9.9.9.9, 149.112.112.112, [2620:fe::fe], [2620:fe::9]"
+              DNS_SERVER_FORWARDERS: "9.9.9.9, 149.112.112.112"
               DNS_SERVER_FORWARDER_PROTOCOL: Tls
+              DNS_SERVER_PREFER_IPV6: "false"
               DNS_SERVER_ENABLE_BLOCKING: "true"
+              DNS_SERVER_ALLOW_TXT_BLOCKING_REPORT: "false"
+              DNS_SERVER_LOG_USING_LOCAL_TIME: "true"
+              DNS_SERVER_STATS_ENABLE_IN_MEMORY_STATS: "true"
               DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP: "true"
-              # SSO static env vars (first-start only — init-job applies them at runtime too)
               DNS_SERVER_SSO_ENABLED: "true"
               DNS_SERVER_SSO_ALLOW_SIGNUP: "true"
               DNS_SERVER_SSO_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS: "true"
               DNS_SERVER_SSO_GROUP_MAP: "admins:Administrators"
+              DNS_SERVER_SSO_SCOPES: "openid,profile,email"
             envFrom:
               - secretRef:
                   name: ${APP}-env
@@ -110,8 +119,7 @@ spec:
           effect: NoSchedule
 
     service:
-      # DNS traffic (port 53 UDP/TCP) is handled directly by the ipvlan interface (see macvlan-nad.yaml).
-      # No LoadBalancer service is needed for DNS — TECHNITIUM_VIP is owned by the pod's net1 interface.
+      # LAN DNS traffic arrives directly on the ipvlan interface (see nad).
       admin:
         controller: *app
         ports:
@@ -119,6 +127,36 @@ spec:
             port: *adminPort
             protocol: TCP
           cluster-https:
+            port: 53443
+            protocol: TCP
+      # Dedicated per-service tailscale proxy (NOT a ProxyGroup/Tailscale
+      # Service — those cannot forward UDP today). Defined here rather than as
+      # a raw manifest so kustomize commonLabels cannot rewrite the selector.
+      # The device joins the tailnet as dns-<cluster> with tag:dns.
+      tailscale:
+        controller: *app
+        type: LoadBalancer
+        loadBalancerClass: tailscale
+        annotations:
+          tailscale.com/hostname: dns-${CLUSTER_CNAME}
+          tailscale.com/tags: tag:dns
+        ports:
+          dns-udp:
+            port: 53
+            protocol: UDP
+          dns-tcp:
+            port: 53
+            protocol: TCP
+          dot:
+            port: 853
+            protocol: TCP
+          doq:
+            port: 853
+            protocol: UDP
+          doh:
+            port: 443
+            protocol: TCP
+          admin-tls:
             port: 53443
             protocol: TCP
 


### PR DESCRIPTION
kustomize commonLabels from the volsync component rewrote the raw Service selector (adds driscoll.dev/name + the flux force label) which pods don't carry — endpoints were empty and the dns-<cluster> proxy forwarded to nothing. Moving the service into the HelmRelease values sidesteps kustomize entirely (same reason the admin service worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)