### PR TITLE
fix(observability): escape ${DS_PROMETHEUS} in inlined GPU dashboard JSON

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/gpu.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/gpu.yaml
@@ -17,6 +17,15 @@
 # NOT used: grafana.com dashboard #23251 ("Intel GPU Metrics"). It targets
 # onedr0p/intel-gpu-exporter, which is archived, and its metric names do not
 # match clambin's gpumon_*.
+#
+# Datasource placeholders below are written `$${DS_PROMETHEUS}`, matching
+# flux.yaml. Inlined JSON is visible to Flux's post-build substitution, which
+# runs in strict mode and aborts the whole observability/grafana Kustomization
+# on any `${...}` it cannot resolve. The doubled `$$` collapses to a single
+# `$` during substitution, so grafana-operator still receives the
+# `${DS_PROMETHEUS}` it maps via the `datasources:` inputName below.
+# Grafana's own template variables ($cluster, $node, $__all) use the bare-`$`
+# form, which Flux does not touch, so they are deliberately left unescaped.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
@@ -67,7 +76,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -138,7 +147,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -196,7 +205,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "avg (gpumon_power{cluster=~\"$cluster\", node=~\"^$node$\", type=\"gpu\"}) by (cluster, node, type)",
@@ -212,7 +221,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -265,7 +274,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum (gpumon_clients_count{cluster=~\"$cluster\", node=~\"^$node$\"}) by (cluster, node, name)",
@@ -281,7 +290,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -349,7 +358,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "avg by (cluster, node, engine) (gpumon_engine_usage{cluster=~\"$cluster\", attrib=\"busy\", node=~\"^$node$\"})",
@@ -365,7 +374,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -449,7 +458,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "avg by (cluster, node, engine) (gpumon_engine_usage{cluster=~\"$cluster\", attrib=\"busy\", node=~\"^$node$\"})",
@@ -465,7 +474,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -535,7 +544,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -553,7 +562,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -647,7 +656,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -681,7 +690,7 @@ spec:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "$${DS_PROMETHEUS}"
             },
             "definition": "label_values(gpumon_engine_usage, cluster)",
             "includeAll": true,
@@ -705,7 +714,7 @@ spec:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "$${DS_PROMETHEUS}"
             },
             "definition": "label_values(gpumon_engine_usage{cluster=~\"$cluster\"}, node)",
             "includeAll": true,
@@ -788,7 +797,7 @@ spec:
           "title": "GPU busy",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 8,
