### PR TITLE
fix(meilisearch): set MEILI_UPGRADE_DB to unblock the 1.47 -> 1.51 migration

### DIFF
--- a/kubernetes/apps/equestria/home/meilisearch/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/helmrelease.yaml
@@ -39,9 +39,18 @@ spec:
     envFrom:
       - secretRef:
           name: meilisearch-env
-    env:
+    # NOTE: this chart's key is `environment:` (rendered into the
+    # meilisearch-environment ConfigMap and consumed via envFrom), NOT `env:`.
+    # The previous `env:` block was silently ignored by the chart — see vault#102.
+    environment:
       MEILI_NO_ANALYTICS: "true"
-      MEILI_ENV: "production"
+      # One-way on-startup DB migration 1.47.0 -> 1.51.0. See vault#102.
+      MEILI_UPGRADE_DB: "true"
+      # Left at the chart default rather than "production": production mode
+      # requires a >=16 byte MEILI_MASTER_KEY, and meilisearch-env currently
+      # resolves MEILI_MASTER_KEY to an empty string, so production would
+      # refuse to boot. Tracked separately — see vault#102.
+      MEILI_ENV: "development"
 
     persistence:
       enabled: true


### PR DESCRIPTION
Unblocks `meilisearch-0`, in CrashLoopBackOff since the `0.33.0 → 0.35.0` chart bump (`24c0e184d`, #2949) carried the image from 1.47.0 to 1.51.0. Diagnosis in david-driscoll/vault#102.

## ⚠️ The `env:` block was a no-op — this PR is not the one-liner it looks like

The issue proposed adding `MEILI_UPGRADE_DB` to the existing `env:` block. **That would not have worked.** This chart has no `env:` value at all — the key is `environment:`, and it is what gets rendered into the `meilisearch-environment` ConfigMap that the StatefulSet consumes via `envFrom`:

```yaml
# meilisearch-0.35.0/templates/configmap.yaml
data:
  {{- range $key, $value := .Values.environment }}
```

`grep -rn "Values.env" templates/` matches only `Values.environment` and `Values.envFrom` — never a bare `Values.env`.

The live ConfigMap proves it: it reads `MEILI_ENV: development` even though the repo has asked for `production` since this app was split out. That value has never been applied.

So this PR renames the block to `environment:` as well as adding the flag.

## MEILI_ENV stays at `development` — deliberately

Making `environment:` live would have turned on `MEILI_ENV: production` for the first time. It is **not** safe to do that right now:

```
$ kubectl get secret -n equestria meilisearch-env -o jsonpath='{.data}'
{"MEILI_MASTER_KEY":"","MEILI_NO_ANALYTICS":"dHJ1ZQ==","TZ":"QW1lcmljYS9OZXdfWW9yaw=="}
```

`MEILI_MASTER_KEY` is an **empty string**, and the ExternalSecret reports `SecretSynced` — so this is not a sync failure, the 1Password item field genuinely resolves to empty. Meilisearch in production mode refuses to boot without a ≥16 byte master key, so enabling it would have swapped one crash loop for another.

Two follow-ups worth their own issues, not this PR:
- the `meili_password` rewrite in `externalsecret.yaml` is not matching a field on the `MeiliSearch Secret Key` 1Password item;
- with an empty master key, **meilisearch is currently running unauthenticated**.

## Verified render — nothing changes except the flag

`helm template` of chart 0.35.0 with these values, versus the live ConfigMap:

| key | live | rendered |
|---|---|---|
| `MEILI_ENV` | `development` | `development` |
| `MEILI_NO_ANALYTICS` | `true` | `true` |
| `MEILI_EXPERIMENTAL_ENABLE_METRICS` | `true` | `true` |
| `MEILI_UPGRADE_DB` | *(absent)* | **`true`** |

Byte-identical apart from the added key.

---

## 1. Backups: there is no usable restore point

`--upgrade-db` is one-way. The rollback picture, checked read-only:

- **Longhorn snapshots — none usable.** The only snapshot on `pvc-79ce29f2-8968-43c0-971f-ac2abcefc7f0` is `60e21b65-…`, and it is `userCreated: false`, `markRemoved: true`, `readyToUse: false` — a system snapshot already flagged for purge, not a restore point.
- **Longhorn backups — none, and none possible.** `kubectl get backups.longhorn.io -A` is empty, and the `default` BackupTarget has an **empty URL** with `available: false`. Off-cluster Longhorn backup is not configured at all.
- **The only RecurringJob is `snapshot-cleanup`** (`0 10 * * *`). Nothing *creates* snapshots on a schedule.
- **No VolSync**, removed deliberately in `44a0c1da4`.

**Net: if this migration eats the index, there is nothing to restore from.** The issue's step 1 ("confirm a snapshot exists, take one if not") cannot be satisfied by anything already on disk.

If you want a checkpoint before merging, this is the command — **not run here**, snapshot creation is a cluster mutation:

```bash
kubectl -n longhorn-system apply -f - <<'EOF'
apiVersion: longhorn.io/v1beta2
kind: Snapshot
metadata:
  name: meilisearch-pre-151-upgrade
  namespace: longhorn-system
spec:
  volume: pvc-79ce29f2-8968-43c0-971f-ac2abcefc7f0
  createSnapshot: true
EOF
```

Counter-argument for skipping it, as the issue notes: this is a rebuildable search index, karakeep can reindex, and VolSync was dropped on purpose. Worst case is a reindex, not data loss. Your call — but make it knowingly.

## 2. Merging alone is **not** enough — the StatefulSet is deadlocked

This is the part that will bite. Current state:

| | value |
|---|---|
| StatefulSet template image | `getmeili/meilisearch:v1.47.0` (rolled back) |
| Pod `meilisearch-0` image | `getmeili/meilisearch:v1.51.0` (**stale revision**) |
| `sts.status.currentRevision` / `updateRevision` | `meilisearch-6d4bfb55b9` |
| Pod `controller-revision-hash` | `meilisearch-cdf575bdf` |
| `podManagementPolicy` | `OrderedReady` |
| Pod created | `01:04:46` — never replaced since |

The partial rollback put the StatefulSet template back to 1.47.0, but the pod is still on the 1.51.0 revision and **the StatefulSet controller will not replace it**. Under `OrderedReady`, the controller blocks on any pod that is not Running-and-Ready before it reaches its rolling-update phase. The pod is stuck unready, so the update never runs. It has been in this state since 01:04 and will not self-correct.

A Helm upgrade from this PR rewrites the ConfigMap and the StatefulSet, then waits for readiness — which never comes, so it hits the 10m `timeout`, fails, and re-enters the same rollback loop that produced the 11 failed release revisions already in history.

**Recommended sequence (none of this was run):**

```bash
# 1. after merge, pull the change immediately — the ks interval is 1h
flux reconcile kustomization meilisearch -n equestria --with-source

# 2. wait until the flag is actually in the ConfigMap before touching the pod
kubectl get cm -n equestria meilisearch-environment -o jsonpath='{.data.MEILI_UPGRADE_DB}{"\n"}'

# 3. break the StatefulSet deadlock — the ONLY step that actually unsticks it.
#    Recreated from the current revision, it picks up the new ConfigMap.
kubectl delete pod -n equestria meilisearch-0

# 4. watch the migration
kubectl logs -n equestria meilisearch-0 -f

# 5. only if the HelmRelease is still not Ready once the pod is up
flux reconcile helmrelease meilisearch -n equestria --force
```

Do step 3 **promptly** after step 2 — the Helm upgrade is on a 10 minute clock, and if the pod comes up inside that window the release converges on its own without needing step 5.

No `helm rollback` and no suspend/resume is needed. The spec change bumps `metadata.generation`, which resets the `upgradeFailures` counter and triggers a fresh attempt on its own; the release is `failed`, not `pending-*`, so nothing is lock-wedged. The blocker is the StatefulSet, not Helm.

One caveat in the optimistic direction: kubelet re-resolves `envFrom` on each container start, so the crash-looping pod *might* pick up the new ConfigMap by itself on its next restart, since it is already on the 1.51.0 image. Don't plan around it — the 5 minute back-off plus the ConfigMap cache TTL makes it slower than the Helm timeout even when it works.

## 3. Should the flag be removed afterwards? **Yes — in a follow-up PR.**

Recommend removing it once the migration is confirmed.

Leaving it set means every future Renovate image bump silently performs a one-way on-disk migration with no checkpoint and no signal. Given that this app has *no backups at all* (section 1), a silent auto-migration is exactly the failure mode you cannot recover from — the flag would convert a loud, safe crash loop into a quiet, irreversible data rewrite. The crash loop is a feature here: it is the only thing that forced this to be a deliberate decision.

The counter-argument — "this recurs on the next major bump" — is the point. Recurring costs one PR like this one and 30 seconds of downtime on an index that can be rebuilt. The alternative costs an unrecoverable index on a bump nobody watched.

If the recurrence is genuinely annoying, the better fix is restoring VolSync or configuring a Longhorn backup target, not leaving the migration flag armed.

## 4. Post-merge verification — a clean start is not proof

The engine will start happily against an empty database, so "pod is Ready" verifies nothing. Check the data:

```bash
kubectl exec -n equestria meilisearch-0 -- \
  wget -qO- http://localhost:7700/version

# indexes must be present, not an empty list
kubectl exec -n equestria meilisearch-0 -- \
  wget -qO- http://localhost:7700/indexes

# document count must be non-zero and plausible
kubectl exec -n equestria meilisearch-0 -- \
  wget -qO- http://localhost:7700/indexes/<uid>/stats

# a real query must return hits
kubectl exec -n equestria meilisearch-0 -- \
  wget -qO- --header='Content-Type: application/json' \
  --post-data='{"q":"<term you know exists>"}' \
  http://localhost:7700/indexes/<uid>/search
```

No auth header needed — the master key is empty (see above).

Also confirm the migration in the logs (`Upgrading from 1.47.0 to 1.51.0` rather than a fresh-database start), and sanity-check the volume: the Longhorn volume held ~172 MB before the outage, so an index reporting a few MB means the data did not survive. Finally, verify **karakeep** search returns results end-to-end — that is the only real consumer.

---

Closes the immediate outage in david-driscoll/vault#102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
