### PR TITLE
feat(database): enable barman-cloud WAL archiving and PITR (prereq for PG 17→18)

### DIFF
--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -8,7 +8,10 @@ spec:
   chart:
     spec:
       chart: cluster
-      version: 0.7.0
+      # 0.8.x is the first cluster chart that can emit a barmancloud.cnpg.io
+      # ObjectStore and wire the plugin into .spec.plugins. 0.7.0 only knows
+      # the deprecated in-core .spec.backup.barmanObjectStore.
+      version: 0.8.1
       sourceRef:
         kind: HelmRepository
         name: cloudnative-pg

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -18,13 +18,23 @@ recovery:
     accessKey: "{{ .minio_username }}"
     secretKey: "{{ .minio_password }}"
 backups:
-  enabled: false
+  enabled: true
+  # `plugin` routes backups through plugin-barman-cloud (already deployed at
+  # v0.7.1) rather than the operator's in-core barmanObjectStore, which is
+  # deprecated upstream and slated for removal. This renders an
+  # ObjectStore/postgres-backups and attaches the plugin to the Cluster as the
+  # WAL archiver, which is what gives us continuous archiving and PITR.
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   endpointURL: "{{ .minio_endpoint }}"
   provider: s3
   s3:
     region: "{{ .minio_region }}"
     bucket: "{{ .backblaze_bucket }}"
-    path: "/"
+    # Dedicated prefix so barman's base backups + WAL never share a namespace
+    # with the logical dumps or the `-restore` staging bucket.
+    path: "/barman/${CLUSTER_CNAME}"
     accessKey: "{{ .minio_username }}"
     secretKey: "{{ .minio_password }}"
   wal:
@@ -39,7 +49,9 @@ backups:
   - name: daily-backup
     schedule: "${POSTGRES_BACKUP_SCHEDULE:=0 0 16 * * *}"
     backupOwnerReference: self
-    method: barmanObjectStore
+    method: plugin
+    pluginConfiguration:
+      name: barman-cloud.cloudnative-pg.io
   retentionPolicy: "30d"
 cluster:
   instances: 3


