### PR TITLE
fix(dns): exec-based probes for technitium (ipvlan asymmetric routing)

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -119,9 +119,7 @@ spec:
           effect: NoSchedule
 
     service:
-      # LAN DNS traffic arrives directly on the ipvlan interface (see nad);
-      # tailnet DNS traffic arrives via the dedicated tailscale proxy service
-      # (see tailscale-service.yaml). Only admin/cluster ports need a Service.
+      # LAN DNS traffic arrives directly on the ipvlan interface (see nad).
       admin:
         controller: *app
         ports:


### PR DESCRIPTION
Same as stargate-command-cluster#1685: kubelet tcpSocket probes time out due to asymmetric replies via the ipvlan net1 interface; exec probes run in-pod. Live deployment already hot-patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)