### PR TITLE
fix(dns): disable kube-secret state for the tailscale sidecar

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -118,6 +118,10 @@ spec:
               tag: v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
             env:
               TS_STATE_DIR: /var/lib/tailscale
+              # containerboot defaults to storing state in a kube Secret when it
+              # detects kubernetes; we keep state on the volsync PVC instead, and
+              # the pod has no service-account token mounted.
+              TS_KUBE_SECRET: ""
               TS_USERSPACE: "false"
               TS_AUTH_ONCE: "true"
               # leave pod DNS alone — technitium resolves via its own engine and


### PR DESCRIPTION
The sidecar crash-loops with `error initializing kube client: open /var/run/secrets/kubernetes.io/serviceaccount/namespace: no such file or directory` — containerboot defaults to kube-Secret state storage when it detects kubernetes, and the pod mounts no service-account token. We intentionally keep node state on the volsync-managed PVC via `TS_STATE_DIR`, so this sets `TS_KUBE_SECRET: ""` to use the filesystem backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)