### PR DESCRIPTION
Prerequisite #1 for the PostgreSQL 17 → 18 major upgrade tracked in
[david-driscoll/vault#114](https://github.com/david-driscoll/vault/issues/114).
**Do not merge until the preconditions below are satisfied.** No PostgreSQL
version change is in this PR.

## Why

`plugin-barman-cloud` v0.7.1 has been deployed in `cloudnative-pg` since July, but
`kubectl get objectstore.barmancloud.cnpg.io -A` returns **No resources found** on
both clusters. The plugin has been running with nothing to do. There is no
continuous WAL archiving and no point-in-time recovery for any of the 16 databases
on this cluster.

The only recovery artefact today is the nightly `pg_dump` CronJob writing to
`${SPIKE_IP}:/mnt/stash/data/pgdump`. That is a once-a-day RPO, and while auditing
it I found two holes (both filed separately, both out of scope here):

- **`tandoor` has had no dump at all.** `pg_dump` fails with
  `permission denied for schema tandoor` — the database has a non-`public`
  `tandoor` schema owned by `postgres` holding 95 tables, and the `tandoor` login
  role has no `USAGE` on it. The script catches the exception, logs it, and the Job
  still exits 0, so nothing has ever alerted.
- **The dumps are `--no-owner --no-privileges`,** so schema ownership and grants are
  not captured anywhere. Restoring one is not a faithful restore of the database.

Neither of those is fixed here, but both are reasons the WAL archive should not
wait behind them.

## What this does

| | |
|---|---|
| `helmrelease.yaml` | cloudnative-pg `cluster` chart **0.7.0 → 0.8.1** |
| `resources/values.yaml` | `backups.enabled: true`, `backups.method: plugin` |

Chart 0.7.0 has no `backups.method` and no `cluster.plugins` — it can only emit the
operator's in-core `.spec.backup.barmanObjectStore`, which is deprecated upstream and
slated for removal alongside the `system` container images. 0.8.x is the first
version that can render a `barmancloud.cnpg.io/v1 ObjectStore`, so the chart bump is
a hard requirement for using the plugin that is already installed.

Rendered result (verified with `helm template` against the real values, placeholders
substituted):

```yaml
# ObjectStore/postgres-backups
spec:
  retentionPolicy: 30d
  configuration:
    endpointURL: <Spike Minio>
    destinationPath: s3://<bucket>/barman/equestria
    wal:  {compression: gzip, maxParallel: 4}
    data: {compression: gzip, jobs: 2}
    s3Credentials: {from postgres-backup-s3-creds}

# Cluster/postgres
spec:
  plugins:
    - name: barman-cloud.cloudnative-pg.io
      enabled: true
      isWALArchiver: true
      parameters: {barmanObjectName: postgres-backups}

# ScheduledBackup/postgres-daily-backup
spec: {method: plugin, pluginConfiguration: {name: barman-cloud.cloudnative-pg.io}}
```

### Why Minio on `spike` and not Backblaze

Both credential sets are already wired into `postgres-values` by the existing
ExternalSecret, so either was a one-line choice. Minio wins on the failure mode that
actually matters:

`archive_command` failures pin WAL on the primary's PVC indefinitely —
`max_slot_wal_keep_size` does not govern archive backlog. That is precisely the shape
of the SGC out-of-disk cascade. Putting a WAN hop in the WAL path converts every ISP
blip into WAL accumulation on a live primary. On-LAN Minio does not have that
property.

**The cost of that choice is that `spike` now holds four things at once**: the Pulumi
state backend, the Longhorn backup target, the logical dumps, and now the WAL
archive. Losing `spike` loses all recovery options simultaneously. Note that
`postgres-backup-values` already defines an `rclone.conf` with a `[backblaze]` remote
— and nothing in the repo ever invokes it, so there is currently no off-site copy of
anything. Closing that gap is filed separately; it is the natural follow-up to this
PR, not a blocker for it.

### Storage headroom

PVCs are 40Gi with 2.1Gi used (6%). Total database size across the cluster is
~940MB, largest is `immich` at 626MB. WAL volume will be small and there is ample
room for a backlog.

## Preconditions before merge

1. **Bucket exists and the prefix is writable.** The values reuse the
   `{{ .backblaze_bucket }}` name against the Spike Minio endpoint — the same pairing
   the existing (never-exercised) `recovery:` block uses. Confirm that bucket exists
   on Minio and that `barman/equestria/` is writable with the `Spike Minio Access
   Token` credentials. If the bucket name does not exist on Minio, change
   `backups.s3.bucket` before merging rather than after.
2. **etcd health.** `fluttershy` (10.10.206.16) is currently at **235ms p99 etcd
   backend commit** and 72ms WAL fsync, against ~4ms and ~3ms on `hard-hat` and
   `kerfuffle`, with ~1 leader election in the last hour. Adding the plugin sidecar
   rolls all three instance pods. That is a small amount of churn, but it is churn
   against a degraded quorum member and there is no reason to spend it before the
   cause is known.

## Blast radius

Adding `.spec.plugins` injects a sidecar into the instance pods, so **this triggers a
rolling restart of all three PostgreSQL instances** (replicas first, then a
switchover). Expect a brief connection interruption at the switchover.

`stopDelay: 1800` appears in the rendered Cluster as a new chart 0.8.1 default; it
matches the operator's own default, so behaviour is unchanged. `flate diff` against
`origin/main` shows no other unintended drift from the chart bump.

## Validation

- `flate test all --allow-missing-secrets` — 324 passed, 2 skipped, no new warnings
- `flate diff hr postgres` against `origin/main` — only the intended delta
- `yamllint -c .yamllint` on both changed files — clean
- `helm template` of chart 0.8.1 with real values — output above

## Verify after merge (gates the version-bump PR)

```bash
kubectl -n database get objectstore postgres-backups
kubectl -n database get cluster postgres -o jsonpath='{.status.conditions}'
kubectl -n database get backup     # first ScheduledBackup runs immediately
```

Continuous archiving must be confirmed healthy, **and a restore into a scratch
cluster must be exercised at least once**, before the PostgreSQL 18 image bump is
opened. An untested backup is not a backup, and the major upgrade is the operation
where that distinction gets expensive.
