### PR TITLE
fix(dns): pin technitium cert private key across renewals

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/certificate.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/certificate.yaml
@@ -22,6 +22,10 @@ spec:
   commonName: ${CLUSTER_CNAME}.dns.${ROOT_DOMAIN}
   dnsNames:
     - ${CLUSTER_CNAME}.dns.${ROOT_DOMAIN}
+  privateKey:
+    # Keep the key stable across renewals: the cluster's DANE TLSA records pin
+    # the SPKI hash, so a rotated key silently breaks node-to-node heartbeats.
+    rotationPolicy: Never
   keystores:
     pkcs12:
       create: true


### PR DESCRIPTION
The technitium cluster pins each node's certificate via DANE TLSA (SPKI SHA-256). cert-manager rotates the private key on every renewal by default, which invalidates that pin — node-to-node heartbeats then fail and the node shows Unreachable (exactly what happened when the LE certs replaced the self-signed ones; I've updated the live TLSA records already). `rotationPolicy: Never` keeps the key stable so the TLSA fingerprint survives renewals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)