### PR TITLE
fix(crowdsec): add volsync-restore bootstrap RD and fix the ExternalSecret store so crowdsec-ui can start

### DIFF
--- a/kubernetes/apps/network/crowdsec-ui/externalsecret.yaml
+++ b/kubernetes/apps/network/crowdsec-ui/externalsecret.yaml
@@ -97,7 +97,22 @@ spec:
       sourceRef:
         storeRef:
           kind: ClusterSecretStore
-          name: cluster
+          # `network`, NOT `cluster`. These stores are all the kubernetes
+          # provider pointed at a FIXED remoteNamespace (see
+          # kubernetes/apps/kube-system/external-secrets/stores/kubernetes.yaml):
+          # `cluster` reads from the equestria namespace, `network` from the
+          # network namespace. The oidc-credentials Secret is written into the
+          # app's OWN namespace, which for this app is network -- so `cluster`
+          # resolved it to equestria, where it does not exist, and the WHOLE
+          # ExternalSecret failed: "error processing spec.dataFrom[1].extract,
+          # err: Secret does not exist". No -env Secret was created at all, so
+          # the envFrom in helmrelease.yaml would have left the pod in
+          # CreateContainerConfigError even once its PVC binds.
+          # Every existing user of `cluster` is an app in the equestria
+          # namespace, where store name and app namespace coincide; this is the
+          # first app outside it to take this path, which is why the mismatch
+          # had not surfaced before.
+          name: network
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/network/crowdsec-ui/ks.yaml
+++ b/kubernetes/apps/network/crowdsec-ui/ks.yaml
@@ -38,6 +38,40 @@ spec:
     - ../../../components/failover/fast-node-eviction
     - ../../../components/tailscale
     - ../../../components/volsync
+    # BOOTSTRAP ONLY -- REMOVE ONCE THE RESTORE HAS COMPLETED.
+    #
+    # components/volsync always stamps the app PVC with a dataSourceRef to a
+    # ReplicationDestination named ${APP}-dst, but the ReplicationDestination
+    # itself lives here, in components/volsync-restore. Without it the PVC is
+    # claimed by the VolSync volume populator, Longhorn stands down
+    # ("assuming an external populator will provision the volume"), and the
+    # populator waits forever for an object nothing creates -- so the PVC never
+    # binds and the pod never schedules. That is exactly what happened on the
+    # initial crowdsec-ui deploy, and to tsiam on stargate-command-cluster
+    # (sgc#1739); technitium in this namespace is Bound only because its own
+    # -dst existed when its PVC was created and was later reaped by the
+    # nightly volsync-system/restore-cleanup CronJob.
+    #
+    # crowdsec-ui has no backup to restore: the restic repository at
+    # /repository/crowdsec-ui does not exist yet. That is fine and is the
+    # intended bootstrap path. VolSync 0.16.0's restic mover runs
+    # `ensure_initialized` (creating the repo) and then do_restore finds
+    # nothing, logs "No eligible snapshots found / No data will be restored",
+    # and exits 0. The result is an empty volume, a bound PVC, and an
+    # initialized repository for the ReplicationSource to back up into at 14:00.
+    #
+    # The PVC itself is deliberately NOT touched: dataSourceRef is immutable,
+    # and the populator watches ReplicationDestinations and re-enqueues unbound
+    # PVCs, so simply creating crowdsec-ui-dst is sufficient.
+    #
+    # Lifecycle from here (see components/volsync-restore/AGENTS.md):
+    #   1. RD restores (no-op), sets status.lastManualSync=restore-once, PVC binds.
+    #   2. The nightly volsync-restore-cleanup CronJob (03:30) deletes the
+    #      completed RD, cascading away the -dst-dest/-dst-cache PVCs.
+    #   3. This component MUST then be removed from this list, or Flux recreates
+    #      the RD every reconcile and fights the cleanup job -- the permanent
+    #      -dst-dest/-dst-cache pair is what caused the 2026-07 Longhorn incident.
+    - ../../../components/volsync-restore
   postBuild:
     substitute:
       APP: *app
