### PR TITLE
fix(database): stop leaking postgres credentials into backup job logs

### DIFF
--- a/kubernetes/apps/database/postgres/backups/resources/App.cs
+++ b/kubernetes/apps/database/postgres/backups/resources/App.cs
@@ -3,7 +3,6 @@
 #:package gstocco.YamlDotNet.YamlPath@1.0.26
 #:package KubernetesClient@*
 #:package Microsoft.Extensions.Logging@10.*
-#:package Dumpify@0.7.0
 #:package Lunet.Extensions.Logging.SpectreConsole@1.2.0
 #:package ProcessX@1.5.6
 #:package 1Password.Connect.Sdk@1.0.4
@@ -13,7 +12,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
-using Dumpify;
 using Npgsql;
 using OnePassword.Connect.Sdk;
 using OnePassword.Connect.Sdk.Models;
@@ -47,7 +45,9 @@ List<string> databases;
 {
   // Get list of databases
   var postgres = await GetItemByTitle("${CLUSTER_CNAME}-postgres-user");
-  var connectionString = postgres.Fields.Single(f => f.Label == "connection-string").Value.Dump();
+  // NEVER log this — the connection string embeds the plaintext password and
+  // pod stdout is shipped to Loki.
+  var connectionString = GetField(postgres, "connection-string");
   Console.WriteLine("Fetching list of databases...");
   await using var dataSource = NpgsqlDataSource.Create(connectionString);
   databases = await GetDatabases(dataSource);
@@ -60,10 +60,9 @@ foreach (var db in databases)
   try
   {
     var postgres = await GetItemByTitle($"{clusterKey}-{db}-postgres");
-    var connectionString = (await GetItemByTitle($"{clusterKey}-{db}-postgres")).Fields.Single(f => f.Label == "connection-string").Value.Dump();
-    await using var dataSource = NpgsqlDataSource.Create(connectionString);
 
-    Console.WriteLine($"Backing up database: {db}");
+    // Host/port/user only — never the password or the full connection string.
+    Console.WriteLine($"Backing up database: {db} ({GetField(postgres, "username")}@{GetField(postgres, "hostname")}:{GetField(postgres, "port")})");
     var backupFile = Path.Combine(backupDir, $"{db}.sql.gz");
     Directory.CreateDirectory(Path.GetDirectoryName(backupFile) ?? throw new InvalidOperationException("Failed to get directory name for backup file"));
 


### PR DESCRIPTION
## Problem

The nightly `postgres-backup` CronJob printed every PostgreSQL connection string it fetched from 1Password straight to stdout, via leftover Dumpify `.Dump()` calls in `kubernetes/apps/database/postgres/backups/resources/App.cs`:

```
"Host=postgres-rw.database.svc.cluster.local;Port=5432;Database=romm;Username=romm;Password=<plaintext>;Trust Server Certificate=true;SSL Mode=Disable;"
```

One line for the cluster-level `${CLUSTER_CNAME}-postgres-user`, plus one for each of the 16 application databases — **every night**. Pod stdout is scraped by Alloy into Loki, so these passwords are retained and grep-able for the full Loki retention window.

Verified 2026-08-01 against `kubectl --context admin@equestria logs -n database postgres-backup-29759160-8hfpr`.

An identical copy of this script exists in `david-driscoll/stargate-command-cluster` and needs the same fix.

## Fix

- **Cluster-level connection string** — dropped `.Dump()`, now fetched through the existing `GetField` helper. The value is still needed to enumerate databases, so it stays in memory but never reaches stdout.
- **Per-database loop** — the connection string turned out to be entirely dead code. An `NpgsqlDataSource` was built from it and never used; the actual dump runs through `pg_dump` with `PGPASSWORD` set from the item fields inside `CreateDatabaseDump`. Removed the fetch, the unused data source, and the duplicated `GetItemByTitle` call for the same 1Password item (it was being fetched twice).
- **Replacement diagnostic** — the `Backing up database: <db>` line now carries `username@hostname:port`, which is what the `.Dump()` was presumably there to show, minus the password.
- **Dumpify** — removed the package reference and `using` directive, since nothing uses `.Dump()` anymore and leaving it in place makes this easy to reintroduce.

Net effect: per-database credentials are no longer read into this process at all, and the one connection string that is still needed never gets logged.

## Validation

- `dotnet build kubernetes/apps/database/postgres/backups/resources/App.cs` — clean.
- `flate test all` — 322 passed, `HelmRelease database/postgres-backup` ✓. Identical to the baseline run on unmodified `main`; the 2 blocked resources (`network/cloudflare-tunnel`, `tailscale-system/tailscale-operator`) and the skipped `vault` GitRepository are pre-existing missing-secret conditions unrelated to this change.
- `yamllint -c .yamllint kubernetes/apps/database/postgres/` — clean.

No cluster changes were applied.

## Follow-up needed (not in this PR)

These are deliberately left out of scope — flagging for a decision:

1. **Purge the captured credentials from Loki.** The fix stops new leakage; it does nothing about what is already stored. Loki needs either a retention-based expiry wait or a targeted deletion against the `{namespace="database", pod=~"postgres-backup-.*"}` stream.
2. **Rotate the affected passwords.** All 16 per-database passwords plus the cluster-level user should be treated as exposed. They are managed declaratively via CNPG managed roles and `passwordSecret` entries in `kubernetes/apps/database/postgres/app/resources/values.yaml`, sourced from 1Password — so rotation means updating the 1Password items and letting CNPG reconcile, with attention to any app that caches its DSN at startup and will need a restart.

Ordering matters: rotate before or alongside the purge, since anything still holding the old value in Loki stays valid until rotation.

## Context

Found while auditing backup coverage for the CNPG 17 → 18 upgrade planning in david-driscoll/vault#114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- crew:agent=seraph -->
