### PR TITLE
fix(dynacat): pin VOLSYNC_CACHE_CAPACITY and document the volsync-restore lifecycle (vault#120)

### DIFF
--- a/kubernetes/apps/equestria/home/dynacat/ks.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/ks.yaml
@@ -33,12 +33,31 @@ spec:
   components:
     - ../kubernetes/components/failover/fast-node-eviction
     - ../kubernetes/components/tailscale
+    # NOTE: these paths resolve inside the home-operations repo, not this one --
+    # sourceRef above is GitRepository/home-operations. If this app ever needs a
+    # bootstrap or disaster-recovery restore, add
+    # `../kubernetes/components/volsync-restore` here, wait for
+    # `kubectl -n equestria get replicationdestination dynacat-dst` to report a
+    # lastSyncTime, then REMOVE it again. Leaving it in permanently is what
+    # caused the 2026-07 Longhorn incident (vault#120): the restore-once trigger
+    # had already fired, the nightly volsync-system/restore-cleanup CronJob
+    # reaped the RD at 03:30, and Flux recreated it on the next reconcile --
+    # re-running a full restic restore and re-provisioning a 5Gi
+    # longhorn-snapshot + 8Gi longhorn-cache PVC pair, every single day.
     - ../kubernetes/components/volsync
   postBuild:
     substitute:
       APP: *app
       NAMESPACE: *namespace
       VOLSYNC_CAPACITY: 5Gi
+      # Both movers read this one variable, but the defaults are asymmetric:
+      # 2Gi in the ReplicationSource and 8Gi in the ReplicationDestination. The
+      # ReplicationSource has run fine on 2Gi for 83 days against this exact
+      # restic repository (which is tiny -- a full restore completes in 4s), so
+      # pinning 2Gi changes nothing today and stops a future volsync-restore
+      # from silently provisioning an 8Gi longhorn-cache volume to restore a 5Gi
+      # source. Same pin as crowdsec-ui (#2987) and tsiam (sgc#1739).
+      VOLSYNC_CACHE_CAPACITY: 2Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
     substituteFrom:


### PR DESCRIPTION
The equestria half of david-driscoll/vault#120. Paired with david-driscoll/home-operations#631, which does the actual component split; the two are independent and can land in either order.

## Context

`dynacat` is the only Kustomization in the estate that sources `components/volsync` from the **home-operations** repo (`sourceRef: GitRepository/home-operations`, `path: ./dashboard`). That repo's copy still bundled the `restore-once` ReplicationDestination that this repo split out in `2c7403deb` after the 2026-07 Longhorn incident, so `dynacat-dst` was being recreated by Flux every reconcile and reaped by `volsync-system/restore-cleanup` every night at 03:30 — re-running a full restic restore daily. home-operations#631 fixes that.

## This change

**Pin `VOLSYNC_CACHE_CAPACITY: 2Gi`.** It was never set. The variable feeds both movers, but the component defaults are asymmetric — 2Gi in the `ReplicationSource`, 8Gi in the `ReplicationDestination` — so each nightly recreate provisioned an 8Gi `longhorn-cache` volume to restore a 5Gi source. Pinning 2Gi is a **no-op for the live ReplicationSource**: it has run on the 2Gi default for 83 days against this repository, verified live as `spec.restic.cacheCapacity: 2Gi`, last sync `2026-08-01T14:01:42Z` `Successful`, and a full restore of it completes in 4s. The pin only removes the 8Gi over-provision from any future restore. Same reasoning and same value as crowdsec-ui (#2987) and tsiam (sgc#1739).

**Comment the `components:` list.** It records why no ReplicationDestination is listed, how to add `../kubernetes/components/volsync-restore` for a genuine bootstrap or DR restore, the obligation to remove it once `dynacat-dst` reports a `lastSyncTime`, and — the detail that hid this bug for a month — that these paths resolve inside the *home-operations* repo, not this one, so a `git grep` in either repo finds nothing.

## Verification

- ReplicationSource healthy before touching anything: last sync `2026-08-01T14:01:42Z`, `result: Successful`, next `2026-08-02T14:00:00Z`, restic pruned `2026-07-22`.
- `spec.restic.cacheCapacity` on the live RS is already `2Gi`, so the rendered manifest does not change and no PVC is resized. Cache PVC size is immutable in practice, which is exactly why this had to be confirmed rather than assumed.
- `yamllint` clean via `hk check`; the file parses to the intended `substitute` map.

No behaviour change for the running app.

Refs: david-driscoll/vault#120, david-driscoll/home-operations#631