### PR TITLE
fix(dns): let the sidecar inherit the auth key's tags

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -128,7 +128,6 @@ spec:
               # the cluster resolver must stay intact for everything else
               TS_ACCEPT_DNS: "false"
               TS_HOSTNAME: dns-${CLUSTER_CNAME}
-              TS_EXTRA_ARGS: --advertise-tags=tag:dns
               TS_AUTHKEY:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Sidecar fails to register: `requested tags [tag:dns] are invalid or not permitted`. A tagged auth key stamps its own tags on the device and rejects any `--advertise-tags` that isn't an exact match — the key now grants `[tag:apps, tag:dns]`, so advertising just `tag:dns` is refused. Removing the flag lets the device inherit both tags (which is what we want; `tag:dns` is what the ACL grants 53/853/443 on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)