### PR TITLE
fix(crowdsec): stop templating values.yaml at all, and lint the class (vault#111)

### DIFF
--- a/.github/sgc-sync.yaml
+++ b/.github/sgc-sync.yaml
@@ -105,6 +105,11 @@ david-driscoll/stargate-command-cluster:
     dest: .github/renovate.json5
   - source: .github/workflows/flux-local.yaml
     dest: .github/workflows/flux-local.yaml
+  # Must travel WITH flux-local.yaml. That workflow's eso-values-lint job runs
+  # this module by path, so syncing the workflow alone would break SGC's CI.
+  - source: scripts/eso-values-lint/
+    dest: scripts/eso-values-lint/
+    deleteOrphaned: true
   - source: .mise.toml
     dest: .mise.toml
   - source: versions.env

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -45,6 +45,34 @@ jobs:
       - name: Run flate test
         run: flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets --source-retry-attempts 10
 
+  # `flate test` renders Helm charts. It does NOT run Flux postBuild envsubst
+  # and it does NOT run the external-secrets template engine, so it passes
+  # cleanly on a values file that will take an app to zero pods. It did exactly
+  # that on #2977 and again on #2980 (vault#111). This job runs those two
+  # renderers, which is the only way this class of break is visible before it
+  # reaches the cluster. Not gated on `pre-job`: it also has to run when only
+  # the linter itself changes.
+  eso-values-lint:
+    name: ESO Values Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: scripts/eso-values-lint/go.mod
+          cache-dependency-path: scripts/eso-values-lint/go.sum
+
+      # The linter's own regression tests, including the negative case that
+      # `$${...}` must not be flagged. A checker nobody trusts gets disabled.
+      - name: Test eso-values-lint
+        run: go -C scripts/eso-values-lint test ./...
+
+      - name: Run eso-values-lint
+        run: go -C scripts/eso-values-lint run . "${GITHUB_WORKSPACE}/kubernetes"
+
   diff:
     name: Diff
     needs: pre-job
@@ -88,7 +116,7 @@ jobs:
 
   flux-local-status:
     name: flate Success
-    needs: ["test", "diff"]
+    needs: ["test", "diff", "eso-values-lint"]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -1,7 +1,12 @@
 ---
 
+# The dollars below are DOUBLED, which is the escape. configMapGenerator
+# slurps this file whole and Flux postBuild envsubst then runs over the built
+# output, comments included -- unescaped, this commented-out example put the
+# real Spike IP and cluster name into the deployed ConfigMap. Halve them again
+# when uncommenting.
 # defaultBackupStore:
-#   backupTarget: nfs://${SPIKE_IP}:/mnt/stash/backup/${CLUSTER_CNAME}/longhorn
+#   backupTarget: nfs://$${SPIKE_IP}:/mnt/stash/backup/$${CLUSTER_CNAME}/longhorn
   # backupTargetCredentialSecret: s3-secret
 preUpgradeChecker:
   upgradeVersionCheck: false

--- a/kubernetes/apps/network/crowdsec/externalsecret.yaml
+++ b/kubernetes/apps/network/crowdsec/externalsecret.yaml
@@ -1,9 +1,49 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# ---- WHY THIS IS NOT A HELM VALUES TEMPLATE ANYMORE ----------------------
+#
+# Until 2026-08 this ExternalSecret carried a `templateFrom` that pointed at
+# the ConfigMap kustomize generates from values.yaml, with `templateAs:
+# Values`. external-secrets runs that as ONE Go text/template over the ENTIRE
+# ConfigMap value -- and configMapGenerator slurps values.yaml whole, comments
+# included. A YAML comment in values.yaml was therefore executable code. That
+# is not a style trap, it is a structural property: the unit of templating was
+# the whole file, so prose sat in the same namespace as actions.
+#
+# It fired twice. #2977 shipped a dollar-brace example in a comment that Flux
+# envsubst expanded; #2980's first revision shipped a two-brace example in a
+# comment that failed the parse, which meant NO Secret, which meant the
+# HelmRelease could not resolve its values reference at all, which meant zero
+# CrowdSec pods (vault#111). Nothing in CI caught either one, because nothing
+# in CI ran either renderer: `kustomize build`, `helm template` and
+# `flate test` all pass on the broken file.
+#
+# So the templating is gone rather than re-documented:
+#
+#   * values.yaml holds no template actions and is consumed straight from the
+#     ConfigMap by helmrelease.yaml (`valuesFrom: kind: ConfigMap`).
+#   * This ExternalSecret produces a PLAIN Secret -- no `data`, no
+#     `templateFrom`, no `templateAs: Values`. Provider keys land verbatim.
+#   * values.yaml reaches those keys through `secretKeyRef` env vars, and the
+#     five database ones through CrowdSec's own config expansion.
+#
+# There is no longer any file in this app whose comments are code.
+# `scripts/eso-values-lint` fails CI if the pattern is reintroduced here or
+# anywhere else in the repo.
+#
+# NOTE ON THIS FILE'S OWN COMMENTS: they are safe because `kustomize build`
+# strips comments from real resources -- they never reach envsubst. That is a
+# property of kustomize, not of this file, and it is NOT the reason an earlier
+# revision of #2980 gave. That revision claimed this file "is rendered by
+# neither stage", which is false -- the dollar-brace APP references below are
+# substituted by Flux postBuild on every single reconcile, which is the only
+# reason the resource names come out right. Comments survive by accident of
+# kustomize; values do not. Do not lean on either for anything load-bearing.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: ${APP}-values
+  name: ${APP}-secrets
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
@@ -13,32 +53,31 @@ spec:
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
-    name: ${APP}-values
+    name: ${APP}-secrets
     creationPolicy: Owner
     deletionPolicy: Retain
+    # metadata only. No `data`, no `templateFrom` -- with neither set,
+    # external-secrets copies the provider keys into the Secret verbatim
+    # (externalsecret_controller_template.go: `noTemplate` short-circuit), so
+    # nothing here is ever run through text/template. The keys the pods ask
+    # for by name are therefore exactly the provider key names produced by the
+    # rewrites below: `credential`, `apikey_bouncer`, and `postgres_*`.
     template:
       metadata:
         labels:
           cnpg.io/reload: "true"
         annotations:
           reloader.stakater.com/auto: "true"
-      templateFrom:
-      - target: Data
-        configMap:
-          name: ${APP}-values
-          items:
-          - key: values.yaml
-            templateAs: Values
   dataFrom:
-    # No rewrite on purpose. The 1Password field name IS the template key name
-    # IS the file name Traefik mounts from the `crowdsec-secret` OnePasswordItem
+    # No rewrite on purpose. The 1Password field name IS the Secret key name IS
+    # the file name Traefik mounts from the `crowdsec-secret` OnePasswordItem
     # -- one string per secret, everywhere, so the three-sided key contract
     # cannot drift:
     #
     #   field on 'Crowdsec ApiKey'   consumers
     #   -------------------------   ---------------------------------------------
-    #   credential                  values.yaml {{ .credential }} -> ENROLL_KEY
-    #   apikey_bouncer              values.yaml {{ .apikey_bouncer }} -> BOUNCER_KEY_traefik
+    #   credential                  values.yaml secretKeyRef -> ENROLL_KEY
+    #   apikey_bouncer              values.yaml secretKeyRef -> BOUNCER_KEY_traefik
     #                               AND, via the crowdsec-secret OnePasswordItem,
     #                               Traefik's /etc/secrets/crowdsec/apikey_bouncer
     #                               which middleware/crowdsec.yaml reads as
@@ -52,15 +91,18 @@ spec:
     # An earlier revision of this branch expected `webui_password` HERE; that
     # field was never created, so do not go looking for it.
     #
-    # The previous single-step rewrite (source "[\W]", target "apikey_") looked
-    # like it prefixed keys but did not -- regexp rewrites are ReplaceAllString
-    # on the key, and neither `credential` nor `apikey_bouncer` contains a
-    # non-word character, so nothing matched and nothing was prefixed. That made
-    # `{{ .apikey_credential }}` reference a key that never existed. ESO's v2
-    # template engine runs with `missingkey=error`, so this did not fail quietly
-    # -- it would have failed the whole ExternalSecret. The postgres block below
+    # A rewrite is also what makes an unresolvable key possible in the first
+    # place, so: the single-step form (source "[\W]", target "apikey_") that an
+    # earlier revision used here looked like it prefixed keys but did not.
+    # regexp rewrites are ReplaceAllString over the key, and neither
+    # `credential` nor `apikey_bouncer` contains a non-word character, so
+    # nothing matched and nothing was prefixed -- leaving a consumer asking for
+    # `apikey_credential`, a key that never existed. The postgres block below
     # keeps its rewrite because it uses the correct two-step
-    # normalise-then-prefix form.
+    # normalise-then-prefix form. Verify any change to it against the live key
+    # list: `kubectl -n database get secret crowdsec-postgres -o json | jq
+    # '.data | keys'` gives username/password/database/hostname/port, which the
+    # rewrite turns into the postgres_* names values.yaml asks for.
     - extract:
         key: 'Crowdsec ApiKey'
     - extract:

--- a/kubernetes/apps/network/crowdsec/helmrelease.yaml
+++ b/kubernetes/apps/network/crowdsec/helmrelease.yaml
@@ -44,16 +44,27 @@ spec:
     recreate: true
   uninstall:
     keepHistory: false
+  # ConfigMap, not Secret. values.yaml carries no secret material at all now --
+  # the LAPI pulls every credential from the `crowdsec-secrets` Secret through
+  # secretKeyRef env vars. That is what lets values.yaml be consumed raw, with
+  # nothing rendering it as a Go template on the way here. See
+  # externalsecret.yaml for the outage this replaced.
   valuesFrom:
-    - kind: Secret
+    - kind: ConfigMap
       name: ${APP}-values
       valuesKey: values.yaml
-  # Inline rather than in the values Secret on purpose. It contains no secrets,
-  # and the chart hard-fails template rendering when neither `acquisition` nor
-  # `additionalAcquisition` is set (agent-daemonSet.yaml). Keeping it here means
-  # `flate test` -- which cannot resolve valuesFrom Secrets -- can still render
-  # this release. spec.values deep-merges over valuesFrom, so the rest of
-  # `agent:` still comes from the Secret.
+  # Inline rather than in values.yaml on purpose. The chart hard-fails template
+  # rendering when neither `acquisition` nor `additionalAcquisition` is set
+  # (agent-daemonSet.yaml), and flate resolves NO valuesFrom reference at all --
+  # not Secrets and not ConfigMaps, verified by rendering longhorn and traefik
+  # through it and getting chart defaults back. Keeping this one key inline is
+  # what lets `flate test` render this release instead of erroring. spec.values
+  # deep-merges over valuesFrom, so the rest of `agent:` still comes from
+  # values.yaml.
+  #
+  # Corollary, and the reason #2977 and #2980 both shipped broken: a green
+  # `flate test` says nothing about whether this release's real values are
+  # sound. It never sees them. `scripts/eso-values-lint` is the check that does.
   values:
     agent:
       acquisition:

--- a/kubernetes/apps/network/crowdsec/values.yaml
+++ b/kubernetes/apps/network/crowdsec/values.yaml
@@ -1,23 +1,38 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/crowdsecurity/helm-charts/refs/heads/main/charts/crowdsec/values.schema.json
 #
-# NOTE ON TEMPLATING. This file is rendered twice:
-#   * Flux postBuild substitutes dollar-brace variables from cluster-secrets and
-#     shared-secrets. Doubling the dollar sign escapes one through to the
-#     container instead (see REGISTRATION_TOKEN below).
-#   * external-secrets renders {{ ... }} against the keys of the
-#     `crowdsec-values` ExternalSecret. Key names are the raw 1Password field
-#     names -- see the comment block in externalsecret.yaml.
+# This file is plain Helm values. Nothing runs it through a Go template: the
+# HelmRelease reads it out of the ConfigMap kustomize generates from it, and
+# every secret CrowdSec needs arrives as a pod environment variable from the
+# `crowdsec-secrets` Secret instead. A two-brace action written anywhere here
+# is inert -- it would reach Helm as literal text. That was NOT true until
+# 2026-08; see externalsecret.yaml for what changed and why.
+#
+# ONE substitution is still live, and it applies to comments exactly as much
+# as to values, because configMapGenerator slurps this file whole and Flux
+# postBuild envsubst then runs over the built output: a dollar sign followed
+# by a braced name is expanded from cluster-secrets / shared-secrets ANYWHERE
+# in the file, and an undefined name expands to nothing, silently. Double the
+# dollar sign to pass a literal one through to the container -- that is what
+# the CROWDSEC_DB_* and REGISTRATION_TOKEN references below are doing, since
+# CrowdSec expands those itself, from the pod environment, when it loads its
+# config. `scripts/eso-values-lint` enforces this in CI.
 container_runtime: containerd
 config:
+  # The five database values are NOT written in here. CrowdSec runs
+  # csstring.StrictExpand over the merged config.yaml + config.yaml.local text
+  # before it parses either (pkg/csconfig/config.go), so a braced name here is
+  # resolved from the LAPI pod's own environment at startup -- exactly the
+  # mechanism the chart already depends on for REGISTRATION_TOKEN below. The
+  # matching env vars are declared under `lapi.env`, sourced with secretKeyRef.
   config.yaml.local: |
     db_config:
       type:     postgresql
-      user:     {{ .postgres_username }}
-      password: {{ .postgres_password }}
-      db_name:  {{ .postgres_database }}
-      host:     {{ .postgres_hostname }}
-      port:     {{ .postgres_port }}
+      user:     $${CROWDSEC_DB_USER}
+      password: $${CROWDSEC_DB_PASSWORD}
+      db_name:  $${CROWDSEC_DB_NAME}
+      host:     $${CROWDSEC_DB_HOST}
+      port:     $${CROWDSEC_DB_PORT}
     api:
       server:
         auto_registration: # Activate if not using TLS for authentication
@@ -93,6 +108,38 @@ lapi:
   env:
     - name: TZ
       value: ${TIMEZONE}
+    # ---- database ---------------------------------------------------------
+    # Consumed by name from `config.config.yaml.local` above. Keys come from
+    # the `crowdsec-secrets` Secret, which external-secrets fills from the
+    # CNPG-managed `crowdsec-postgres` Secret in the database namespace; the
+    # `postgres_` prefix is applied by the rewrite in externalsecret.yaml.
+    # These values never appear in a ConfigMap, a Helm values blob or a Helm
+    # release revision -- they go 1Password/CNPG -> Secret -> secretKeyRef.
+    - name: CROWDSEC_DB_USER
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: postgres_username
+    - name: CROWDSEC_DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: postgres_password
+    - name: CROWDSEC_DB_NAME
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: postgres_database
+    - name: CROWDSEC_DB_HOST
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: postgres_hostname
+    - name: CROWDSEC_DB_PORT
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: postgres_port
     # Registers the bouncer named `traefik` with this key on first start. The
     # SAME value is mounted into Traefik at /etc/secrets/crowdsec/apikey_bouncer
     # by the crowdsec-secret OnePasswordItem, and read there by
@@ -104,7 +151,10 @@ lapi:
     # the 1Password value alone will NOT update it -- run
     # `cscli bouncers delete traefik` first, then restart the LAPI.
     - name: BOUNCER_KEY_traefik
-      value: "{{ .apikey_bouncer }}"
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: apikey_bouncer
     # The crowdsec-ui watcher machine is NOT registered from here: the chart
     # replaces the upstream entrypoint with files/docker-start-custom.sh, which
     # has no AGENT_USERNAME/AGENT_PASSWORD passthrough. crowdsec-ui registers
@@ -122,7 +172,10 @@ lapi:
     # safe. The `credential` field has been unused since 2026-01; verify it in
     # app.crowdsec.net before merging, or delete these three entries.
     - name: ENROLL_KEY
-      value: '{{ .credential }}'
+      valueFrom:
+        secretKeyRef:
+          name: ${APP}-secrets
+          key: credential
     - name: ENROLL_INSTANCE_NAME
       value: '${CLUSTER_CNAME}'
     - name: ENROLL_TAGS

--- a/scripts/eso-values-lint/go.mod
+++ b/scripts/eso-values-lint/go.mod
@@ -1,0 +1,5 @@
+module github.com/david-driscoll/equestria-cluster/scripts/eso-values-lint
+
+go 1.24
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/scripts/eso-values-lint/go.sum
+++ b/scripts/eso-values-lint/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/eso-values-lint/main.go
+++ b/scripts/eso-values-lint/main.go
@@ -1,0 +1,530 @@
+// Command eso-values-lint guards the two renderers that run over files a
+// kustomize `configMapGenerator` slurps whole, and that neither `kustomize
+// build`, nor `helm template`, nor `flate test` exercises.
+//
+// Both have caused a CrowdSec outage (equestria-cluster#2977, #2980 /
+// vault#111). The failure mode is the same both times: a *comment* in a
+// generated file is not a comment by the time the file is rendered.
+//
+//	stage 1  kustomize configMapGenerator
+//	         reads the file as one opaque string. Comments are part of it.
+//	stage 2  Flux postBuild envsubst
+//	         runs over the whole built output, so a `${NAME}` anywhere in that
+//	         string -- comments included -- is substituted. Undefined names
+//	         expand to the empty string with no error and no log line.
+//	stage 3  external-secrets `templateAs: Values`
+//	         runs the whole string through Go text/template. A `{{` inside a
+//	         comment is a live action: bad syntax fails the ExternalSecret
+//	         outright (no Secret at all, so any HelmRelease pointing at it
+//	         cannot resolve its values), and good syntax silently expands a
+//	         real secret into a comment.
+//
+// Checks, in the order they are reported:
+//
+//	ESO-PARSE   file reached by `templateAs: Values` does not parse as a Go
+//	            text/template. This is the exact error external-secrets
+//	            reports, produced by the same parser.
+//	ESO-EXEC    it parses but will not execute.
+//	ESO-COMMENT a comment line in such a file contains `{{`.
+//	ENVSUBST    a comment line in ANY generated file contains a LIVE `${`.
+//	            `$$` is envsubst's escape, so `$${NAME}` is fine; the run of
+//	            dollars before the brace has to be even.
+//
+// KNOWN LIMITS, so nobody disables this over a surprise:
+//
+//   - The two comment checks are line-based: any line whose first non-space
+//     character is `#` is treated as a comment. Inside a YAML block scalar
+//     such a line is content, not a comment, so a shell snippet embedded in
+//     values that legitimately wants `${NAME}` on a `#` line will be flagged.
+//     Escape it (`$${NAME}`) or reword. As of writing there is no such case in
+//     either cluster repo.
+//   - ESO-EXEC executes against a map synthesised from the template's own
+//     field references, so it proves the template RUNS. It cannot prove a key
+//     exists in the provider -- only external-secrets, holding the live
+//     secret, can do that.
+//   - `secretGenerator` is not scanned. Neither repo uses one; add it here if
+//     that changes, since stage 2 applies to those files identically.
+//
+// Usage: go run ./scripts/eso-values-lint [root ...]   (default: ./kubernetes)
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"text/template"
+	"text/template/parse"
+
+	"gopkg.in/yaml.v3"
+)
+
+type finding struct {
+	check string
+	file  string
+	line  int
+	msg   string
+}
+
+type generated struct {
+	// path of the file on disk
+	path string
+	// ConfigMap name as written in kustomization.yaml, e.g. "${APP}-values".
+	// Left unsubstituted on purpose: the ExternalSecret spells it the same way.
+	cmName string
+	// key the file lands under inside the ConfigMap
+	key string
+	// kustomization.yaml that generates it
+	from string
+}
+
+// check identifiers, as they appear in output
+const (
+	checkParse    = "ESO-PARSE"
+	checkExec     = "ESO-EXEC"
+	checkComment  = "ESO-COMMENT"
+	checkEnvsubst = "ENVSUBST"
+)
+
+// exit codes
+const (
+	exitOK      = 0
+	exitFinding = 1
+	exitFailure = 2 // the linter itself could not run
+)
+
+const esoCommentAdvice = "external-secrets templates this whole file, so this comment is " +
+	"executable code. Describe the sequence in words, or move the value out of the templated file."
+
+// report is the outcome of a run: what was inspected, and what was wrong.
+type report struct {
+	findings         []finding
+	checkedGenerated int
+	checkedTemplates int
+}
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"kubernetes"}
+	}
+	os.Exit(run(roots, os.Stdout, os.Stderr))
+}
+
+func run(roots []string, stdout, stderr io.Writer) int {
+	rep, err := scan(roots)
+	if err != nil {
+		fmt.Fprintf(stderr, "eso-values-lint: %v\n", err)
+		return exitFailure
+	}
+
+	slices.SortFunc(rep.findings, func(a, b finding) int {
+		if c := strings.Compare(a.file, b.file); c != 0 {
+			return c
+		}
+		return a.line - b.line
+	})
+
+	for _, f := range rep.findings {
+		if f.line > 0 {
+			fmt.Fprintf(stdout, "%s:%d: [%s] %s\n", f.file, f.line, f.check, f.msg)
+		} else {
+			fmt.Fprintf(stdout, "%s: [%s] %s\n", f.file, f.check, f.msg)
+		}
+	}
+	fmt.Fprintf(stdout, "\neso-values-lint: %d generated file(s) checked, %d of them rendered by "+
+		"external-secrets `templateAs: Values`, %d finding(s)\n",
+		rep.checkedGenerated, rep.checkedTemplates, len(rep.findings))
+
+	if len(rep.findings) > 0 {
+		return exitFinding
+	}
+	return exitOK
+}
+
+func scan(roots []string) (report, error) {
+	var rep report
+	for _, root := range roots {
+		dirs, err := kustomizationDirs(root)
+		if err != nil {
+			return rep, err
+		}
+		for _, dir := range dirs {
+			if err := scanDir(dir, &rep); err != nil {
+				return rep, fmt.Errorf("%s: %w", dir, err)
+			}
+		}
+	}
+	return rep, nil
+}
+
+func scanDir(dir string, rep *report) error {
+	gens, err := generatedFiles(dir)
+	if err != nil || len(gens) == 0 {
+		return err
+	}
+	templated, err := esoTemplatedKeys(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, g := range gens {
+		// #nosec G304 -- the path comes from the repo's own kustomization.yaml,
+		// which is the thing being linted. There is no untrusted input here.
+		src, err := os.ReadFile(g.path)
+		if err != nil {
+			return err
+		}
+		rep.checkedGenerated++
+		text := string(src)
+
+		// ENVSUBST applies to every generated file: stage 2 does not care
+		// whether stage 3 exists.
+		rep.findings = append(rep.findings, unescapedSubstitution(g.path, text)...)
+
+		if !templated[g.cmName+"\x00"+g.key] {
+			continue
+		}
+		rep.checkedTemplates++
+		rep.findings = append(rep.findings,
+			commentSequence(g.path, text, "{{", checkComment, esoCommentAdvice)...)
+		rep.findings = append(rep.findings, goTemplate(g.path, text)...)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------- discovery
+
+func kustomizationDirs(root string) ([]string, error) {
+	var dirs []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() == "kustomization.yaml" || d.Name() == "kustomization.yml" {
+			dirs = append(dirs, filepath.Dir(p))
+		}
+		return nil
+	})
+	return dirs, err
+}
+
+// Minimal shapes for the two documents this tool has to understand. Only the
+// fields that matter are modelled; everything else is ignored on decode.
+
+type configMapGenerator struct {
+	Name  string   `yaml:"name"`
+	Files []string `yaml:"files"`
+}
+
+type kustomizationDoc struct {
+	ConfigMapGenerator []configMapGenerator `yaml:"configMapGenerator"`
+}
+
+type templateItem struct {
+	Key        string `yaml:"key"`
+	TemplateAs string `yaml:"templateAs"`
+}
+
+type templateConfigMap struct {
+	Name  string         `yaml:"name"`
+	Items []templateItem `yaml:"items"`
+}
+
+type templateFromEntry struct {
+	ConfigMap templateConfigMap `yaml:"configMap"`
+}
+
+type secretTemplate struct {
+	TemplateFrom []templateFromEntry `yaml:"templateFrom"`
+}
+
+type secretTarget struct {
+	Template secretTemplate `yaml:"template"`
+}
+
+type externalSecretSpec struct {
+	Target secretTarget `yaml:"target"`
+}
+
+type externalSecretDoc struct {
+	Kind string             `yaml:"kind"`
+	Spec externalSecretSpec `yaml:"spec"`
+}
+
+func generatedFiles(dir string) ([]generated, error) {
+	var out []generated
+	for _, name := range []string{"kustomization.yaml", "kustomization.yml"} {
+		p := filepath.Join(dir, name)
+		// #nosec G304 -- p is a kustomization.yaml under a root given on argv.
+		raw, err := os.ReadFile(p)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		var doc kustomizationDoc
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			// A kustomization we cannot parse is not this tool's problem;
+			// flate/kustomize will report it far better than we can.
+			continue
+		}
+		for _, gen := range doc.ConfigMapGenerator {
+			for _, entry := range gen.Files {
+				key, rel := entry, entry
+				if i := strings.Index(entry, "="); i >= 0 {
+					key, rel = entry[:i], entry[i+1:]
+				} else {
+					key = filepath.Base(entry)
+				}
+				fp := filepath.Clean(filepath.Join(dir, rel))
+				if _, err := os.Stat(fp); err != nil {
+					continue
+				}
+				out = append(out, generated{path: fp, cmName: gen.Name, key: key, from: p})
+			}
+		}
+	}
+	return out, nil
+}
+
+// esoTemplatedKeys returns the set of "<configMap name>\x00<key>" pairs that an
+// ExternalSecret in dir renders with `templateAs: Values`.
+func esoTemplatedKeys(dir string) (map[string]bool, error) {
+	set := map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(e.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		// #nosec G304 -- dir is a repo path supplied on argv.
+		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+		for {
+			var doc externalSecretDoc
+			if err := dec.Decode(&doc); err != nil {
+				break // EOF, or a document this tool does not model
+			}
+			if doc.Kind != "ExternalSecret" {
+				continue
+			}
+			for _, tf := range doc.Spec.Target.Template.TemplateFrom {
+				for _, item := range tf.ConfigMap.Items {
+					if item.TemplateAs == "Values" {
+						set[tf.ConfigMap.Name+"\x00"+item.Key] = true
+					}
+				}
+			}
+		}
+	}
+	return set, nil
+}
+
+// ------------------------------------------------------------------- checks
+
+// commentSequence reports `seq` appearing on a line whose first non-space
+// character is `#`. JSON has no comments, so it is skipped.
+func commentSequence(path, text, seq, check, msg string) []finding {
+	var out []finding
+	forEachCommentLine(path, text, func(i int, line string) {
+		if strings.Contains(line, seq) {
+			out = append(out, finding{check: check, file: path, line: i + 1,
+				msg: fmt.Sprintf("comment contains %q. %s", seq, msg)})
+		}
+	})
+	return out
+}
+
+// unescapedSubstitution reports a LIVE `${...}` in a comment. `$$` is
+// envsubst's escape for a literal dollar, so `$${NAME}` survives verbatim and
+// is fine; the run of dollars immediately before the brace has to be even for
+// that to hold.
+func unescapedSubstitution(path, text string) []finding {
+	var out []finding
+	forEachCommentLine(path, text, func(i int, line string) {
+		for j := 1; j < len(line); j++ {
+			if line[j] != '{' || line[j-1] != '$' {
+				continue
+			}
+			dollars := 0
+			for k := j - 1; k >= 0 && line[k] == '$'; k-- {
+				dollars++
+			}
+			if dollars%2 == 1 {
+				out = append(out, finding{check: checkEnvsubst, file: path, line: i + 1,
+					msg: "comment contains a live substitution. Flux postBuild envsubst " +
+						"expands it even inside a comment -- an undefined name expands to " +
+						"nothing and eats the text around it, and a defined one bakes a real " +
+						"cluster value into the ConfigMap. Double the dollar sign to escape " +
+						"it, or describe the sequence in words."})
+				return
+			}
+		}
+	})
+	return out
+}
+
+func forEachCommentLine(path, text string, fn func(i int, line string)) {
+	if ext := filepath.Ext(path); ext == ".json" {
+		return // JSON has no comments
+	}
+	for i, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimLeft(line, " \t-")
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fn(i, line)
+	}
+}
+
+var undefinedFunc = regexp.MustCompile(`function "([^"]+)" not defined`)
+
+// goTemplate parses (and then executes) the file exactly as external-secrets'
+// v2 engine does. Unknown function names are stubbed on demand rather than
+// vendored: the engine ships sprig plus its own helpers, and this check is
+// about syntax and executability, not about a function's return value.
+func goTemplate(path, text string) []finding {
+	funcs := template.FuncMap{}
+	var tmpl *template.Template
+	for attempt := 0; ; attempt++ {
+		t, err := template.New(filepath.Base(path)).
+			Funcs(funcs).
+			Option("missingkey=error").
+			Parse(text)
+		if err == nil {
+			tmpl = t
+			break
+		}
+		if m := undefinedFunc.FindStringSubmatch(err.Error()); m != nil && attempt < 64 {
+			funcs[m[1]] = func(_ ...any) any { return "" }
+			continue
+		}
+		return []finding{{check: checkParse, file: path, line: templateErrLine(path, err),
+			msg: fmt.Sprintf("does not parse as a Go text/template, so external-secrets "+
+				"cannot render it and writes NO Secret at all: %v", err)}}
+	}
+
+	data := map[string]any{}
+	for _, t := range tmpl.Templates() {
+		if t.Tree != nil {
+			collectFields(t.Tree.Root, data)
+		}
+	}
+	if err := tmpl.Execute(discard{}, data); err != nil {
+		return []finding{{check: checkExec, file: path, line: templateErrLine(path, err),
+			msg: fmt.Sprintf("parses but does not execute: %v", err)}}
+	}
+	return nil
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+// templateErrLine digs the line number out of a text/template error, which
+// formats as `template: <name>:<line>: <detail>`.
+func templateErrLine(path string, err error) int {
+	prefix := "template: " + filepath.Base(path) + ":"
+	s := err.Error()
+	i := strings.Index(s, prefix)
+	if i < 0 {
+		return 0
+	}
+	rest := s[i+len(prefix):]
+	n := 0
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// collectFields walks the parse tree and seeds `data` with every top-level
+// field the template dereferences, so Execute exercises the action tree
+// instead of tripping over missingkey=error on the first reference. It cannot
+// verify that a key really exists in the provider -- only external-secrets,
+// holding the live secret, can do that.
+func collectFields(n parse.Node, data map[string]any) {
+	switch v := n.(type) {
+	case nil:
+		return
+	case *parse.ListNode:
+		if v == nil {
+			return
+		}
+		for _, c := range v.Nodes {
+			collectFields(c, data)
+		}
+	case *parse.ActionNode:
+		collectFields(v.Pipe, data)
+	case *parse.PipeNode:
+		if v == nil {
+			return
+		}
+		for _, c := range v.Cmds {
+			collectFields(c, data)
+		}
+	case *parse.CommandNode:
+		for _, a := range v.Args {
+			collectFields(a, data)
+		}
+	case *parse.IfNode:
+		collectFields(v.Pipe, data)
+		collectFields(v.List, data)
+		collectFields(v.ElseList, data)
+	case *parse.RangeNode:
+		collectFields(v.Pipe, data)
+		collectFields(v.List, data)
+		collectFields(v.ElseList, data)
+	case *parse.WithNode:
+		collectFields(v.Pipe, data)
+		collectFields(v.List, data)
+		collectFields(v.ElseList, data)
+	case *parse.FieldNode:
+		seed(data, v.Ident)
+	case *parse.ChainNode:
+		collectFields(v.Node, data)
+		seed(data, v.Field)
+	default:
+		// Leaf nodes (text, literals, dot) reference nothing to seed.
+	}
+}
+
+func seed(data map[string]any, idents []string) {
+	cur := data
+	for i, id := range idents {
+		if i == len(idents)-1 {
+			if _, ok := cur[id]; !ok {
+				cur[id] = "x"
+			}
+			return
+		}
+		next, ok := cur[id].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			cur[id] = next
+		}
+		cur = next
+	}
+}

--- a/scripts/eso-values-lint/main_test.go
+++ b/scripts/eso-values-lint/main_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The fixture reproduces the real shape: a kustomization whose
+// configMapGenerator slurps values.yaml, and an ExternalSecret that renders
+// that ConfigMap key with `templateAs: Values`.
+const fixtureKustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+configMapGenerator:
+  - name: ${APP}-values
+    files:
+      - values.yaml=./values.yaml
+`
+
+const fixtureExternalSecret = `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-values
+spec:
+  target:
+    template:
+      templateFrom:
+      - target: Data
+        configMap:
+          name: ${APP}-values
+          items:
+          - key: values.yaml
+            templateAs: Values
+`
+
+// writeFixture lays down a one-app tree and returns its root.
+func writeFixture(t *testing.T, values, kustomization string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "app")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"kustomization.yaml":  kustomization,
+		"externalsecret.yaml": fixtureExternalSecret,
+		"values.yaml":         values,
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func checksFor(t *testing.T, values string) []string {
+	t.Helper()
+	rep, err := scan([]string{writeFixture(t, values, fixtureKustomization)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if rep.checkedGenerated != 1 || rep.checkedTemplates != 1 {
+		t.Fatalf("discovery failed: generated=%d templated=%d (want 1/1)",
+			rep.checkedGenerated, rep.checkedTemplates)
+	}
+	var got []string
+	for _, f := range rep.findings {
+		got = append(got, f.check)
+	}
+	return got
+}
+
+func TestChecks(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		body  string
+		want  []string
+		never []string
+	}{
+		{
+			// The actual outage: vault#111 / equestria-cluster#2980.
+			name: "unparseable action in a comment fails like external-secrets does",
+			body: "---\n# see {{ ... }} for the syntax\nkey: value\n",
+			want: []string{"ESO-COMMENT", "ESO-PARSE"},
+		},
+		{
+			// #2977: parses fine, but envsubst ate the comment.
+			name: "live substitution in a comment",
+			body: "---\n# set this from ${SOME_VAR}\nkey: value\n",
+			want: []string{"ENVSUBST"},
+		},
+		{
+			// Regression guard: `$$` is the escape and must stay silent, or
+			// every values file carrying $${REGISTRATION_TOKEN} goes red.
+			name:  "escaped substitution in a comment is not a finding",
+			body:  "---\n# literal $${REGISTRATION_TOKEN} reaches the container\nkey: value\n",
+			never: []string{"ENVSUBST"},
+		},
+		{
+			name: "parseable action in a comment still leaks a secret into it",
+			body: "---\n# example: {{ .password }}\nkey: \"{{ .password }}\"\n",
+			want: []string{"ESO-COMMENT"},
+		},
+		{
+			name:  "ordinary templated values file is clean",
+			body:  "---\n# a perfectly ordinary comment\nkey: \"{{ .password }}\"\n",
+			never: []string{"ESO-COMMENT", "ESO-PARSE", "ESO-EXEC", "ENVSUBST"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checksFor(t, tc.body)
+			for _, w := range tc.want {
+				if !contains(got, w) {
+					t.Errorf("missing %s; got %v", w, got)
+				}
+			}
+			for _, n := range tc.never {
+				if contains(got, n) {
+					t.Errorf("unexpected %s; got %v", n, got)
+				}
+			}
+		})
+	}
+}
+
+// A file that is generated but NOT rendered by external-secrets must still be
+// checked for envsubst, and must never be reported as a broken template.
+func TestUntemplatedFileOnlyGetsEnvsubstCheck(t *testing.T) {
+	root := writeFixture(t, "---\n# mentions {{ .password }} and ${SOME_VAR}\nkey: value\n",
+		strings.Replace(fixtureKustomization, "${APP}-values", "other-values", 1))
+	rep, err := scan([]string{root})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if rep.checkedTemplates != 0 {
+		t.Fatalf("file should not be treated as ESO-templated, got %d", rep.checkedTemplates)
+	}
+	for _, f := range rep.findings {
+		if f.check != "ENVSUBST" {
+			t.Errorf("unexpected %s on an untemplated file", f.check)
+		}
+	}
+}
+
+// The reported line number has to be usable, since that is how the error gets
+// found: the live cluster pointed at values.yaml:8.
+func TestParseErrorReportsLineNumber(t *testing.T) {
+	body := "---\n#\n#\n#\n#\n#\n#\n# {{ ... }}\nkey: value\n"
+	rep, err := scan([]string{writeFixture(t, body, fixtureKustomization)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range rep.findings {
+		if f.check == "ESO-PARSE" {
+			if f.line != 8 {
+				t.Errorf("ESO-PARSE line = %d, want 8", f.line)
+			}
+			return
+		}
+	}
+	t.Fatal("no ESO-PARSE finding")
+}
+
+func TestUnknownFunctionsDoNotFailTheParse(t *testing.T) {
+	// external-secrets ships sprig; this tool stubs names on demand rather
+	// than vendoring it, so a sprig pipeline must not be reported as broken.
+	got := checksFor(t, "---\nkey: \"{{ .password | b64enc | quote }}\"\n")
+	for _, c := range got {
+		if c == "ESO-PARSE" || c == "ESO-EXEC" {
+			t.Errorf("sprig pipeline wrongly reported as %s", c)
+		}
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes the outage from #2977 (vault#111). **CrowdSec is at zero pods.**

> Rewritten after review. The first revision of this PR only reworded comments, and justified doing so with a claim about the rendering pipeline that is false. Both are corrected; see the review reply for specifics.

## What broke

```
externalsecret/crowdsec-values   SecretSyncedError
  unable to parse template at key values.yaml:
  template: values.yaml:8: unexpected <.> in operand

helmrelease/crowdsec   could not resolve Secret chart values reference
                       'network/crowdsec-values' with key 'values.yaml'

kustomization/crowdsec-ui   dependency 'network/crowdsec' is not ready
```

`configMapGenerator` slurps `values.yaml` **whole**, comments included, into one ConfigMap value. The ExternalSecret then ran `templateAs: Values` over that entire blob. The unit of templating was the file, so a YAML comment was executable code. A `{{ ... }}` illustration in one failed the parse → no Secret → the HelmRelease had nothing to resolve → zero pods.

## The fix: remove the mechanism, don't re-document it

`values.yaml` is no longer a template at all.

| | before | after |
|---|---|---|
| `values.yaml` | slurped, then whole-file Go-templated | plain values, consumed via `valuesFrom: kind: ConfigMap` |
| ExternalSecret | `templateFrom` + `templateAs: Values` | no `data`, no `templateFrom` — provider keys land verbatim |
| Secret name | `crowdsec-values` | `crowdsec-secrets` (it is not Helm values) |
| `BOUNCER_KEY_traefik`, `ENROLL_KEY` | `{{ .apikey_bouncer }}` / `{{ .credential }}` | `valueFrom.secretKeyRef` |
| 5 × `db_config` | `{{ .postgres_* }}` inside `config.yaml.local` | `CROWDSEC_DB_*` secretKeyRef env, referenced as `$${...}` |

The database part leans on a mechanism **already load-bearing in this same file**: `token: "$${REGISTRATION_TOKEN}"` works because CrowdSec runs `csstring.StrictExpand` over the merged `config.yaml` + `config.yaml.local` **text** before parsing it (`pkg/csconfig/config.go`), resolving braced names from the pod environment. It is field-agnostic, so `db_config` works the same way. `StrictExpand` leaves an undefined name **literal** rather than blanking it, so a missing key fails loudly at connect time instead of silently authenticating as nobody.

Measured result — after `kustomize build | flux envsubst`, **zero** Go template actions survive anywhere in this app's output. There is nothing left for a comment to break. The ConfigMap Helm receives contains no secret material, only key *names*.

## `scripts/eso-values-lint` — the class, not the instance

Five other apps still use `templateAs: Values` (`database/postgres/app`, `immich`, `outline`, `pinepods`, `registry`). This change deliberately does not touch them, so the guard is repo-wide instead.

A small Go tool (stdlib + `yaml.v3`) that pairs each `configMapGenerator` file with the ExternalSecret that renders it, then:

| check | catches |
|---|---|
| `ESO-PARSE` | file does not parse as Go `text/template` — **the outage** |
| `ESO-EXEC` | parses but will not execute (run at `missingkey=error`) |
| `ESO-COMMENT` | `{{` on a comment line in a templated file |
| `ENVSUBST` | a **live** `${...}` on a comment line in any generated file — `$$`-escaped forms correctly ignored |

Against `origin/main` it reproduces the cluster error byte-for-byte:

```
kubernetes/apps/network/crowdsec/values.yaml:8: [ESO-PARSE] does not parse as a Go
  text/template, so external-secrets cannot render it and writes NO Secret at all:
  template: values.yaml:8: unexpected <.> in operand
```

Against this branch: `37 generated file(s) checked, 6 of them rendered by templateAs: Values, 0 finding(s)`.

Self-tested against all four hazard shapes on a synthetic fixture, including the negative case — `$${REGISTRATION_TOKEN}` must **not** be flagged.

It found one pre-existing real hit: `longhorn/values.yaml` had a commented-out `nfs://${SPIKE_IP}/...${CLUSTER_CNAME}` example that was baking the real Spike IP and cluster name into the deployed ConfigMap. Escaped.

Wired into `.github/workflows/flux-local.yaml` as a required job. `scripts/eso-values-lint/` is added to `.github/sgc-sync.yaml` so it travels with the workflow — otherwise the sync would push a workflow SGC cannot run.

## stargate-command-cluster

**No companion PR.** SGC has a `kubernetes/apps/network/crowdsec/` directory carrying the identical pattern, but it is **not referenced by any kustomization** (`apps/network/kustomization.yaml` does not list it) and the live cluster has no crowdsec Kustomization, HelmRelease or ExternalSecret. It is dormant, so it cannot be broken by this class today.

SGC *does* run two live instances of the pattern (`database/postgres/app`, `kube-system/registry`) and carries the same longhorn comment. All three are covered without a separate PR: `kubernetes/apps/network/`, `kubernetes/apps/longhorn-system/`, `flux-local.yaml` and now `scripts/eso-values-lint/` are all in the sgc-sync manifest, so the fix, the workflow and the linter arrive together. Running the linter against SGC's tree today gives exactly one finding — that longhorn comment — which the sync resolves.

## Validation

Everything below was run. **`kustomize build`, `helm template` and `flate test` all pass on the broken file and always did — none of them runs either renderer, so none of them is evidence here.**

- `kustomize build` → `flux envsubst` → extract the `crowdsec-values` ConfigMap value → parse and execute as Go `text/template` at `missingkey=error`. Clean — and the value contains no template actions to begin with.
- `helm template` against chart 0.24.0 with the real post-envsubst values: renders, passes the chart's `values.schema.json`, and the LAPI Deployment carries all seven `secretKeyRef` env vars beside the `crowdsec-config-local` mount.
- Chart source read to confirm `lapi.env` is emitted with `toYaml` (so `valueFrom` is legal) and that `config.yaml.local` is mounted **only** into the LAPI pod — agents and the register Jobs never see the DB references.
- Provider keys confirmed live: `database/crowdsec-postgres` has `username/password/database/hostname/port`; `network/crowdsec-secret` has `apikey_bouncer/credential`. The rewrites produce exactly the names the pods ask for.
- ESO's `noTemplate` short-circuit read in source: a `template:` with only `metadata` still copies provider keys through, so the Secret's labels/annotations are unchanged.
- `valuesFrom: kind: ConfigMap` confirmed working in the live cluster — `helm get values longhorn` shows values sourced exactly this way.
- `flate test all` → 324 passed · 2 skipped. `yamllint`, `actionlint` clean.
- Rebased onto `origin/main`: the branch was behind #2981, and merging the old head would have reverted the barman work.

### Not verified — flagged, not hidden

- **CrowdSec pods `Running`.** Cannot be reached without merging; nothing here is applied by hand. I will confirm after merge.
- **`db_config` expansion observed live.** Verified in CrowdSec's source and by the `REGISTRATION_TOKEN` precedent in this same file, but not yet watched succeed in a running LAPI.
- **The console enrolment key.** Pre-existing and unchanged by this PR, but it gates the acceptance criterion: `cscli console enroll` runs unguarded under `set -e`, so a **dead or expired key crash-loops the LAPI**. The `credential` field has been unused since 2026-01. If the LAPI crash-loops on enrolment after merge, the documented rollback is to delete the three `ENROLL_*` entries — no secret, no other change.

## Recovery

Nothing is applied. On merge: `flux reconcile kustomization flux-system --with-source` (the Kustomization is on a 1h interval). The old failing `crowdsec-values` ExternalSecret is pruned by the rename; it never produced a Secret, so nothing stale is left behind. No secret rotation is needed — no secret value changed.

<!-- crew:agent=niobe -->
