### PR TITLE
docs(database): record the applied schema-permission fix for postgres backups

### DIFF
--- a/docs/postgres-backup-schema-permissions.md
+++ b/docs/postgres-backup-schema-permissions.md
@@ -1,21 +1,28 @@
-# PostgreSQL logical backup — `tandoor` has no coverage, and the job never said so
+# PostgreSQL logical backup — `tandoor` had no coverage, and the job never said so
 
 Found while planning the CNPG 17 → 18 upgrade
 ([david-driscoll/vault#114](https://github.com/david-driscoll/vault/issues/114),
 blocking prerequisite 0a). Two independent defects; the second is why the first
 went unnoticed.
 
-The PR that adds this file fixes **only the second one** (the silent-success
-bug, in code). The first needs one-time SQL against the live cluster and is
-written out below — **nothing here has been applied.**
+> **Status: both resolved, 2026-08-02.**
+>
+> - The silent-success bug was fixed in code by
+>   [#2984](https://github.com/david-driscoll/equestria-cluster/pull/2984) (§4).
+> - The schema permissions were applied to the live cluster at ~01:20 UTC on
+>   2026-08-02, to `tandoor` **and** to the four databases carrying the same
+>   latent pattern (§5). §3 records exactly what ran.
+>
+> Kept as the record of why this happened and what to check if it recurs. The
+> stale `tandoor` schema itself has **not** been dropped — see §3B.
 
 ---
 
-## 1. What is broken
+## 1. What was broken
 
-`postgres-backup` (`kubernetes/apps/database/postgres/backups`, daily at 02:00)
+`postgres-backup` (`kubernetes/apps/database/postgres/backups`, daily at 02:00 UTC)
 iterates every non-template database and shells out to `pg_dump`. For `tandoor`
-it has been failing for as long as the current script has run:
+it had been failing for as long as the current script had run:
 
 ```text
 Backing up database: tandoor
@@ -28,13 +35,15 @@ pg_dump: error: query failed: ERROR:  permission denied for schema tandoor
 read 2026-08-01.)
 
 `tandoor` carries two parallel schemas. `pg_dump` runs as the unprivileged
-`tandoor` login role, reaches the second one, tries to `LOCK` its tables, and
-aborts the whole dump — including the half it *could* read.
+`tandoor` login role, reached the second one, tried to `LOCK` its tables, and
+aborted the whole dump — including the half it *could* read.
 
 The job still reported `Complete`. See §4.
 
-**`tandoor` therefore has no logical backup at all.** Physical coverage is
-unaffected: barman-cloud WAL archiving and PITR were enabled in
+**`tandoor` therefore had no logical backup at all** until 2026-08-02. How far
+back is not knowable from the cluster — `successfulJobsHistory: 3` means only
+the last three runs are retained, and all three failed this way. Physical
+coverage was never affected: barman-cloud WAL archiving and PITR were enabled in
 [#2981](https://github.com/david-driscoll/equestria-cluster/pull/2981) and back
 up the whole cluster at the storage layer.
 
@@ -77,54 +86,85 @@ drifted.
 
 ---
 
-## 3. Remediation — not applied
+## 3. Remediation — applied 2026-08-02
 
-Two-step, deliberately. Step A is non-destructive and restores coverage
-immediately; it also pulls the stale schema *into* the backup, so step B stops
-being irreversible.
-
-### A. Grant, so `pg_dump` completes
+### A. Pin the search path, then grant — applied
 
 The 95 tables and 91 sequences in `tandoor.tandoor` are all owned by `postgres`,
-so schema USAGE alone is not enough — `pg_dump` takes `ACCESS SHARE` locks and
-reads sequence values.
+so schema USAGE alone is not enough: `pg_dump` takes `ACCESS SHARE` locks on
+every table and reads sequence values.
+
+There is a trap in granting that access. Tandoor is Django and sets no
+`search_path`, so it uses the PostgreSQL default `"$user", public`. Today
+`"$user"` — the schema named `tandoor` — is skipped only because the role cannot
+see it. **Granting USAGE makes it resolvable and moves it ahead of `public`**,
+so a restarted Tandoor would silently start reading the January data.
+
+Pinning the search path first removes the trap outright, which is better than
+sequencing around it:
 
 ```sql
-\c tandoor
+-- ran against admin@equestria, database tandoor, as postgres
+BEGIN;
+ALTER ROLE tandoor IN DATABASE tandoor SET search_path = public;  -- do this FIRST
 ALTER SCHEMA tandoor OWNER TO tandoor;
 GRANT USAGE ON SCHEMA tandoor TO tandoor;
 GRANT SELECT ON ALL TABLES IN SCHEMA tandoor TO tandoor;
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA tandoor TO tandoor;
+COMMIT;
 ```
 
-`ALTER SCHEMA ... OWNER` is what converges the live cluster with the ownership
-already declared in `components/postgres/database.yaml`. The `GRANT`s cover the
-objects inside, whose ownership that declaration does not reach.
+With `search_path` pinned, `"$user"` can no longer shadow `public`, the grant is
+safe across restarts, and step B becomes optional cleanup rather than a
+prerequisite. `ALTER SCHEMA ... OWNER` converges the live cluster with the
+ownership already declared in `components/postgres/database.yaml`; the `GRANT`s
+cover the objects inside, which that declaration does not reach.
 
-> Granting `tandoor` access to the `tandoor` schema makes `"$user"` resolvable
-> and therefore **puts it ahead of `public` in the app's search path**. Restart
-> the Tandoor deployment only after step B, or verify the app still reads the
-> `public` tables. This is the one sharp edge in this document.
+The same `ALTER SCHEMA` + `GRANT` block (**without** the `search_path` pin — see
+§5) was applied to `immich`, `n8n`, `retrom`, and `vikunja`.
 
-### B. Drop the stale schema — only after a verified restore
+### B. Drop the stale schema — still outstanding, optional
 
-Once the next nightly run produces a `tandoor.sql.gz` that restores cleanly:
+Once a `tandoor.sql.gz` has been restored and checked:
 
 ```sql
 \c tandoor
 DROP SCHEMA tandoor CASCADE;   -- 95 tables, last written 2026-01-30
 ```
 
-This also removes the search-path hazard from step A permanently.
+No longer urgent — the search-path hazard is gone and the schema is now captured
+in the nightly dump. This is housekeeping to stop backing up a dead 95-table
+copy indefinitely.
 
 ### Verify
 
-```bash
-kubectl --context admin@equestria create job -n database \
-  --from=cronjob/postgres-backup postgres-backup-verify
+Rehearse exactly what `pg_dump` does — take its locks as the app role, inside a
+transaction that rolls back. Read-only, safe at any time:
+
+```sql
+BEGIN;
+SET ROLE tandoor;
+DO $$
+DECLARE r record; n int := 0;
+BEGIN
+  FOR r IN SELECT c.relname FROM pg_class c JOIN pg_namespace ns ON ns.oid = c.relnamespace
+           WHERE ns.nspname = 'tandoor' AND c.relkind = 'r'
+  LOOP
+    EXECUTE format('LOCK TABLE tandoor.%I IN ACCESS SHARE MODE', r.relname);
+    n := n + 1;
+  END LOOP;
+  RAISE NOTICE 'locked % tables as role %', n, current_user;
+END $$;
+ROLLBACK;
 ```
 
-Expect exit 0 and `Successfully created backup: /backups/tandoor.sql.gz`.
+Confirmed `locked 95 tables in schema tandoor as role tandoor` on 2026-08-02.
+
+> **Do not verify with `kubectl create job --from=cronjob/postgres-backup`.**
+> `concurrencyPolicy: Forbid` governs only CronJob-created Jobs, so a manual Job
+> can run alongside the 02:00 scheduled one. Both would write the same
+> `<db>.sql.gz.tmp` staging paths on the NFS share and race each other. Either
+> use the lock rehearsal above, or run a manual Job well clear of 02:00 UTC.
 
 ---
 
@@ -136,7 +176,7 @@ unconditionally printed `PostgreSQL backup completed successfully` and fell off
 the end of the program with exit 0. The CronJob reported `Complete`, so the
 existing Job-failure alerting had nothing to fire on.
 
-Fixed in this PR:
+Fixed in [#2984](https://github.com/david-driscoll/equestria-cluster/pull/2984):
 
 - failed databases are collected; a non-empty list logs to **stderr** and exits **1**
 - each dump is written to `<db>.sql.gz.tmp` and moved into place only after
@@ -154,31 +194,39 @@ the exit code, so a non-zero exit fails the Job with no manifest change.
 
 ## 5. The same pattern elsewhere
 
-Every database using the `postgres` component gets an `<app>` schema. Five have
-one owned by `postgres` rather than the app role:
+Every database using the `postgres` component gets an `<app>` schema. Five had
+one owned by `postgres` rather than the app role. All five were fixed on
+2026-08-02; state before → after:
 
-| database | schema tables | app role has USAGE | dump status |
-|---|---|---|---|
-| **tandoor** | 95 | no | **failing** |
-| immich | 18 | yes — **only because `immich` is a superuser** | passing, latently fragile |
-| n8n | 0 | no | passing (nothing to lock) |
-| retrom | 0 | no | passing (nothing to lock) |
-| vikunja | 0 | no | passing (nothing to lock) |
+| database | schema tables | app role had USAGE | dump status before | now |
+|---|---|---|---|---|
+| **tandoor** | 95 | no | **failing** | owner `tandoor`, USAGE + SELECT on all 95 tables / 91 sequences |
+| immich | 18 | yes — **only because `immich` is a superuser** | passing, latently fragile | owner `immich`, USAGE + SELECT, no longer superuser-dependent *for the dump* |
+| n8n | 0 | no | passing (nothing to lock) | owner `n8n` |
+| retrom | 0 | no | passing (nothing to lock) | owner `retrom` |
+| vikunja | 0 | no | passing (nothing to lock) | owner `vikunja` |
 
-Two things worth acting on separately from this PR:
+Transferring schema ownership is what closes this permanently for the empty
+ones: tables the app role creates in a schema it owns are owned by that role, so
+a future `CREATE TABLE` cannot reopen the gap.
 
-- **`immich` is live data, not a stale copy** — `geodata_places` alone holds
-  227,901 rows and was read on 2026-08-01. Recent Immich versions genuinely use
-  a dedicated schema. It dumps today purely because `rolsuper = t` on the
-  `immich` role bypasses the ACL check. Revoking that superuser bit — reasonable
-  hardening, and something a CNPG major-version upgrade may prompt — would break
-  Immich's backup exactly the way Tandoor's is broken now. Apply the same
-  `ALTER SCHEMA` / `GRANT` before touching that role.
-- **`n8n`, `retrom`, `vikunja`** are one `CREATE TABLE` away from the same
-  failure. Applying step A's grants pre-emptively costs nothing.
+Two caveats that survive the fix:
 
-After this PR, none of these can fail silently again — but they will fail the
-whole nightly job, so fixing them is not optional once the exit code is honest.
+- **The `search_path` pin from §3A applies to `tandoor` only.** It was correct
+  there because `public` is authoritative and the `tandoor` schema is a dead
+  copy. **`immich` is the opposite** — its schema is live data, `geodata_places`
+  alone holds 227,901 rows read on 2026-08-01, because recent Immich versions
+  genuinely use a dedicated schema. Pinning `search_path = public` on `immich`
+  would break the app. Do not copy §3A wholesale.
+- **`immich`'s grant covers the backup, not the application.** `pg_dump` needs
+  `SELECT`; Immich itself needs write access, which it currently gets from
+  `rolsuper = t`. Revoking that superuser bit — reasonable hardening, and
+  something a CNPG major-version upgrade may prompt — would leave the nightly
+  dump working but break the app. Transfer ownership of the 18 tables and their
+  sequences to the `immich` role first.
+
+Since [#2984](https://github.com/david-driscoll/equestria-cluster/pull/2984),
+none of these can fail silently again — they fail the whole nightly job instead.
 
 ---
 


### PR DESCRIPTION
Follow-up to #2984. Docs only — no manifest or code changes.

The runbook that shipped in #2984 opened with *"nothing here has been applied"*. The SQL has since been applied to all five affected databases, so the checked-in document contradicted the live cluster. This reconciles it.

## What was applied (2026-08-02 ~01:20 UTC)

| database | before | after |
|---|---|---|
| **tandoor** | schema owned by `postgres`, no USAGE, **dump failing** | owner `tandoor`, USAGE + SELECT on all 95 tables / 91 sequences, `search_path` pinned to `public` |
| immich | owned by `postgres`, worked only via `rolsuper` | owner `immich`, USAGE + SELECT |
| n8n / retrom / vikunja | owned by `postgres`, empty | owner `n8n` / `retrom` / `vikunja` |

Verified: schema USAGE true and **zero** tables or sequences without SELECT across all five. For tandoor I also rehearsed the exact failing operation — `SET ROLE tandoor` then `LOCK TABLE ... IN ACCESS SHARE MODE` on all 95 tables inside a rolled-back transaction — which now reports `locked 95 tables in schema tandoor as role tandoor`.

Transferring schema *ownership* (rather than only granting) is what closes this permanently on the empty ones: tables the app role creates in a schema it owns are owned by that role, so a future `CREATE TABLE` can't reopen the gap.

## Two corrections to what #2984 said

Both are cases where the original document was workable but not right:

**1. Pin `search_path` before granting.** #2984 flagged that granting USAGE makes `"$user"` resolvable and moves the stale schema *ahead of* `public` in Django's default search path — then asked the operator not to restart Tandoor between the grant and the drop. That's a hazard scheduled around rather than removed. `ALTER ROLE tandoor IN DATABASE tandoor SET search_path = public` first makes the grant safe across restarts unconditionally, and demotes `DROP SCHEMA` from prerequisite to optional cleanup.

**2. The suggested verification step was unsafe.** #2984 suggested `kubectl create job --from=cronjob/postgres-backup`. `concurrencyPolicy: Forbid` governs only CronJob-*created* Jobs, so a manual Job can run alongside the 02:00 scheduled one — and after #2984 both stage to the same `<db>.sql.gz.tmp` paths on the NFS share and would race. Replaced with the rolled-back `SET ROLE` + `LOCK TABLE` rehearsal, which reproduces exactly the privilege check `pg_dump` performs and is safe at any time.

## Caveats now recorded in §5

- **The `search_path` pin is tandoor-specific and would break immich.** It was correct for tandoor because `public` is authoritative and the `tandoor` schema is a dead January copy. immich is the opposite — its schema is *live* (227,901 rows in `geodata_places`), because recent Immich versions genuinely use a dedicated schema.
- **immich's grant covers the dump, not the app.** `pg_dump` needs SELECT; Immich itself needs write access, which it still gets from `rolsuper = t`. Revoking that superuser bit now leaves the backup working but breaks the application — its 18 tables and their sequences need ownership transferred first. Worth knowing before the CNPG 17 → 18 work touches that role.

## Also corrected

§1 said tandoor "has no logical backup at all" in the present tense. Moved to past tense, and the *duration* of the gap is now stated as unknowable rather than estimated — `successfulJobsHistory: 3` retains only the last three runs. I confirmed all three failed identically (`permission denied for schema tandoor`), but nothing older survives to date the start.

## Validation

- `flate test all` — `322 passed · 2 skipped · 2 blocked`, unchanged from base
- `yamllint -c .yamllint kubernetes/apps/database/postgres/` — clean

## Still outstanding

- `DROP SCHEMA tandoor CASCADE` (§3B) — no longer urgent now the hazard is gone and the schema is captured in the dump; housekeeping to stop backing up a dead 95-table copy.
- The `.Dump()` connection-string leak into pod logs, noted in #2984 and tracked separately.

<!-- crew:agent=seraph -->