@@ -46,6 +80,15 @@ spec:
       # alert history) is the size driver.
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_ACCESSMODES: ReadWriteOnce
+      # Both movers read this one variable, but the defaults differ: 2Gi in the
+      # ReplicationSource and 8Gi in the ReplicationDestination. Left unset, the
+      # bootstrap restore below would provision an 8Gi 2-replica longhorn-cache
+      # volume to restore zero bytes. 2Gi rather than a smaller number because
+      # this same value also sizes the long-lived ReplicationSource cache, and
+      # 2Gi is what every other volsync-backed app on this cluster runs with;
+      # this pin only removes the 8Gi over-provision, it does not shrink the
+      # source cache below the estate norm.
+      VOLSYNC_CACHE_CAPACITY: 2Gi
       # The image runs as the `node` user (1000:1000); the restic mover has to
       # match or it cannot read what it is backing up.
       VOLSYNC_PUID: "1000"


### PR DESCRIPTION
Fixes the `crowdsec-ui` deploy, Pending since it merged. Tracking: david-driscoll/vault#111 (stays open — the Stage 1–6 enforcement ladder is untouched).

Two independent first-deploy bugs. Either one alone keeps the pod from running, so both are here.

## Bug 1 — the PVC can never bind (identical to sgc#1739)

```
pod crowdsec-ui-6b654648cf-fn966  0/1 Pending
  FailedScheduling: pod has unbound immediate PersistentVolumeClaims
pvc crowdsec-ui  Pending  sc=longhorn
  Warning VolSyncPopulatorReplicationDestinationMissing:
    Unable to populate volume: ReplicationDestination.volsync.backube "crowdsec-ui-dst" not found
  Normal  Provisioning: Assuming an external populator will provision the volume
  Normal  ExternalProvisioning (x64): waiting for 'driver.longhorn.io' or an administrator
```

`components/volsync` **always** stamps the app PVC with a `dataSourceRef` to `${APP}-dst`, but the ReplicationDestination itself lives in the **separate** `components/volsync-restore`. `crowdsec-ui`'s `ks.yaml` had the first and not the second, so the VolSync populator claimed the PVC, Longhorn deliberately stood down, and the populator is waiting on an object nothing in this repo creates. Deadlock, not a slow start.

sgc#1739 fixed the byte-identical failure for `tsiam` ~2h ago and predicted this one for equestria. Everything it established was re-verified here rather than assumed:

| claim from sgc#1739 | verified on equestria |
|---|---|
| components are the same arrangement | `diff -r` of both `components/volsync` and `components/volsync-restore` against SGC: **identical, zero differences** |
| RD cache defaults 8Gi vs RS 2Gi | confirmed in this repo's own component files, and in a local `kustomize build` render |
| VolSync version with no-op empty-repo restore | `quay.io/backube/volsync:0.16.0` in `volsync-system` — **same version** SGC verified the mover source against |
| a cleanup CronJob exists to reap the RD | `volsync-system/restore-cleanup`, `30 3 * * *`, cluster-wide (`-A`), same script |

**`technitium` is the control and it confirms the diagnosis.** It is the other volsync-backed app in the `network` namespace, its PVC carries the identical `dataSourceRef` to `technitium-dst`, there is no `technitium-dst` in the cluster today, and it is Bound — because its `-dst` existed when its PVC was created and was later reaped by the cleanup CronJob. Its component list is `volsync` only, same as crowdsec-ui's was. The difference is bootstrap history, not configuration.

Local render confirms the names line up:

| | |
|---|---|
| PVC `crowdsec-ui` `dataSourceRef.name` | `crowdsec-ui-dst` |
| rendered RD `metadata.name` | `crowdsec-ui-dst` |

### Why a restore is correct when there is nothing to restore

`crowdsec-ui-volsync-secret` resolves to `/repository/crowdsec-ui`, which does not exist yet — this app has never been backed up (its ReplicationSource shows no `LAST SYNC` purely because it is blocked on the same unbound `sourcePVC`). On VolSync 0.16.0's restic mover that is the supported bootstrap path: `ensure_initialized` runs `restic init`, `do_restore` finds no snapshots, logs *No eligible snapshots found / No data will be restored*, exits 0. Net effect is exactly what a new app wants — empty volume, **bound PVC**, and an **initialized repository** for the ReplicationSource to back into from 14:00. crowdsec-ui ends up genuinely covered by VolSync, not merely unblocked.

### The PVC is deliberately not touched

`dataSourceRef` is immutable and the estate has been bitten by that before. No PVC recreation, no scale-to-0. The populator watches ReplicationDestinations and re-enqueues only *unbound* PVCs, so creating `crowdsec-ui-dst` is sufficient.

### `VOLSYNC_CACHE_CAPACITY: 2Gi`, not 1Gi

