### PR TITLE
fix(crowdsec): stop a dead console enrolment key from crash-looping the LAPI (vault#111)

### DIFF
--- a/docs/crowdsec-enforcement-rollout.md
+++ b/docs/crowdsec-enforcement-rollout.md
@@ -54,7 +54,7 @@ CGNAT range are already listed.
 | # | Prerequisite | How to check |
 |---|---|---|
 | P1 | 1Password item `Crowdsec ApiKey` (vault `Eris`) has field `apikey_bouncer` | `kubectl get secret crowdsec-secret -n network -o json \| jq '.data \| keys'` — done, present |
-| P2 | The same item has field `credential` holding a **currently valid** console enrollment key | Sign in to `app.crowdsec.net` → Security Engines → enrollment keys. See §Enrollment below |
+| P2 | ~~The same item has field `credential` holding a **currently valid** console enrollment key~~ **DROPPED 2026-08-02** — console enrolment is off (Option B) after the stale `credential` key crash-looped the LAPI. Not a prerequisite for any stage | n/a. See §Enrollment and §Re-enabling below if you ever want the console back |
 | P3 | A **separate** item `Crowdsec UI` (vault `Eris`) has field `password` (a generated password, ≥ 24 chars) | needed by `crowdsec-ui`; provisioned 2026-08-01. Deliberately *not* a field on `Crowdsec ApiKey` — `crowdsec-ui`'s ExternalSecret extracts this item itself and prefixes its keys to `webui_*`, so the template key stays `webui_password` |
 | P4 | Authentik OIDC app for `crowdsec-ui` provisioned, `crowdsec-ui-oidc-credentials` present in the `cluster` store | runs automatically once `definition.yaml` lands and the Pulumi authentik stack runs |
 
@@ -70,23 +70,76 @@ useful negative test only — it proves nothing about validity.
 
 ### Enrollment (`ENROLL_KEY`) is a crash-loop risk, not a log line
 
-The LAPI entrypoint (`build/docker/docker-start-custom.sh` in the crowdsec
-image) runs under `set -e` and calls:
+**This fired on 2026-08-02. Console enrolment is now OFF (Option B).** P2 above
+is therefore not a prerequisite for anything — leave it unchecked.
+
+The entrypoint is the *chart's* `files/docker-start-custom.sh`, not the image's:
+the chart embeds it via `.Files.Get` into `crowdsec-docker-start-script-configmap`
+and mounts it at `/docker_start.sh`. It runs under `set -e` (line 9) and calls,
+at line 277 of chart 0.24.0:
 
 ```bash
-cscli console enroll "${enroll_args[@]}" "$ENROLL_KEY"
+cscli console enroll $enroll_args "$ENROLL_KEY"
 ```
 
 unguarded. `cscli console enroll` returns non-zero on a rejected or expired key,
 so **a dead key crash-loops the LAPI**. An *already enrolled* instance returns
-success with a warning, so restarts after a good first enrollment are safe.
+success, so restarts after a good first enrollment are safe.
 
-If the LAPI comes up `CrashLoopBackOff` with `could not enroll instance` in its
-logs, the fix is to delete the three `ENROLL_*` entries from
-`kubernetes/apps/network/crowdsec/values.yaml` — that falls back to Option B
-(community blocklist, no SaaS console), needs no key, and loses only the hosted
-dashboard, which `crowdsec-ui` replaces anyway. **Enrollment is optional garnish
-and must never gate the security engine.**
+Two details that make it worse than "no console":
+
+* **Bouncer registration is downstream.** Enrolment is line 277; the
+  `BOUNCER_KEY_*` loop is line 310. A dead enrolment key means the `traefik`
+  bouncer is never registered either, so Stage 2's proof below cannot pass.
+* **Flux uninstalls the release.** The HelmRelease has `timeout: 10m`; when the
+  LAPI never goes Ready the install fails and install remediation *uninstalls*
+  CrowdSec entirely, then retries. The symptom cycles rather than sitting still.
+
+There is no chart value for this and no fixed chart to upgrade to (0.24.0 is the
+newest published, and the call is still unguarded on the chart's main branch).
+`helmrelease.yaml` therefore carries a `postRenderers` patch that rewrites that
+one line to append `|| echo CROWDSEC_CONSOLE_ENROLL_FAILED_NONFATAL`. Grep the
+LAPI log for that string to see it catch. It fails open: if a chart bump changes
+the line, the `sed` no-ops and behaviour returns to the unguarded default.
+
+**Enrollment is optional garnish and must never gate the security engine.**
+
+### Re-enabling console enrolment
+
+Only worth doing for the hosted console UI and CAPI signal-sharing; `crowdsec-ui`
+already replaces the dashboard, and the community blocklist works without any of
+this.
+
+1. Sign in to `app.crowdsec.net` → **Security Engines → Enroll**, and copy the
+   enrollment key.
+2. Put it on the 1Password item **`Crowdsec ApiKey`** (vault `Eris`), field
+   **`credential`**. Nothing else needs rewiring — `externalsecret.yaml` still
+   copies that field into the `crowdsec-secrets` Secret verbatim, and was left
+   untouched when enrolment was switched off.
+3. Paste this block back into `lapi.env` in
+   `kubernetes/apps/network/crowdsec/values.yaml`, where the
+   `---- console enrolment: OFF ----` comment is:
+
+   ```yaml
+   - name: ENROLL_KEY
+     valueFrom:
+       secretKeyRef:
+         name: ${APP}-secrets
+         key: credential
+   - name: ENROLL_INSTANCE_NAME
+     value: '${CLUSTER_CNAME}'
+   - name: ENROLL_TAGS
+     value: 'k8s ${CLUSTER_CNAME}'
+   ```
+
+The block lives here rather than commented out in `values.yaml` because a
+dollar-brace sequence in a *comment* in that file is not inert — Flux `postBuild`
+envsubst expands comments too, which is the trap that broke #2977 and #2980, and
+`scripts/eso-values-lint` fails CI for it. In this Markdown file it is inert.
+
+Verify after re-enabling: `cscli console status` in the LAPI pod, and confirm the
+log has no `CROWDSEC_CONSOLE_ENROLL_FAILED_NONFATAL` line (which would mean the
+new key was rejected too — the guard caught it and the LAPI stayed up).
 
 ---
 

--- a/kubernetes/apps/network/crowdsec/helmrelease.yaml
+++ b/kubernetes/apps/network/crowdsec/helmrelease.yaml
@@ -71,3 +71,59 @@ spec:
         - namespace: network
           podName: traefik-*
           program: traefik
+  # ---- console-enrolment guard -------------------------------------------
+  # Makes `cscli console enroll` unable to kill the LAPI.
+  #
+  # WHY A POSTRENDERER AND NOT A CHART VALUE: there is no chart value for this,
+  # verified rather than assumed against chart 0.24.0 itself. The entrypoint is
+  # embedded with `.Files.Get "files/docker-start-custom.sh"` into a fixed
+  # ConfigMap name (templates/docker-start-configmap.yaml), the `command` below
+  # is a hardcoded string in templates/lapi-deployment.yaml with no value hook,
+  # and neither values.yaml nor values.schema.json exposes any enrol-related
+  # toggle. 0.24.0 is also the newest published chart, and the call is still
+  # unguarded on the chart's main branch, so there is no upgrade to wait for.
+  # The only remaining lever is the command line, hence this.
+  #
+  # WHAT IT DOES: rewrites the one `cscli console enroll` line of the entrypoint
+  # to append `|| echo ...` before running it, so a rejected key logs and the
+  # script continues to bouncer registration instead of aborting under `set -e`.
+  # The rewrite is a copy to /tmp; the ConfigMap mount stays read-only.
+  #
+  # FAILS OPEN: if a future chart changes that line so the pattern stops
+  # matching, sed passes the script through untouched and behaviour is exactly
+  # what it is today -- the guard can stop protecting, it cannot itself break
+  # startup. Grep for CROWDSEC_CONSOLE_ENROLL_FAILED_NONFATAL in the LAPI log to
+  # see the guard actually catch something.
+  #
+  # COUPLING TO WATCH: the `cp`/`ln` half of this command is copied verbatim
+  # from templates/lapi-deployment.yaml (emitted only when
+  # lapi.persistentVolume.config.enabled is true, which it is). The chart is
+  # pinned by digest above, so a bump is a deliberate act -- re-diff this
+  # command against the chart's own when you take one.
+  #
+  # Deliberately no dollar signs anywhere in the command: this file is subject
+  # to Flux postBuild envsubst, and a bare or braced name would be eaten.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: crowdsec-lapi
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: crowdsec-lapi
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: crowdsec-lapi
+                        command:
+                          - sh
+                          - -c
+                          - >-
+                            cp -nR /staging/etc/crowdsec/* /etc/crowdsec_data/
+                            && ln -s /etc/crowdsec_data /etc/crowdsec
+                            && sed 's#^\( *\)cscli console enroll \(.*\)#\1cscli console enroll \2 || echo CROWDSEC_CONSOLE_ENROLL_FAILED_NONFATAL#' /docker_start.sh > /tmp/docker_start.sh
+                            && bash /tmp/docker_start.sh

--- a/kubernetes/apps/network/crowdsec/values.yaml
+++ b/kubernetes/apps/network/crowdsec/values.yaml
@@ -159,28 +159,49 @@ lapi:
     # replaces the upstream entrypoint with files/docker-start-custom.sh, which
     # has no AGENT_USERNAME/AGENT_PASSWORD passthrough. crowdsec-ui registers
     # itself against the auto_registration endpoint configured above instead.
-    # ---- BEGIN console enrollment (Option C) ----------------------------
-    # DELETE THESE THREE ENTRIES TO FALL BACK TO OPTION B (community blocklist,
-    # no SaaS console). That is the entire rollback and it needs no secret.
     #
-    # WHY THIS MATTERS: the LAPI entrypoint runs under `set -e` and calls
-    # `cscli console enroll "$ENROLL_KEY"` unguarded
-    # (build/docker/docker-start-custom.sh:265-277). `cscli console enroll`
-    # returns a non-zero exit on a rejected or expired key, so a DEAD KEY
-    # CRASH-LOOPS THE LAPI -- it does not merely log. An already-enrolled
-    # instance returns success, so restarts after a good first enrollment are
-    # safe. The `credential` field has been unused since 2026-01; verify it in
-    # app.crowdsec.net before merging, or delete these three entries.
-    - name: ENROLL_KEY
-      valueFrom:
-        secretKeyRef:
-          name: ${APP}-secrets
-          key: credential
-    - name: ENROLL_INSTANCE_NAME
-      value: '${CLUSTER_CNAME}'
-    - name: ENROLL_TAGS
-      value: 'k8s ${CLUSTER_CNAME}'
-    # ---- END console enrollment ------------------------------------------
+    # ---- console enrolment: OFF, deliberately (Option B) -------------------
+    # There is no ENROLL_KEY / ENROLL_INSTANCE_NAME / ENROLL_TAGS entry here.
+    # That is the whole of Option B: the community blocklist still works, the
+    # SaaS console is simply not linked.
+    #
+    # WHAT HAPPENED. Option C (console linked) shipped in #2977 / #2980 and took
+    # the LAPI down on 2026-08-02. The `credential` field on the 'Crowdsec
+    # ApiKey' item had been unused since 2026-01 and the console rejected it
+    # with a 403. The chart entrypoint runs under `set -e` and calls
+    # `cscli console enroll` with nothing catching a non-zero exit -- chart
+    # 0.24.0, files/docker-start-custom.sh line 277, still unguarded on the
+    # chart's main branch as of 2026-08. So the rejection killed PID 1: the LAPI
+    # crash-looped, the four agents never left Init, and Flux's 10m install
+    # timeout then UNINSTALLED the release outright.
+    #
+    # Note the ordering, because it is worse than "no console": enrolment is
+    # line 277 and bouncer registration is line 310 of the same script. A dead
+    # enrolment key therefore also means BOUNCER_KEY_traefik above is never
+    # registered, so Traefik's bouncer cannot authenticate either.
+    #
+    # CAPI -- the community blocklist -- is NOT affected by any of this. It is
+    # registered in an earlier, separate block gated only on DISABLE_ONLINE_API,
+    # which we do not set. Turning enrolment off costs the hosted console UI and
+    # nothing else, and crowdsec-ui already replaces that dashboard.
+    #
+    # TO RE-ENABLE. Two steps, both small, neither archaeology:
+    #   1. app.crowdsec.net -> Security Engines -> Enroll: copy the enrollment
+    #      key shown there onto the 1Password item 'Crowdsec ApiKey' (vault
+    #      Eris), field `credential`. The ExternalSecret that copies that field
+    #      into the `crowdsec-secrets` Secret is UNCHANGED and still live, so
+    #      there is nothing to rewire -- see externalsecret.yaml.
+    #   2. Paste the three env entries back here. The exact block is kept in
+    #      docs/crowdsec-enforcement-rollout.md, under "Re-enabling console
+    #      enrolment". It is held there rather than commented out below on
+    #      purpose: a dollar-brace or two-brace sequence in a COMMENT in this
+    #      file is not inert, which is the exact trap that broke #2977 and
+    #      #2980, and `scripts/eso-values-lint` fails CI for it.
+    #
+    # helmrelease.yaml now carries a postRenderer that makes a failed enrolment
+    # non-fatal, so step 2 can no longer re-arm this outage: a key that dies
+    # later degrades to a log line. Read that comment before deleting it.
+    # ---- end console enrolment --------------------------------------------
   # D2: `lapi.dashboard` removed -- it is not a key in the chart schema in
   # 0.21.1 or 0.24.0. The bundled Metabase dashboard is gone; crowdsec-ui
   # replaces it.


### PR DESCRIPTION
## What broke

eq#2980 unblocked the ExternalSecret and CrowdSec finally got pods. The LAPI then crash-looped immediately, and the four agents wedged behind it in `Init:0/1`:

```
Local agent already registered
level=info msg="attempt 1 out of 2"
level=info msg="attempt 2 out of 2"
level=info msg="max attempts reached for status code 403"
Error: cscli console enroll: could not enroll instance: API error: the attachment key provided is not valid
```

The `credential` field has been unused since 2026-01 and the console now rejects it with a 403.

By the time I looked, Flux had already hit the 10m install timeout and **uninstalled the release** (`Remediated=True UninstallSucceeded`), so the outage was cycling install to crash to uninstall to retry rather than sitting still.

## Two faults, two fixes

### 1. Console enrolment off (Option B)

The three `ENROLL_*` entries are gone — the rollback #2980 named, and it needs no secret.

**CAPI is not affected.** `cscli capi register` sits in an earlier block gated only on `DISABLE_ONLINE_API`, which we do not set. The community blocklist keeps working; what is lost is the hosted console UI, which `crowdsec-ui` already replaces.

`externalsecret.yaml` is **deliberately untouched** so re-enabling is a paste, not archaeology.

### 2. A postRenderer makes enrolment non-fatal

I looked for a chart-supported mechanism first, and verified rather than inferred that there isn't one — against chart 0.24.0 itself:

- the entrypoint is embedded with `.Files.Get "files/docker-start-custom.sh"` into a fixed ConfigMap name (`templates/docker-start-configmap.yaml`) — no value overrides its content;
- the `command` is a hardcoded string in `templates/lapi-deployment.yaml` with no value hook;
- neither `values.yaml` nor `values.schema.json` exposes any enrol-related toggle;
- **0.24.0 is the newest published chart**, and the call is [still unguarded on the chart's main branch](https://raw.githubusercontent.com/crowdsecurity/helm-charts/main/charts/crowdsec/files/docker-start-custom.sh) — there is no upgrade to wait for.

`set -e` is line 9; the unguarded call is line 277. The only remaining lever is the command line, so the postRenderer rewrites that one line to append `|| echo CROWDSEC_CONSOLE_ENROLL_FAILED_NONFATAL`.

**It fails open.** If a future chart changes the line so the pattern stops matching, `sed` passes the script through untouched and behaviour is exactly what it is today. The guard can stop protecting; it cannot itself break startup.

## Worth recording

Enrolment is line 277, bouncer registration is line 310 of the same script. **A dead enrolment key therefore also meant `BOUNCER_KEY_traefik` was never registered** — the bouncer key itself is fine and is a separate credential, but registration never ran, so Stage 2's proof in the rollout doc could not have passed.

## Re-enabling

Deliberately **not** commented out in `values.yaml`: a dollar-brace sequence in a *comment* in that file is not inert — the exact trap that broke #2977 and #2980, and `scripts/eso-values-lint` fails CI for it. The paste-able block lives in `docs/crowdsec-enforcement-rollout.md` under "Re-enabling console enrolment". `values.yaml` points at it.

Two steps: put a fresh key from `app.crowdsec.net` → Security Engines → Enroll onto 1Password item `Crowdsec ApiKey` (vault `Eris`), field `credential`; paste the three entries back.

## Verification

- `scripts/eso-values-lint` — clean (37 files, 0 findings)
- `kustomize build` — OK; no `ENROLL_*` env entries survive
- `helm template` with the real values, then the postRenderer patch applied through kustomize — final command renders exactly as intended
- that rendered `sed`, run against the real chart script under **GNU sed 4.10**, changes **exactly one line**
- guarded vs unguarded simulated under `set -e`: unguarded exits 1 and never reaches bouncer registration; guarded logs and exits 0

## Scope checks

- **stargate-command-cluster: nothing to do.** Its crowdsec tree is dormant, confirmed both ways — `kubernetes/apps/network/kustomization.yaml` does not list `./crowdsec/ks.yaml`, and the live cluster has no crowdsec Kustomization, HelmRelease or pods. No companion PR.
- Respects #2980: `values.yaml` stays non-templated, no `templateFrom` / `templateAs: Values`, secrets still arrive via `secretKeyRef`, `$${...}` sequences untouched.

Refs vault#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)