@@ -846,7 +855,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_drm_gpu_busy_percent{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
@@ -863,7 +872,7 @@ spec:
           "title": "GPU temperature",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 8,
@@ -920,7 +929,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_hwmon_temp_celsius{cluster=~\"$cluster\", kubernetes_node=~\"$node\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
@@ -937,7 +946,7 @@ spec:
           "title": "GPU power",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 7,
@@ -994,7 +1003,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_hwmon_power_watt{cluster=~\"$cluster\", kubernetes_node=~\"$node\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
@@ -1005,7 +1014,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_hwmon_power_average_watt{cluster=~\"$cluster\", kubernetes_node=~\"$node\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
@@ -1022,7 +1031,7 @@ spec:
           "title": "VRAM",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 7,
@@ -1079,7 +1088,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_drm_memory_vram_used_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
@@ -1090,7 +1099,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_drm_memory_vram_size_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
@@ -1107,7 +1116,7 @@ spec:
           "title": "GTT",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 7,
@@ -1164,7 +1173,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_drm_memory_gtt_used_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
@@ -1175,7 +1184,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_drm_memory_gtt_size_bytes{cluster=~\"$cluster\", kubernetes_node=~\"$node\"}",
@@ -1192,7 +1201,7 @@ spec:
           "title": "GPU clock (sclk)",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "gridPos": {
             "h": 7,
@@ -1249,7 +1258,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "node_hwmon_freq_freq_mhz{cluster=~\"$cluster\", kubernetes_node=~\"$node\", sensor=\"sclk\"} * on (instance, chip) group_left(chip_name) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
@@ -1278,7 +1287,7 @@ spec:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "$${DS_PROMETHEUS}"
             },
             "definition": "label_values(node_drm_gpu_busy_percent, cluster)",
             "includeAll": true,
@@ -1302,7 +1311,7 @@ spec:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "$${DS_PROMETHEUS}"
             },
             "definition": "label_values(node_drm_gpu_busy_percent{cluster=~\"$cluster\"}, kubernetes_node)",
             "includeAll": true,


### PR DESCRIPTION
## Problem

`observability/grafana` has been `READY=False` since 2026-08-01T19:24:10Z:

```
post build failed for 'GrafanaDashboard.v1beta1.grafana.integreatly.org/intel-gpu-exporter':
  envsubst error: variable substitution failed: variable not set (strict mode): "DS_PROMETHEUS"
```

**The whole Kustomization fails, not just that dashboard** — so every change under
`kubernetes/apps/observability/grafana/` is blocked until this clears.

## Cause

`gpu.yaml` (from #2976, vault#110) inlines its dashboard bodies via `json: |`. That
puts the `${DS_PROMETHEUS}` datasource placeholders into the built manifest, where
Flux's post-build substitution can see them. Running in strict mode, Flux aborts the
entire Kustomization on the first placeholder it cannot resolve.

Dashboards sourced via `grafanaCom:` / `url:` never hit this, because the JSON is
fetched by grafana-operator at runtime and Flux never sees it.

## Fix

**The repo already has a convention for this.** `flux.yaml` also inlines its JSON, and
writes all **64** of its placeholders as `$${DS_PROMETHEUS}`. `gpu.yaml` simply didn't
follow the existing precedent. This applies the same escape to its 32 occurrences.

Flux collapses `$$` to a single `$` during substitution, so grafana-operator still
receives `${DS_PROMETHEUS}` and resolves it through the existing mapping:

```yaml
datasources:
  - datasourceName: Prometheus
    inputName: DS_PROMETHEUS   # unchanged
```

The alternative — switching to `grafanaCom`/`url` — was rejected: the header comment
documents deliberate customisation (a `cluster` variable so it renders equestria and
sgc together through Thanos, and aggregations changed to keep `node` so multi-node
selection stops averaging five GPUs into one line). Fetching upstream would discard
all of that plus the version pinning.

## Grafana's own template variables are untouched

This was the main risk in an escape-based fix. Verified that `flux envsubst` only
expands the `${...}` form and leaves bare `$VAR` alone:

```
$ printf 'a: ${DS_PROMETHEUS}\nb: $cluster\nc: $__all\n' | flux envsubst
a:
b: $cluster
c: $__all
```

Grafana's variables in this file are all bare-`$` (`$cluster` ×22, `$node` ×18,
`$__all` ×4), so they are invisible to Flux and correctly left unescaped. The diff is
exclusively `"uid": "${DS_PROMETHEUS}"` → `"uid": "$${DS_PROMETHEUS}"` on 32 lines,
plus a header comment explaining the convention.

## No other placeholders were waiting behind this one

Strict-mode envsubst aborts on the *first* unresolved variable, so a single-variable
fix risks hitting the next one on the following reconcile. Swept the file: `${DS_PROMETHEUS}`
was the **only** `${...}`-shaped token — all 33 occurrences. Nothing else would have tripped.

## Verification

```
$ kustomize build ./kubernetes/apps/observability/grafana/dashboards \
    | flux envsubst --strict
exit 0
```

All 96 placeholders (32 from `gpu.yaml` + 64 from `flux.yaml`) restore to
`${DS_PROMETHEUS}` after substitution. Both dashboard bodies still parse as valid JSON
(`intel-gpu-exporter`: 7 panels, `amd-gpu-drm`: 6 panels) with `templating` vars
`[cluster, node]` intact.

`flate test all`: **317 passed, 0 failed** (2 skipped / 2 blocked on missing secrets,
pre-existing).

## stargate-command-cluster is not affected

Checked rather than assumed. SGC's #1735 touched only
`kubernetes/apps/observability/intel-gpu-exporter/**` — no dashboard files. SGC has no
`GrafanaDashboard` resources and no `DS_PROMETHEUS` anywhere in `kubernetes/`; Grafana
is equestria-only, which is why that PR was reported as "no dashboards".

## Note on the validation gap

`flate test all` passed on #2976 and still passes here — it runs `kustomize build` but
not Flux's post-build substitution, so it structurally cannot catch this class of bug.
Piping the build through `flux envsubst --strict` would have caught it. Worth
considering as a follow-up to `flate`, though it needs the `substituteFrom` vars
(`ROOT_DOMAIN` et al. come from a SOPS-encrypted secret), so it would need to tolerate
cluster-supplied variables while still failing on genuinely unknown ones.

Refs: #2976, vault#110