Both movers read this one variable, and the defaults genuinely differ (8Gi RD / 2Gi RS) exactly as sgc#1739 said — but the right *value* does not carry over. sgc used 1Gi because tsiam's payload is a JWK plus tsnet state. crowdsec-ui's is SQLite plus the GeoNames snapshot plus 168h of alert history, up to 5Gi, and this same variable also sizes the **long-lived ReplicationSource cache**. 2Gi removes the 8Gi over-provision on the one-shot restore (`longhorn-cache` is `numberOfReplicas: 2`, so 8Gi is 16Gi on disk) while leaving the source cache at exactly the default every other volsync-backed app on this cluster runs with.

## Bug 2 — the ExternalSecret was failing, and would have held the pod after the PVC bound

Found while verifying the above; it is not cosmetic and not deferrable, because `helmrelease.yaml` does a required `envFrom: secretRef: crowdsec-ui-env`.

```
externalsecret crowdsec-ui-env   SecretSyncedError   False
  Warning UpdateFailed (x11): error processing spec.dataFrom[1].extract, err: Secret does not exist
$ kubectl -n network get secret crowdsec-ui-env
Error from server (NotFound)
```

The `${APP}-oidc-credentials` extract used `ClusterSecretStore/cluster`. Those stores are the kubernetes provider pinned to a **fixed** `remoteNamespace` (`kubernetes/apps/kube-system/external-secrets/stores/kubernetes.yaml`): `cluster` → `equestria`, `network` → `network`. The Secret is written into the app's own namespace, and this app lives in `network`:

```
network/crowdsec-ui-oidc-credentials   Opaque   9   16m
```

One failing `dataFrom` entry fails the whole ExternalSecret, so **no `crowdsec-ui-env` Secret was created at all** — the pod would have gone Pending → CreateContainerConfigError the moment the PVC bound. Switched to `name: network`. The remote Secret's key set is identical to a known-good control (`equestria/tududi-oidc-credentials`), so `oidc_client_id` / `oidc_client_secret` / `oidc_issuer` resolve unchanged.

Every existing user of `cluster` is an app in the `equestria` namespace, where store name and app namespace coincide. crowdsec-ui is the first outside it, which is why this had not surfaced.

## Follow-up required — `volsync-restore` must come back out

Per `components/volsync-restore/AGENTS.md`, leaving it in permanently is what caused the **2026-07 Longhorn incident**. Lifecycle:

1. RD restores (no-op), sets `status.lastManualSync: restore-once`, PVC binds, pod schedules.
2. The nightly `volsync-system/restore-cleanup` CronJob (03:30) deletes the completed RD, cascading away the `crowdsec-ui-dst-dest` / `crowdsec-ui-dst-cache` PVCs.
3. **A follow-up PR must remove `../../../components/volsync-restore` from this `components:` list**, or Flux recreates the RD every reconcile and fights the cleanup job.

The exit condition for step 3 is `kubectl -n network get replicationdestination crowdsec-ui-dst` returning NotFound with `pvc/crowdsec-ui` Bound. Earliest that can be true is 03:30 tomorrow.

## Sweep — nothing else on this cluster is in this state

`crowdsec-ui` is the **only** non-Bound PVC in the entire cluster, and the only one whose `dataSourceRef` points at a ReplicationDestination that does not exist. The other 38 `dataSourceRef` PVCs are all Bound. No other app needed fixing.

One unrelated observation, **not touched here**: `equestria/dynacat-dst` is a live ReplicationDestination re-created by Flux every reconcile. dynacat is sourced from the `home-operations` GitRepository, whose `kubernetes/components/volsync` still bundles `replicationdestination.yaml` inline rather than split out — i.e. the pre-split component shape. That is the permanent-RD condition `AGENTS.md` warns about, in a different repo, and belongs in its own change.

## Validation

```
yamllint -c .yamllint kubernetes/apps/network/crowdsec-ui/                 # clean
go -C scripts/eso-values-lint test ./...                                  # ok
go -C scripts/eso-values-lint run . ./kubernetes                           # 0 findings
flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets    # 324 passed, 2 skipped
```

The 7 `flate` warnings (meilisearch, windmill, amd-device-plugin, external-secrets, alloy, grafana, tailscale-operator) are pre-existing on `main` and untouched. `crowdsec/values.yaml` is not touched at all — no templating reintroduced, per #2980/#2985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
