### PR TITLE
feat(observability): GPU metrics for AMD (drm collector) and Intel (intel-gpu-exporter)

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/gpu.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/gpu.yaml
@@ -1,0 +1,1334 @@
+---
+# GPU dashboards — vault#110.
+#
+# Two vendors, two data paths, so two dashboards:
+#   * Intel  -> clambin/intel-gpu-exporter (i915 PMU, per-engine busyness)
+#   * AMD    -> node_exporter --collector.drm + the amdgpu hwmon sensors
+#
+# Both JSONs are vendored rather than referenced by grafanaCom id or url, so
+# the metric names stay pinned to the exporter versions actually deployed.
+# The Intel one is adapted from the exporter's own grafana-operator export
+# (assets/dashboard/dashboards.yaml, v0.7.1): datasource swapped to the
+# estate's ${DS_PROMETHEUS} input, a `cluster` variable added so it renders
+# equestria and sgc together through Thanos, and the aggregations changed to
+# keep `node` so selecting multiple nodes stops averaging five different GPUs
+# into a single line.
+#
+# NOT used: grafana.com dashboard #23251 ("Intel GPU Metrics"). It targets
+# onedr0p/intel-gpu-exporter, which is archived, and its metric names do not
+# match clambin's gpumon_*.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: gpu
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  title: "GPU"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: intel-gpu-exporter
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folder: "gpu"
+  resyncPeriod: 10m
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1500,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1200
+                  },
+                  {
+                    "color": "red",
+                    "value": 1400
+                  }
+                ]
+              },
+              "unit": "rotmhz"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "avg (gpumon_frequency{cluster=~\"$cluster\", type=\"actual\",node=~\"^$node$\"}) by (cluster, node)",
+              "legendFormat": "{{node}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Frequency",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "red",
+                    "value": 95
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 0
+          },
+          "id": 8,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg (gpumon_power{cluster=~\"$cluster\", node=~\"^$node$\", type=\"gpu\"}) by (cluster, node, type)",
+              "instant": false,
+              "legendFormat": "{{node}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Power",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 0
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (gpumon_clients_count{cluster=~\"$cluster\", node=~\"^$node$\"}) by (cluster, node, name)",
+              "instant": false,
+              "legendFormat": "{{node}} \u00b7 {{name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "clients",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "red",
+                    "value": 95
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "displayMode": "lcd",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (cluster, node, engine) (gpumon_engine_usage{cluster=~\"$cluster\", attrib=\"busy\", node=~\"^$node$\"})",
+              "instant": false,
+              "legendFormat": "{{node}} \u00b7 {{engine}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Load",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (cluster, node, engine) (gpumon_engine_usage{cluster=~\"$cluster\", attrib=\"busy\", node=~\"^$node$\"})",
+              "instant": false,
+              "legendFormat": "{{node}} \u00b7 {{engine}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Load",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "MiBs"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 7,
+          "options": {
+            "displayMode": "lcd",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg (gpumon_imc_read{cluster=~\"$cluster\", node=~\"^$node$\"}) by (cluster, node)",
+              "instant": true,
+              "legendFormat": "{{node}} read",
+              "range": false,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg (gpumon_imc_write{cluster=~\"$cluster\", node=~\"^$node$\"}) by (cluster, node)",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "{{node}} write",
+              "range": false,
+              "refId": "B"
+            }
+          ],
+          "title": "IMC bandwidth",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "MiBs"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg (gpumon_imc_read{cluster=~\"$cluster\", node=~\"^$node$\"}) by (cluster, node)",
+              "instant": false,
+              "legendFormat": "{{node}} read",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg (gpumon_imc_write{cluster=~\"$cluster\", node=~\"^$node$\"}) by (cluster, node)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{node}} write",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "IMC bandwidth",
+          "type": "timeseries"
+        }
+      ],
+      "preload": false,
+      "refresh": "1m",
+      "schemaVersion": 42,
+      "tags": [
+        "gpu",
+        "intel",
+        "i915",
+        "quicksync"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(gpumon_engine_usage, cluster)",
+            "includeAll": true,
+            "multi": true,
+            "label": "Cluster",
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(gpumon_engine_usage, cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(gpumon_engine_usage{cluster=~\"$cluster\"}, node)",
+            "includeAll": true,
+            "name": "node",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(gpumon_engine_usage{cluster=~\"$cluster\"}, node)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query",
+            "multi": true,
+            "label": "Node"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Intel GPU (Quick Sync)",
+      "uid": "intel-gpu-exporter",
+      "version": 1,
+      "weekStart": "",
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "description": "Intel Quick Sync GPU utilisation from clambin/intel-gpu-exporter. The Video and VideoEnhance engines are the ones Plex/Jellyfin/Tdarr use."
+    }
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: amd-gpu-drm
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folder: "gpu"
+  resyncPeriod: 10m
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  json: |
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "annotations": {
+        "list": []
+      },
+      "description": "AMD integrated GPU metrics from node_exporter's drm collector (--collector.drm) plus the amdgpu hwmon sensors. hard-hat is 0x15bf / RDNA3 Phoenix, shining-armor is 0x164e / RDNA2 Raphael.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "id": 1,
+          "type": "timeseries",
+          "title": "GPU busy",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "spanNulls": true,
+                "axisPlacement": "auto"
+              },
+              "mappings": [],
+              "unit": "percent",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "max": 100
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_drm_gpu_busy_percent{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
+              "legendFormat": "{{kubernetes_node}} \u00b7 {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "description": "amdgpu gpu_busy_percent from /sys/class/drm/card*/device. Whole-GPU occupancy \u2014 amdgpu does not break this down per engine the way the i915 PMU does, so there is no AMD equivalent of the Video engine line."
+        },
+        {
+          "id": 2,
+          "type": "timeseries",
+          "title": "GPU temperature",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "spanNulls": true,
+                "axisPlacement": "auto"
+              },
+              "mappings": [],
+              "unit": "celsius",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_hwmon_temp_celsius{cluster=~\"$cluster\", kubernetes_node=~\"$node\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
+              "legendFormat": "{{kubernetes_node}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "description": "These sensors were ALREADY in Prometheus before vault#110 \u2014 the hwmon collector has been reporting them all along under an opaque PCI-path chip label. node_hwmon_chip_names supplies chip_name=\"amdgpu\", which is all that was needed to name them. Integrated parts share a die and cooler with the CPU, so read this alongside k10temp, not instead of it."
+        },
+        {
+          "id": 3,
+          "type": "timeseries",
+          "title": "GPU power",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 8
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "spanNulls": true,
+                "axisPlacement": "auto"
+              },
+              "mappings": [],
+              "unit": "watt",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_hwmon_power_watt{cluster=~\"$cluster\", kubernetes_node=~\"$node\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
+              "legendFormat": "{{kubernetes_node}} instant",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_hwmon_power_average_watt{cluster=~\"$cluster\", kubernetes_node=~\"$node\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
+              "legendFormat": "{{kubernetes_node}} average",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "description": "A better proxy for real GPU work than temperature on an APU. power1_average is not exposed by every amdgpu generation \u2014 shining-armor (RDNA2 Raphael) reports only the instantaneous value."
+        },
+        {
+          "id": 4,
+          "type": "timeseries",
+          "title": "VRAM",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 8
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "spanNulls": true,
+                "axisPlacement": "auto"
+              },
+              "mappings": [],
+              "unit": "bytes",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_drm_memory_vram_used_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
+              "legendFormat": "{{kubernetes_node}} used",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_drm_memory_vram_size_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
+              "legendFormat": "{{kubernetes_node}} total",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "description": "Carved out of system RAM, not dedicated VRAM \u2014 both parts are integrated graphics. 16 GiB reported on both nodes."
+        },
+        {
+          "id": 5,
+          "type": "timeseries",
+          "title": "GTT",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 8
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "spanNulls": true,
+                "axisPlacement": "auto"
+              },
+              "mappings": [],
+              "unit": "bytes",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_drm_memory_gtt_used_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
+              "legendFormat": "{{kubernetes_node}} used",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_drm_memory_gtt_size_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
+              "legendFormat": "{{kubernetes_node}} total",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "description": "Graphics Translation Table \u2014 system memory mapped into the GPU address space."
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "GPU clock (sclk)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "spanNulls": true,
+                "axisPlacement": "auto"
+              },
+              "mappings": [],
+              "unit": "MHz",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_hwmon_freq_freq_mhz{cluster=~\"$cluster\", kubernetes_node=~\"$node\", sensor=\"sclk\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
+              "legendFormat": "{{kubernetes_node}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        }
+      ],
+      "preload": false,
+      "refresh": "1m",
+      "schemaVersion": 41,
+      "tags": [
+        "gpu",
+        "amd",
+        "amdgpu",
+        "drm"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(node_drm_gpu_busy_percent, cluster)",
+            "includeAll": true,
+            "multi": true,
+            "label": "Cluster",
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(node_drm_gpu_busy_percent, cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(node_drm_gpu_busy_percent{cluster=~\"$cluster\"}, kubernetes_node)",
+            "includeAll": true,
+            "multi": true,
+            "label": "Node",
+            "name": "node",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(node_drm_gpu_busy_percent{cluster=~\"$cluster\"}, kubernetes_node)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "AMD GPU (amdgpu)",
+      "uid": "amd-gpu-drm",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/kubernetes/apps/observability/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./cadvisor.yaml
   - ./flux.yaml
+  - ./gpu.yaml
   - ./kubernetes.yaml
   - ./media.yaml
   - ./network.yaml

--- a/kubernetes/apps/observability/intel-gpu-exporter/helmrelease.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/helmrelease.yaml
@@ -1,0 +1,135 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app intel-gpu-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      intel-gpu-exporter:
+        type: daemonset
+        containers:
+          app:
+            image:
+              repository: ghcr.io/clambin/intel-gpu-exporter
+              tag: 0.7.1@sha256:0fb61d5266001731f8e57dc1e2ac9fc0b29788f3c33f536a7d43ba0ecdc6f20d
+            args:
+              # Sampling interval handed to `intel_gpu_top -s`. The exporter
+              # aggregates (medians) every sample it has seen since the last
+              # scrape, so this is the resolution of the engine-busy signal,
+              # not the scrape interval.
+              - --interval=5s
+            env:
+              TZ: ${TIMEZONE}
+            securityContext:
+              # Least privilege, established empirically top-down (vault#110).
+              # Three independent gates have to be satisfied to read the i915 PMU:
+              #
+              #  1. capability — intel_gpu_top calls perf_event_open(2) for
+              #     system-wide (task == NULL) i915 PMU events. With
+              #     kernel.perf_event_paranoid > 0 the kernel requires
+              #     perfmon_capable(), which CAP_PERFMON satisfies (>= 5.8; nodes
+              #     run 6.18.39-talos). CAP_SYS_ADMIN would also work and is
+              #     strictly wider, so it is deliberately NOT used.
+              #  2. seccomp — containerd's RuntimeDefault profile denies
+              #     perf_event_open UNLESS the container holds CAP_PERFMON or
+              #     CAP_SYS_ADMIN, in which case it is added to the allow list
+              #     (containerd contrib/seccomp/seccomp_default.go). Since Talos
+              #     sets defaultRuntimeSeccompProfileEnabled: true cluster-wide,
+              #     RuntimeDefault applies whether or not it is declared here, so
+              #     it is declared explicitly rather than left to look accidental.
+              #     If the PMU ever returns EPERM with the capability present,
+              #     the next step is seccompProfile: { type: Unconfined }, NOT a
+              #     wider capability set.
+              #  3. sysctl — kernel.perf_event_paranoid is 3 on every node
+              #     (Talos default; not overridden in talos/patches). Verified
+              #     the kernel is built WITHOUT
+              #     CONFIG_SECURITY_PERF_EVENTS_RESTRICT, so there is no
+              #     Debian/AOSP-style "paranoid > 2 blocks everyone" tier — the
+              #     mainline gates are all `&& !perfmon_capable()` and CAP_PERFMON
+              #     clears them. No Talos machine-config change is required.
+              #
+              # runAsUser 0 is required, not incidental: /dev/dri/card0 is
+              # crw------- root:root on Talos, so only uid 0 can open the card
+              # node. Running non-root would need CAP_DAC_OVERRIDE, which is
+              # wider than staying root with everything else dropped.
+              runAsUser: 0
+              runAsGroup: 0
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+                add: ["PERFMON"]
+              seccompProfile: { type: RuntimeDefault }
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 9100
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 15m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+                # Grants /dev/dri access via the Intel device plugin, which runs
+                # with -enable-monitoring. This resource hands the pod EVERY GPU
+                # on the node and — unlike `gpu.intel.com/i915` — does not consume
+                # one of the shared transcode slots (5 per node on equestria,
+                # 2 on sgc) that plex/jellyfin/tdarr/stremio/dispatcharr contend
+                # for.
+                #
+                # DEPRECATION: upstream now prefers a unified
+                # `gpu.intel.com/monitoring` covering all KMD types. The deployed
+                # plugin still advertises i915_monitoring (confirmed in node
+                # allocatable on all 5 Intel nodes), so use what is advertised.
+                # Revisit when Renovate bumps intel-device-plugins.
+                gpu.intel.com/i915_monitoring: 1
+    defaultPodOptions:
+      # Only the Intel Quick Sync nodes (equestria: fluttershy, kerfuffle;
+      # sgc: milky-way, othalla, pegasus). The label is published by the Intel
+      # GPU plugin's NFD rules — verified present on exactly those five nodes
+      # and on neither AMD node.
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"
+      # hostPID is deliberately NOT set, though upstream's README uses it.
+      # It is only needed for the per-client breakdown (intel_gpu_top reads
+      # /proc/*/fdinfo to attribute usage to processes), which powers
+      # gpumon_clients_count. Engine busyness, frequency, power and IMC
+      # bandwidth all come from the PMU and need no host PID namespace.
+      # gpumon_clients_count will therefore report 0 with an empty `name`
+      # label; that is an accepted trade for not exposing the host process
+      # table to this pod.
+    service:
+      metrics:
+        controller: *app
+        ipFamilyPolicy: PreferDualStack
+        ports:
+          metrics:
+            port: 9100
+    persistence:
+      # readOnlyRootFilesystem: true — igt-gpu-tools scratch space.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app intel-gpu-exporter
+  namespace: &namespace observability
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/observability/intel-gpu-exporter
+  dependsOn:
+    - name: prometheus
+      namespace: observability
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/observability/intel-gpu-exporter/kustomization.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/kustomization.yaml
@@ -4,11 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-  - ./definition.yaml
+  - ./servicemonitor.yaml
   - ./prometheusrule.yaml
-configMapGenerator:
-  - name: prometheus-values
-    files:
-      - values.yaml=./values.yaml
-generatorOptions:
-  disableNameSuffixHash: true

--- a/kubernetes/apps/observability/intel-gpu-exporter/prometheusrule.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/prometheusrule.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: intel-gpu-exporter-rules
+spec:
+  groups:
+    - name: intel-gpu-exporter.rules
+      rules:
+        # Absence, not threshold. There is no baseline for what normal
+        # engine utilisation looks like on either silicon generation
+        # (0x46a6 Alder Lake-P on equestria, 0x46d4 Alder Lake-N on sgc),
+        # so any threshold picked today would be a guess. This needs no
+        # baseline: the correct value is "not empty".
+        #
+        # The failure it catches is the nasty one and is NOT covered by
+        # `up`: the pod is Running and being scraped successfully, but
+        # perf_event_open has started returning EPERM — a Talos upgrade
+        # tightening kernel.perf_event_paranoid, a containerd seccomp
+        # profile change, or an Intel device-plugin bump renaming the
+        # i915_monitoring resource. In every one of those cases the
+        # exporter serves /metrics happily and exports nothing.
+        #
+        # `up == 0` is deliberately NOT duplicated here — the standard
+        # ServiceMonitor machinery already pages for a dead target, and
+        # two alerts for one event is how alert fatigue starts.
+        - alert: IntelGpuMetricsAbsent
+          annotations:
+            summary: Intel GPU engine metrics have disappeared from this cluster.
+            description: >-
+              intel-gpu-exporter is not producing gpumon_engine_usage. If the
+              DaemonSet pods are Running and `up` is healthy, the i915 PMU is
+              refusing perf_event_open — check CAP_PERFMON, the seccomp
+              profile, kernel.perf_event_paranoid, and that
+              gpu.intel.com/i915_monitoring is still advertised by the
+              Intel device plugin.
+          expr: absent(gpumon_engine_usage)
+          for: 30m
+          labels:
+            severity: warning
+
+# Deliberately NOT in this iteration: MediaHardwareTranscodeFallback
+# ("Plex silently fell back to CPU"). It is a joint GPU/CPU condition with
+# two thresholds that cannot be guessed — "idle" is not zero on either
+# part, Plex burns real CPU during direct play too, and tdarr legitimately
+# pins the video engine for hours. It needs ~14 days of data, which is the
+# same soak window vault#84 needs for the capacity report, so it costs
+# nothing on the critical path. The label join it depends on is already
+# proven: see the `node` relabeling in servicemonitor.yaml.

--- a/kubernetes/apps/observability/intel-gpu-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/servicemonitor.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app intel-gpu-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: *app
+      app.kubernetes.io/name: *app
+  endpoints:
+    - port: metrics
+      # Matches node-exporter. The exporter medians every intel_gpu_top sample
+      # taken since the previous scrape, so a coarse scrape does not lose peaks
+      # outright, it averages them — revisit if 60s proves too blunt for the
+      # transcode-burst question in vault#84.
+      interval: 60s
+      scrapeTimeout: 30s
+      path: /metrics
+      relabelings:
+        # `instance` = node name, matching how every other node-level exporter
+        # in this estate keys itself (node-exporter, smartctl-exporter).
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: instance
+        # `node` = node name. This one is load-bearing and is NOT redundant:
+        #
+        #  * cAdvisor (job=kubelet) labels series with `node`, but its `instance`
+        #    is <nodeIP>:10250. So `gpumon_* and on (instance) container_cpu_*`
+        #    silently returns nothing — verified empirically against equestria's
+        #    Prometheus. `and on (node)` joins. The planned
+        #    MediaHardwareTranscodeFallback rule depends on this.
+        #  * The upstream clambin dashboard already queries
+        #    gpumon_*{node=~"^$node$"}, so it works unmodified.
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+      metricRelabelings:
+        # Drop `pod`: for a DaemonSet exporter the node is the identity and the
+        # pod name is pure churn. It also keeps the Thanos view sane —
+        # Prometheus' remoteWrite writeRelabelConfigs overwrite `instance` with
+        # `pod` whenever a `pod` label is present, which is why smartctl-exporter
+        # series arrive in Thanos keyed on a pod name instead of a node.
+        - action: labeldrop
+          regex: (pod)

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./grafana-operator/ks.yaml
   - ./thanos/ks.yaml
   - ./smartctl-exporter/ks.yaml
+  - ./intel-gpu-exporter/ks.yaml
   - ./blackbox-exporter/ks.yaml
   - ./priority-class/ks.yaml
   - ./silences/ks.yaml

--- a/kubernetes/apps/observability/prometheus/prometheusrule.yaml
+++ b/kubernetes/apps/observability/prometheus/prometheusrule.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: amd-gpu-rules
+spec:
+  groups:
+    - name: amd-gpu.rules
+      rules:
+        # Counterpart to IntelGpuMetricsAbsent (see
+        # observability/intel-gpu-exporter/prometheusrule.yaml). Lives here
+        # rather than in its own app directory because the AMD half of
+        # vault#110 is a node-exporter collector flag, not a workload — see
+        # `--collector.drm` in this directory's values.yaml.
+        #
+        # Absence, not threshold: no baseline exists for these integrated
+        # parts, and the failure mode worth catching is the silent one. If
+        # amdgpu stops publishing gpu_busy_percent — a kernel bump changing
+        # the sysfs layout, or the flag being lost when the chart's
+        # extraArgs default list is next overwritten — node-exporter keeps
+        # scraping green and simply stops emitting node_drm_*.
+        - alert: AmdGpuMetricsAbsent
+          annotations:
+            summary: AMD GPU DRM metrics have disappeared from this cluster.
+            description: >-
+              node_drm_gpu_busy_percent is empty. Expected on hard-hat (0x15bf)
+              and shining-armor (0x164e). Check that --collector.drm is still
+              in prometheus-node-exporter.extraArgs and that
+              /sys/class/drm/card0/device/gpu_busy_percent still exists on
+              those nodes.
+          expr: absent(node_drm_gpu_busy_percent)
+          for: 30m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/prometheus/values.yaml
+++ b/kubernetes/apps/observability/prometheus/values.yaml
@@ -134,6 +134,25 @@ prometheus:
               storage: 20Gi
 prometheus-node-exporter:
   fullnameOverride: node-exporter
+  # NOTE: Helm replaces lists rather than merging them, so the two
+  # --collector.filesystem.* entries below MUST be repeated verbatim from
+  # kube-prometheus-stack's own values.yaml. Dropping them would un-exclude
+  # every container mount point and blow up filesystem-metric cardinality.
+  # Keep them in sync when bumping the chart.
+  extraArgs:
+    - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+    - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|erofs)$
+    # AMD GPU metrics from /sys/class/drm/card*/device (node_drm_*). Disabled
+    # upstream by default. amdgpu is the ONLY driver that publishes utilisation
+    # through DRM sysfs — i915 does not, and is covered separately by
+    # observability/intel-gpu-exporter (vault#110).
+    #
+    # Verified 2026-08-01 on both AMD nodes that the sysfs attributes the
+    # collector reads are actually populated on these integrated parts:
+    #   hard-hat       0x15bf (RDNA3 Phoenix) gpu_busy_percent, mem_info_vram_*,
+    #   shining-armor  0x164e (RDNA2 Raphael) mem_info_gtt_*, mem_info_vis_vram_*
+    # so this flag is not a silent no-op. Cardinality cost is ~8 series x 2 cards.
+    - --collector.drm
   prometheus:
     monitor:
       enabled: true


### PR DESCRIPTION
Implements **Part 1 (AMD)** and **Part 2 (Intel, equestria)** of david-driscoll/vault#110. sgc half is david-driscoll/stargate-command-cluster#1735.

**Not deployed.** Branch + PR only; nothing has been reconciled and no Talos config was touched.

---

## Step one: does `amdgpu` actually populate `gpu_busy_percent` on these APUs?

The issue flagged this as the thing that decides whether Part 1 is real work — if the sysfs files are absent, `--collector.drm` lands, loads, and silently exports nothing.

**Yes. Verified on both nodes, read directly off `/sys/class/drm/card0/device/`.** No pods were created; this was `kubectl exec` into an existing privileged DaemonSet that already mounts host `/sys`.

| | `hard-hat` (`0x15bf`, RDNA3 Phoenix) | `shining-armor` (`0x164e`, RDNA2 Raphael) |
|---|---|---|
| `gpu_busy_percent` | ✅ `0` (idle) | ✅ `0` (idle) |
| `mem_info_vram_total` / `_used` | ✅ 16 GiB / 72 MB | ✅ 16 GiB / 16 MB |
| `mem_info_gtt_total` / `_used` | ✅ 23.4 GiB / 14 MB | ✅ 23.5 GiB / 14 MB |
| `mem_info_vis_vram_total` / `_used` | ✅ 16 GiB | ✅ 256 MiB |

Every attribute `collector/drm_linux.go` reads is present. Part 1 is real. **Bonus:** both parts also expose `vcn_busy_percent` — the *video* engine specifically, i.e. the AMD analogue of the i915 `Video` engine. node_exporter does not read it, so it is not in this PR, but it exists if the transcode question ever points at `immich`/AMD.

### The free thermal win — better than the issue expected

The issue asked whether the unlabelled `node_hwmon_temp_celsius` PCI chips on the AMD nodes are the amdgpu sensors, and suggested `node_drm_card_info` would supply the join.

**They are — and no join metric was needed, because the label already exists:**

```
node_hwmon_chip_names{instance="hard-hat",      chip="0000:00:08_1_0000:c5:00_0", chip_name="amdgpu"} 1
node_hwmon_chip_names{instance="shining-armor", chip="0000:00:1c_0_0000:01:00_0", chip_name="amdgpu"} 1
```

Those PCI paths match `/sys/class/drm/card0/device` on each node exactly, and `hwmon/hwmon*/name` reads `amdgpu`. So **AMD GPU temperature, power, voltage and sclk have been in Prometheus this whole time**, just unnamed. `node_hwmon_chip_names` was always the join — `node_drm_card_info` is not required. Already available today, no new scrape:

| metric | `hard-hat` | `shining-armor` |
|---|---|---|
| `node_hwmon_temp_celsius` | 58 °C | 63 °C |
| `node_hwmon_power_watt` | 19.2 W | 36.0 W |
| `node_hwmon_power_average_watt` | 22.1 W | *(not exposed on RDNA2 Raphael)* |
| `node_hwmon_freq_freq_mhz{sensor="sclk"}` | 800 | 600 |

The AMD dashboard in this PR uses `* on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name="amdgpu"}` to name them, so they stop being anonymous.

---

## Privilege: `CAP_PERFMON` was enough. No `privileged`, no `SYS_ADMIN`, no sysctl change.

`privileged: true` was pre-approved as a fallback. It is not being used. All three gates were checked independently rather than assumed:

**1. Capability — `CAP_PERFMON`.** Nodes run 6.18.39-talos, well past the 5.8 that introduced it. `CAP_SYS_ADMIN` is strictly wider and is not used.

**2. seccomp — the issue's guidance needs a correction.** The issue said "do **not** set `RuntimeDefault`, it blocks `perf_event_open`". That is true in general but wrong for this cluster, in a way that matters:

- Talos sets `defaultRuntimeSeccompProfileEnabled: true` on every node in both clusters (`talos/clusterconfig/equestria-*.yaml`), so **`RuntimeDefault` is applied whether or not the manifest asks for it.** Leaving `seccompProfile` unset does *not* get you unconfined here.
- containerd's default profile is **capability-conditional**: [`contrib/seccomp/seccomp_default.go:750-755`](https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go) appends `perf_event_open` to the allow list when the container holds `CAP_PERFMON` (and separately for `CAP_SYS_ADMIN`).

So `RuntimeDefault` + `CAP_PERFMON` is coherent and is the tightest posture available. It is declared explicitly in the HelmRelease so it reads as a decision rather than an oversight. If the PMU ever returns `EPERM` with the capability present, the next step is `seccompProfile: Unconfined` — **not** a wider capability set. Also checked: no Kyverno, no PSS labels on `observability`, and the only VAP binding is gateway-related, so nothing injects a profile behind our back.

**3. sysctl — `kernel.perf_event_paranoid` is `3`, and it is NOT a blocker.**

This is the finding I most expected to have to escalate to Roland, and it resolves cleanly. `3` looks alarming (mainline's documented maximum is `2`) and comes from Talos' KSPP-derived defaults. The value only means something stricter than `2` if the kernel carries the Debian/AOSP `CONFIG_SECURITY_PERF_EVENTS_RESTRICT` patch, whose gate historically checks `capable(CAP_SYS_ADMIN)` rather than `perfmon_capable()` — which would have made `CAP_PERFMON` useless.

Read `/proc/config.gz` off the nodes: **`CONFIG_SECURITY_PERF_EVENTS_RESTRICT` is absent.** So mainline semantics apply, every paranoid gate in `perf_event_open` is `… && !perfmon_capable()`, and `CAP_PERFMON` clears all of them. Same on sgc's `milky-way`. **No Talos machine-config change, no rolling reboot, nothing in Roland's lane.**

**Not a gate, but worth recording:** `runAsUser: 0` is required, not incidental. `/dev/dri/card0` is `crw------- root:root` on Talos. Non-root would need `CAP_DAC_OVERRIDE`, which is wider than staying uid 0 with everything else dropped. (`renderD128` is `0666`, but `intel_gpu_top` enumerates via the card node.)

`hostPID` is deliberately omitted despite upstream's README using it. It only feeds `gpumon_clients_count` (per-process attribution via `/proc/*/fdinfo`); engine busyness, frequency, power and IMC bandwidth are all PMU and need no host PID namespace. Accepted cost: `gpumon_clients_count` reports 0.

---

## Label join: `and on (instance)` does **not** join. Verified, and fixed.

The issue asked for this to be proven early since the two exporters have different `instance` semantics. It was worth proving — **the draft expression in the issue comment would have silently returned nothing forever.**

Against equestria's Prometheus (where rules evaluate), using node-exporter as the structural stand-in for `gpumon_*`:

| series | `instance` | node identity |
|---|---|---|
| `node_load1` (node-exporter) | `kerfuffle` | `kubernetes_node="kerfuffle"` |
| `smartctl_device` | `kerfuffle` | *(none)* |
| `container_cpu_usage_seconds_total` (cAdvisor, `job="kubelet"`) | **`10.10.206.17:10250`** | `node="kerfuffle"` |

cAdvisor's `instance` is `<nodeIP>:10250`, so:

```promql
node_load1 and on (instance) (sum by (instance) (rate(container_cpu_usage_seconds_total{container="plex"}[5m])))
→ 0 series

label_replace(node_load1, "node","$1","instance","(.*)")
  and on (node) (sum by (node) (rate(container_cpu_usage_seconds_total{container="plex"}[5m])))
→ 1 series ✅
```

**Fix:** the ServiceMonitor sets `node` from `__meta_kubernetes_pod_node_name` *in addition to* `instance`, so `and on (cluster, node)` joins with cAdvisor with no `label_replace` at all. Two things fall out for free:

- Upstream's dashboard already queries `gpumon_*{node=~"^$node$"}`, so it works unmodified.
- Dropping the `pod` label makes the **Thanos** view correct too. Prometheus' `remoteWrite.writeRelabelConfigs` overwrite `instance` with `pod` whenever a `pod` label is present — which is why `smartctl_device` arrives in Thanos keyed on a churning pod name with no node label at all. Grafana reads Thanos, so this mattered.

`engine` label values confirmed from upstream source rather than guessed: `Render/3D`, `Blitter`, **`Video`**, **`VideoEnhance`**, with `attrib` ∈ `busy|sema|wait`. The issue's `engine=~"Video.*"` matches both video engines correctly.

---

## What's in the PR

**Part 1 — AMD** (`prometheus/values.yaml`)

`--collector.drm` added to `prometheus-node-exporter.extraArgs`. **One trap worth naming:** the issue's snippet was `extraArgs: [--collector.drm]`, which would have been a regression — Helm *replaces* lists, and kube-prometheus-stack ships two `--collector.filesystem.*` excludes in that same key. Setting it to a bare one-element list silently un-excludes every container mount point. Both defaults are re-declared verbatim with a comment to keep them in sync on chart bumps.

**Part 2 — Intel** (`intel-gpu-exporter/`) — app-template DaemonSet in `observability`, `smartctl-exporter`'s `ks.yaml` conventions (`dependsOn: prometheus/observability`, `interval: 1h`, `retryInterval: 2m`, `timeout: 10m`, `driscoll.dev/name`).

- `ghcr.io/clambin/intel-gpu-exporter:0.7.1@sha256:0fb61d52…` — MIT, released 2026-07-18, **linux/amd64 only** (queried the OCI index; all seven nodes are amd64). Digest-pinned per estate practice, in the shape Renovate already bumps.
- `resources.limits["gpu.intel.com/i915_monitoring"]: 1` — grants every GPU on the node without consuming a transcode slot. Node allocatable confirms `i915=5, i915_monitoring=1` on `fluttershy`/`kerfuffle`. The deprecation to `gpu.intel.com/monitoring` is commented; the deployed plugin still advertises the old name, so this uses what is actually advertised.
- `nodeSelector: intel.feature.node.kubernetes.io/gpu: "true"` — verified present on exactly the five Intel nodes and neither AMD node.

**Alerts** — `IntelGpuMetricsAbsent` + `AmdGpuMetricsAbsent`, `absent()`, `for: 30m`, `severity: warning`. No baseline required. `up == 0` is **deliberately excluded** — the standard ServiceMonitor machinery already pages for a dead target. The gap `absent()` closes is the pod being Running and scraped green while the PMU returns nothing, which is exactly the failure mode the three privilege gates above could produce after a Talos or plugin bump.

`MediaHardwareTranscodeFallback` is **not** here. Both thresholds are unguessable ("idle" is not zero, Plex burns real CPU during direct play, and tdarr legitimately pins the video engine for hours) and it needs ~14 days — the same soak window vault#84 needs anyway. Its structural prerequisite, the label join, is proven above.

**Dashboards** — new `GPU` folder, JSON vendored so metric names stay pinned to the deployed exporter.

- *Intel GPU (Quick Sync)* — adapted from the exporter's own grafana-operator export. Datasource → `${DS_PROMETHEUS}`; `cluster` variable added so it renders equestria and sgc together through Thanos; aggregations changed to keep `node`, since upstream's `avg by (engine)` would average five different GPUs into one line.
- *AMD GPU (amdgpu)* — busy %, VRAM, GTT, plus the now-named hwmon temperature/power/clock.
- Grafana.com #23251 was **not** used: it targets the archived `onedr0p/intel-gpu-exporter` and its metric names don't match `gpumon_*`.

Both dashboards go in the `GPU` folder rather than extending `node-monitoring` (the issue's mild preference). Deviation is deliberate: the AMD data is node-exporter-sourced but it is GPU data, and splitting GPU across two folders to honour its provenance would be worse for whoever is looking for it. `node-exporter-full` is a `grafanaCom.id` dashboard anyway and cannot be extended in place.

---

## Validation

- `flate test all` — **319 passed, 2 skipped**, no new warnings. `observability/intel-gpu-exporter` Kustomization + HelmRelease both ✅.
- `helm template` against app-template 5.0.1 — renders a `DaemonSet` with the exact intended securityContext, the `i915_monitoring` limit, and the `/tmp` emptyDir that `readOnlyRootFilesystem: true` needs.
- `yamllint` clean against the repo's `.yamllint`.

## Merge-order note

`.github/sgc-sync.yaml` mirrors `kubernetes/apps/observability/` to sgc, excluding `kustomization.yaml` and the cluster-specific subdirectories — `intel-gpu-exporter/` is **not** excluded. The sgc PR ships a byte-identical directory (`diff -r` clean), so the sync bot has nothing to do and merge order does not matter. If the two ever diverge, the bot will open a PR to re-align them; that is the intended behaviour, same as `smartctl-exporter`.

## After merge

1. Confirm `node_drm_gpu_busy_percent` is non-empty for both AMD nodes.
2. Confirm the DaemonSet pods come up and `gpu.intel.com/i915` allocatable stays at **5** on `fluttershy`/`kerfuffle` (no transcode slot consumed).
3. If `intel_gpu_top` fails PMU init despite `CAP_PERFMON`, escalate in this order and record what was needed: `seccompProfile: Unconfined` → `+CAP_SYS_ADMIN` → `privileged: true`. The reasoning above says none of these should be necessary.
4. Watch for a non-zero `gpumon_engine_usage{engine=~"Video.*"}` during a real Plex/Jellyfin hardware transcode — that is the criterion that proves the whole thing.
5. ~14 days later: peak/p95 `Video`/`VideoEnhance` for `0x46a6` vs `0x46d4` reported on vault#84 (Q1 / Workstream G), then write the fallback-detection rule against real numbers.

Refs david-driscoll/vault#110

<!-- crew:agent=oracle -->
