### PR TITLE
fix(dns): resolve technitium node names via tailscale nameserver

### DIFF
--- a/kubernetes/apps/kube-system/coredns/helm/values.yaml
+++ b/kubernetes/apps/kube-system/coredns/helm/values.yaml
@@ -38,6 +38,24 @@ servers:
       - name: loop
       - name: reload
       - name: loadbalance
+  # Technitium cluster node names: rewrite <node>.dns.driscoll.tech to the
+  # node's tailnet name (dns-<node>) and resolve it via the tailscale operator
+  # nameserver, which maps it to the in-cluster egress service ClusterIP. This
+  # is what lets the in-cluster technitium secondary reach its cluster peers
+  # (heartbeat/config sync) without hardcoded addresses.
+  - zones:
+      - zone: dns.driscoll.tech
+        scheme: dns://
+        use_tcp: false
+    port: 53
+    plugins:
+      - name: errors
+      - name: cache
+        parameters: 30
+      - name: rewrite
+        parameters: name regex ([a-z0-9-]+)\.dns\.driscoll\.tech dns-{1}.${TAILSCALE_DOMAIN} answer auto
+      - name: forward
+        parameters: . "${TAILSCALE_NAMESERVER_IP}"
   # Tailscale DNS stub zone for ts.net domains
   - zones:
       - zone: ts.net


### PR DESCRIPTION
In-pod, `celestia.dns.driscoll.tech` resolves to nothing (upstream chain dead-ends) while `dns-celestia.<tailnet>` resolves to the egress ClusterIP via the operator nameserver — so the in-cluster technitium secondary can't heartbeat to the primary and shows Unreachable. This adds a coredns stub zone for `dns.driscoll.tech` that rewrites node names to their tailnet names and forwards to `${TAILSCALE_NAMESERVER_IP}` — no hardcoded addresses, new nodes work automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)