### PR TITLE
docs(renovate): correct the pinDigest and registryUrls comments

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,8 +14,18 @@
   suppressNotifications: [
     "prEditedNotification",
     "prIgnoreNotification",
-    // Overlapping managers (flux/helm-values/kubernetes globbing the same
-    // kubernetes/**.yaml) yield "Excess registryUrls" lookup warnings; benign.
+    // "Excess registryUrls found for datasource lookup - using first
+    // configured only" is NOT caused by overlapping managers, as previously
+    // assumed here. The flux manager resolves a HelmRelease's sourceRef by
+    // filtering every HelmRepository in the repo on name + namespace
+    // (modules/manager/flux/extract.ts resolveHelmRepository), so two
+    // HelmRepository documents that share a name and namespace produce the
+    // same URL twice in registryUrls and trigger the warning. The fix is to
+    // dedupe the HelmRepository, not to suppress the warning — see
+    // stargate-command-cluster#1720, which collapsed two `authentik`
+    // HelmRepositories into kubernetes/flux/meta/repos/authentik.yaml.
+    // Suppression is kept only to keep unrelated lookup noise off the
+    // dashboard; it does not make a duplicate registry safe.
     "dependencyLookupWarnings",
   ],
   schedule: ["every weekend"],
@@ -30,6 +40,15 @@
   },
   helmfile: {
     managerFilePatterns: ["/(^|/)helmfile\\.ya?ml$/"],
+    // WARNING: this line does nothing on its own. Manager-level config is
+    // merged before packageRules (workers/repository/process/fetch.ts calls
+    // applyPackageRules at 'pre-lookup' *after* the manager config), so the
+    // shared preset's `docker:pinDigests` rule
+    // ({ matchDatasources: ["docker"], pinDigests: true }) overrides it, and
+    // helmfile's oci:// charts use the docker datasource. The effective
+    // suppression is a packageRule in local>david-driscoll/.github:renovate-config
+    // ({ matchManagers: ["helmfile"], pinDigests: false }). Kept here as
+    // documentation of intent — do not rely on it alone.
     pinDigests: false,
   },
   kubernetes: {
@@ -150,15 +169,24 @@
     },
     {
       // Flux OCIRepository Helm charts are cosign-verified and tag-pinned; the
-      // flux manager owns these files with pinDigests: false and will never
-      // write a digest. The global docker:pinDigests (shared preset) otherwise
-      // generates phantom pinDigest updates that park in "Awaiting Schedule"
-      // forever and never produce a branch. Suppress them.
-      // helm-values/kubernetes also scan kubernetes/**.yaml with pinDigests:
-      // true and race flux to patch the same OCI chart ref, which surfaces as
-      // "Error updating branch" for grouped/digest-lookup deps (flux-operator,
-      // coredns, spegel, cert-manager) instead of a normal PR. Excluding all
-      // three managers here stops the collision.
+      // flux manager owns these files and should never write a digest. The
+      // shared preset's docker:pinDigests otherwise generates pinDigest
+      // updates for them. helm-values/kubernetes also scan kubernetes/**.yaml
+      // with pinDigests: true and race flux to patch the same OCI chart ref.
+      // Excluding all three managers here stops both.
+      //
+      // Note this rule does NOT cover the helmfile manager, which is why the
+      // four "pin image ..." entries for coredns / spegel / cert-manager /
+      // flux-operator survived it and sat on the dashboard indefinitely. That
+      // is fixed in the shared preset, not here — see vault#104 and
+      // david-driscoll/.github#2.
+      //
+      // matchUpdateTypes is a post-lookup matcher (updateType does not exist
+      // pre-lookup), so this rule does not prevent the lookup; the update is
+      // generated and then dropped by the `enabled !== false` filter in
+      // workers/repository/updates/flatten.ts. That is fine here, but it is
+      // why the helmfile fix uses `pinDigests: false` + matchManagers instead:
+      // that form is evaluated pre-lookup and suppresses generation outright.
       description: "Don't pin digests on flux-managed OCI Helm charts",
       matchManagers: ["flux", "helm-values", "kubernetes"],
       matchUpdateTypes: ["pinDigest"],
@@ -169,12 +197,18 @@
       // owned by the flux manager (kubernetes/apps/**/helmrelease.yaml).
       // Renovate treats same-named deps found by different managers as one
       // logical update and tries to combine both files' edits into a single
-      // branch. For high-churn grouped deps (CoreDNS/Flux Operator/Spegel
-      // groups, cert-manager) that branch falls behind main faster than it
-      // can be rebased and Renovate fails with "Error updating branch:
-      // update failure" instead of opening a PR. Force helmfile-manager
-      // updates onto their own branch namespace so they never share a
-      // branch with the flux-managed update for the same chart.
+      // branch. Force helmfile-manager updates onto their own branch
+      // namespace so they never share a branch with the flux-managed update
+      // for the same chart.
+      //
+      // Correction: the "Error updating branch: update failure" warning that
+      // originally motivated this rule was NOT a rebase race. It was the
+      // helmfile manager being handed pinDigest updates it cannot apply —
+      // helmfile's extractor never sets currentDigest and the manager exports
+      // no updateDependency/autoReplaceStringTemplate, so doAutoReplace always
+      // throws WORKER_FILE_UPDATE_FAILED. Fixed in the shared preset
+      // (david-driscoll/.github#2). This rule is kept because separate branch
+      // namespaces are still the right shape for a mirrored chart version.
       description: "Keep bootstrap helmfile chart bumps off the flux-managed branch",
       matchManagers: ["helmfile"],
       additionalBranchPrefix: "helmfile-",


### PR DESCRIPTION
Comment-only companion to **david-driscoll/.github#2**, which is the actual fix for the four permanently-stuck `pin image ...` entries on the Renovate dashboard.

Research: david-driscoll/vault#104

**No behaviour change.** Parsing both revisions with JSON5 and deep-comparing yields identical objects — this PR only corrects comments that were wrong, and that caused the same wrong conclusion to be reached twice.

### What was wrong

1. **`helmfile: { pinDigests: false }`** was believed to suppress the pins. It cannot: `applyPackageRules(depConfig, "pre-lookup")` runs *after* the manager config is merged (`lib/workers/repository/process/fetch.ts`), so the shared preset's `docker:pinDigests` rule (`{ matchDatasources: ["docker"], pinDigests: true }`) overrides it. helmfile's `oci://` charts use the `docker` datasource, so they match. Annotated as a no-op.

2. **The "Don't pin digests on flux-managed OCI Helm charts" rule** was believed to cover this. It lists `flux`, `helm-values`, `kubernetes` — not `helmfile`, which is the manager that actually emits these (confirmed by the `renovate/helmfile-*` branch prefix). Also noted: `matchUpdateTypes` is a post-lookup matcher, so that rule suppresses by generating the update and then discarding it at `flatten.ts`'s `enabled !== false` filter, rather than preventing it.

3. **The `additionalBranchPrefix: "helmfile-"` comment** attributed `Error updating branch: update failure` to a rebase race between managers. It is not. The helmfile extractor never sets `currentDigest` and the manager exports neither `updateDependency` nor `autoReplaceStringTemplate`, so `doAutoReplace` can never satisfy `confirmIfDepUpdated` for a `pinDigest` update and throws `WORKER_FILE_UPDATE_FAILED` on every run. The rule is kept — separate branch namespaces are still correct — but the reason is corrected.

4. **The "Excess registryUrls ... benign" comment** blamed overlapping managers. The real cause is two `HelmRepository` documents sharing a name + namespace: `resolveHelmRepository` in `modules/manager/flux/extract.ts` filters *all* HelmRepositories on name+namespace and returns both, yielding the same URL twice.

All references verified against **renovate 44.3.2**, the version actually running these repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
