### PR TITLE
fix(dns): restore exec probes for technitium (regressed by #2903)

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -67,12 +67,16 @@ spec:
               - secretRef:
                   name: ${APP}-env
             probes:
+              # exec probes on purpose: kubelet-dialed tcpSocket probes source
+              # from the node's LAN IP and the pod replies via the ipvlan net1
+              # interface (asymmetric) — they always time out, the pod never
+              # goes Ready, and every Service loses its endpoints.
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
-                    port: &adminPort 5380
+                  exec:
+                    command: ["bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/5380"]
                   initialDelaySeconds: 15
                   periodSeconds: 30
                   timeoutSeconds: 5
@@ -82,8 +86,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
-                    port: *adminPort
+                  exec:
+                    command: ["bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/5380"]
                   initialDelaySeconds: 10
                   periodSeconds: 10
                   failureThreshold: 30
@@ -124,7 +128,7 @@ spec:
         controller: *app
         ports:
           admin:
-            port: *adminPort
+            port: 5380
             protocol: TCP
           cluster-https:
             port: 53443


### PR DESCRIPTION
#2903 was branched before #2899 merged and silently reverted the exec probes. Result: kubelet tcpSocket probes time out against the ipvlan interface, the pod never reaches Ready, and the tailscale Service has no endpoints — so dns-equestria's port 53 went dark (DoT/DoH still appeared to work because those tests resolved to the LAN VIP instead of the proxy). Already hot-patched live; this restores it in git. sgc is unaffected (its exec probes are intact in main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)