### PR TITLE
fix(database): point barman-cloud at a Minio bucket that actually exists (vault#119)

### DIFF
--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -31,7 +31,17 @@ backups:
   provider: s3
   s3:
     region: "{{ .minio_region }}"
-    bucket: "{{ .backblaze_bucket }}"
+    # A Minio bucket, because the endpoint URL, access key and secret key
+    # around it are all Minio-on-truenas. What stood here until vault#119 was
+    # a templated reference to the backblaze item's bucket field, which names
+    # a bucket that exists only on Backblaze B2 -- so every WAL archive died
+    # with NoSuchBucket, reported as barman's opaque "exit status 4". Do not
+    # reintroduce a backblaze-prefixed reference here: the two 1Password items
+    # this file is templated from are told apart only by that prefix, and
+    # nothing downstream will catch the mismatch. The bucket is provisioned in
+    # home-operations stacks/home and must exist before this reconciles,
+    # because barman-cloud does not create buckets.
+    bucket: "cnpg-${CLUSTER_CNAME}"
     # Dedicated prefix so barman's base backups + WAL never share a namespace
     # with the logical dumps or the `-restore` staging bucket.
     path: "/barman/${CLUSTER_CNAME}"


### PR DESCRIPTION
## Why

`vault#119`. WAL archiving has failed on every instance since #2981 landed at 00:17Z:

```
ContinuousArchiving=False
unexpected failure invoking barman-cloud-wal-archive: exit status 4
```

Exit 4 is barman's `GeneralErrorExit` (`src/barman/clients/cloud_cli.py`) — the catch-all for an unhandled exception, deliberately generic. The plugin sidecar log has the real error:

```
Barman cloud WAL archiver exception: An error occurred (NoSuchBucket)
when calling the PutObject operation: The specified bucket does not exist
```

`s3://equestria-db` does not exist. `mc ls` against truenas Minio returns exactly two buckets: `home-operations` and `thanos*`. `equestria-db` is a **Backblaze B2** bucket name, sourced from the `${BACKBLAZE_DATABASE}` 1Password item, and #2981 paired it with the Minio endpoint and Minio credentials. The endpoint and the credentials were right; the bucket name came from the wrong secret. That was my error in #2981.

## What this actually costs us right now

- **Nothing has ever been archived.** `pg_stat_archiver` on postgres-2 has `last_archived_time` frozen at `2026-08-02 00:20:56Z` and `failed_count` climbing. The 3561 segments it counts as archived were CNPG's no-op archiver running with no object store attached — they went nowhere. **PITR does not exist on this cluster.**
- **pg_wal cannot recycle.** Postgres will not reuse a segment until it is archived. 31 `.ready` files queued on the primary, accumulating at ~12 segments/hour (~190 MB/h, floored by `archive_timeout=300`). 38G free on a 40G PVC ≈ **8 days** of runway. Not tonight. But this is the opening move of the 2026-07 SGC out-of-disk cascade.

## What changed

**One file, one value:** `bucket: "cnpg-${CLUSTER_CNAME}"`, plus a comment saying why. The new name is explicit about which object store it lives in and stops the WAL destination from silently moving if the B2 item is ever rotated.

The `Cluster` spec is untouched — this only changes `ObjectStore.spec.configuration.destinationPath`, so no rolling restart of the instances.

### Two corrections since the first push

- **`ESO Values Lint` caught me.** My first version of that comment quoted the old value literally, two braces and all, inside a file external-secrets renders with `templateAs: Values` — the exact class of bug that took CrowdSec down twice tonight and that `scripts/eso-values-lint` was written hours ago to stop. The guard worked. Rewritten in prose, and it now says *don't reintroduce a backblaze-prefixed reference here* rather than demonstrating one. `go run ./scripts/eso-values-lint` is clean locally: 37 files checked, 6 rendered by `templateAs: Values`, 0 findings.
- **Rebased onto `origin/main`.** The branch was cut from a local `main` carrying eq#2987 (crowdsec-ui), so this PR was showing that PR's files too. Rebuilt from `origin/main`; the Files tab is now one file.

## Ordering — do not merge this first

barman-cloud does not create buckets. Blocked on **david-driscoll/home-operations#630**, which provisions `cnpg-equestria` and must be **applied**, not merely merged. That PR is now also clean — one file, `stacks/home/index.ts` — so applying it drags nothing else in with it.

## Second condition, and why it is not a second bug

```
LastBackupSucceeded=False  requested plugin is not available: barman-cloud.cloudnative-pg.io
```

This is stale, not live. The chart's ScheduledBackup is created with `immediate: true`; it fired at 00:22:02Z, in the window between the ObjectStore being created (00:22:01Z) and the instance pods being recreated with the barman sidecar injected (00:22–00:26Z). The backup hit instances that genuinely had no such plugin. It has not been retried since — `nextScheduleTime` is 16:00Z, and there are no `Backup` objects in the namespace.

The plugin is registered now: `Cluster.status.pluginStatus` lists `barman-cloud.cloudnative-pg.io` v0.14.0, and the sidecars are running and actively invoking barman — that is what produces the exit-4 errors. Once a bucket exists, an on-demand `Backup` will clear it. **Acceptance is a completed backup, not the plugin merely loading** — I will verify and report on vault#119.

## Not fixed here, deliberately

The `recovery:` block still pairs the backblaze bucket field with the Minio endpoint — the same class of bug. It is inert under `mode: standalone`, but it is the block you flip to during an actual restore, so it needs the same correction *and* a rehearsal before anyone calls PITR real. Tracked on vault#119 rather than widened into this PR.

<!-- crew:agent=seraph -->