### PR TITLE
fix(longhorn): reclaim VolSync snapshots and re-enable orphan cleanup (vault#123)

### DIFF
--- a/kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml
@@ -59,7 +59,13 @@ spec:
         annotations:
           snapshot.storage.kubernetes.io/is-default-class: "true"
         driver: driver.longhorn.io
-        deletionPolicy: Retain
+        # Must be Delete. VolSync's restic mover snapshots the source PVC, backs
+        # it up, then deletes the VolumeSnapshot. Under Retain the
+        # VolumeSnapshotContent -- and the Longhorn snapshot behind it -- was
+        # never reclaimed, so every VolSync-protected volume grew one permanent
+        # Longhorn snapshot per day until it hit snapshotMaxCount and deadlocked.
+        # See vault#123.
+        deletionPolicy: Delete
         parameters:
           # needed for successful VolumeSnapshots
           # see: https://github.com/longhorn/longhorn/issues/2534#issuecomment-1010508714

--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -20,7 +20,20 @@ defaultSettings:
   guaranteedInstanceManagerCpu: 5
   nodeDownPoddeletionPolicy: Delete-both-statefulset-and-deployment-pod
   volumeAttachmentRecoveryPolicy: never
-  orphanAutoDeletion: true
+  # Chart key is orphanResourceAutoDeletion (chart 1.12.0) and the value is a
+  # SEMICOLON-separated list of resource types, not a boolean. The old
+  # `orphanAutoDeletion: true` matched no key in the chart, so it was dropped
+  # silently and orphan-resource-auto-deletion has been empty -- nothing was
+  # ever cleaned up. Valid items: `instance` (engine and replica runtime
+  # instances) and `replica-data` (replica data directories on disk).
+  #
+  # Only `instance` is enabled. Every orphan on both clusters is an
+  # engine-instance left behind by the VolSync movers, and those are what drive
+  # the respawn loop on milky-way. `replica-data` deletes actual replica data
+  # directories and has never been active on this estate, so turning it on is a
+  # separate, deliberate decision -- not a side effect of this fix. See vault#123.
+  orphanResourceAutoDeletion: instance
+  orphanResourceAutoDeletionGracePeriod: 300
   replicaAutoBalance: best-effort
   storageMinimalAvailablePercentage: 5
   storageReservedPercentageForDefaultDisk: 10


### PR DESCRIPTION
Storage fixes #1 and #4 from [vault#123](https://github.com/david-driscoll/vault/issues/123), equestria side. Paired with the stargate-command-cluster PR; the two are independent.

**equestria state at time of writing:** 5,730 `VolumeSnapshotContent` objects, all `Retain`, 5,728 of them already dangling. 8 orphaned engine-instances (kerfuffle, hard-hat, shining-armor), 421 Longhorn snapshot CRs. One live ReplicationDestination: `network/crowdsec-ui-dst`, synced 2026-08-02T18:21:52Z. `network/technitium` is `robustness: healthy` but `TooManySnapshots`, backup stalled since 2026-08-01T14:02:19Z.

## What this changes

Fixes **#1** and **#4** from vault#123 only. #2 (`snapshotMaxCount`), #3 (unblocking technitium) and #5 (`guaranteedInstanceManagerCpu`) are deliberately **not** here.

| | File | Change |
|---|---|---|
| **#1** | `kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml` | `longhorn-snapclass` `deletionPolicy: Retain` → `Delete` |
| **#4** | `kubernetes/apps/longhorn-system/longhorn/values.yaml` | `orphanAutoDeletion: true` → `orphanResourceAutoDeletion: instance` (+ explicit grace period) |

## ⚠️ technitium is NOT fixed by this PR

Read this before reading anything else. `network/technitium` **remains deadlocked on both clusters**:

- `TooManySnapshots` still true, `snapshotMaxCount: 5` still hit
- `ReplicationSource network/technitium` still `SyncInProgress`, `lastSyncTime` still **2026-08-01** — **no backup for over 24h, and none until #3 lands**
- SGC's volume is still `robustness: degraded` on **1 of 3 replicas**; if `milky-way` is lost, technitium's data goes with it

Nothing in this PR touches that. The stuck snapshots on those two volumes were created under `Retain` and, as explained below, are **not** retroactively reclaimed. Only #3 clears it. Please don't read these two PRs as having fixed the DNS server.

---

## The precondition I set myself in vault#123

I said #1 "needs a check first that no `ReplicationDestination` restore flow depends on retained content." Doing that check turned out to matter, because there is an automated job in this repo that deletes ReplicationDestinations on a timer.

### What `deletionPolicy` actually governs

It decides what happens to the `VolumeSnapshotContent` and the backing Longhorn snapshot **when a `VolumeSnapshot` is deleted**. It does not cause any deletion that was not already happening. Under `Retain` those VolumeSnapshots were *already* being deleted — we just leaked the storage behind them.

So the only way `Delete` can hurt is if something deletes a VolumeSnapshot that a restore still needs.

### The one place that could happen

`kubernetes/apps/volsync-system/restore-cleanup` runs daily at 03:30 and deletes any `restore-once` ReplicationDestination whose `spec.trigger.manual == status.lastManualSync`, cascading via ownerReferences to its destination snapshot. There is no guard that the *app's* PVC has finished being populated.

The theoretical race: RD reports its restore complete → restore-cleanup fires → RD and its snapshot are deleted → but the VolSync volume-populator has not yet finished binding the app PVC.

**That window is closed by a finalizer.** `snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection` blocks deletion of a VolumeSnapshot while any PVC is provisioning from it, so the CSI delete cannot fire until population completes. I confirmed that finalizer is present right now on the live `network/crowdsec-ui-dst` destination snapshot (the eq#2987 bootstrap that synced at 2026-08-02T18:21:52Z).

*The finalizer's presence is verified. That it reliably holds through the whole population is upstream external-snapshotter behaviour, which I did not independently prove — marked **unverified**, but note it is equally load-bearing under `Retain` today.*

### Once a restore is done, nothing depends on the snapshot

Verified on eq: the `crowdsec-ui` PVC is already `Bound` to its own Longhorn volume. `dataSourceRef` stays on the PVC forever because the field is immutable, but it is a historical record, not a live dependency.

Stronger evidence: the `technitium` PVC still carries `dataSourceRef: technitium-dst`, and **no `technitium-dst` ReplicationDestination exists any more**. It was bootstrapped, the RD was cleaned up, and the PVC has been running fine ever since. Removing a `volsync-restore` component after the app PVC is Bound is already routine here and is unaffected by this change.

**Conclusion: safe to merge, and the open task to remove `crowdsec-ui`'s `volsync-restore` component is safe to proceed with — its PVC is Bound.** The one thing that genuinely changes: deleting an RD now actually frees its destination snapshot instead of orphaning it, so the "recover by hand-rebinding an orphaned VolumeSnapshotContent" escape hatch goes away. No procedure in this repo uses it.

---

## Is `deletionPolicy` mutable in place?

**Yes — in place, no recreation.** Verified by server-side dry-run against the live API (validates, does not persist):

```
kubectl patch volumesnapshotclass longhorn-snapclass -p '{"deletionPolicy":"Delete"}' --dry-run=server
→ Delete
```

Upstream enforces VolumeSnapshotClass immutability in the **snapshot-validation-webhook**, and this install sets `webhook.enabled: false`, so there is no admission check. Helm/Flux will patch the existing object; no delete-and-recreate, no window with the class absent.

And it would not matter even if it did recreate: `deletionPolicy` is a real field on each `VolumeSnapshotContent`, copied from the class **at creation time** and never re-read. Existing contents are untouched by a class change either way.

## What happens to what already exists

**The 26 orphan CRs — predicted to age out, and I now believe that more strongly than when I wrote the issue.** All 26 (8 on eq, 18 on SGC) are `orphanType: engine-instance`, exactly what the `instance` item covers, and `orphan-resource-auto-deletion-grace-period: 300` is already applied. Longhorn deliberately does *not* clean orphans on failed/unknown nodes; every one of these is on a healthy node. **Prediction, not yet observed** — it cannot be observed until Flux reconciles.

**The already-leaked snapshots are NOT cleaned retroactively.** This is the part worth being blunt about, and the leak is far bigger than vault#123 said:

- **Every** `VolumeSnapshotContent` on both clusters carries `deletionPolicy: Retain` — 5,730 on eq, 1,463 on SGC. Of those, **5,728 and 1,462 have no live `VolumeSnapshot` at all**. They are already dangling, and thousands point at Longhorn volumes that no longer exist.
- Changing the class does not rewrite them. They keep `Retain` forever, and this PR reclaims **nothing** that already leaked.
- Clearing them means patching `deletionPolicy` on existing contents, which is bulk mutation of ~7,190 objects and hand-editing storage. **Not in this PR. Wants its own issue and its own review.**

I also corrected a claim from my own issue while checking this. I wrote that older `max=250` volumes "show the same leak at 9-10 snapshots each." The real picture: the *K8s object* leak is 150-220 per volume going back to March, while the *Longhorn snapshot* count sits at 9-10 only because those PVCs have been re-provisioned several times, resetting the chain. On the current generation of each volume the leak is genuinely one snapshot per day and unbounded — e.g. eq `dispatcharr` has 9 user-created snapshots, one per day since 2026-07-25, `markRemoved: false`, ~400 MB each. This PR stops that going forward.

## Why `instance` and not `instance;replica-data`

vault#123 proposed `instance,replica-data`. **That value would have been rejected** and #4 would have shipped as another silent no-op. The separator is a semicolon. Confirmed against the live admission webhook:

```
"instance;replica-data"  → accepted
"replica-data;instance"  → accepted
"instance,replica-data"  → rejected: invalid orphan resource types
"true"                   → rejected: invalid orphan resource types
```

This is the same class of mistake as the original `orphanAutoDeletion` — which is exactly why I checked rather than trusting the issue text.

I narrowed the value to `instance` alone:

- **It fixes 100% of the observed problem.** All 26 orphans are `engine-instance`; there are **zero** `replica-data` orphans on either cluster.
- **It deletes no data.** `replica-data` removes real replica directories from disk. That path has never been active on this estate — the old key was silently dropped, so orphan auto-deletion has been off since install. Turning on a data-deletion path that has never run, inside a PR whose purpose is to quiet a CPU respawn loop, is not a trade I'll make without asking.

`replica-data` is a reasonable follow-up; it should be a deliberate decision, not a side effect.

## Verified vs predicted

**Verified now:**
- Chart 1.12.0 defines `orphanResourceAutoDeletion`; `orphanAutoDeletion` is not a key. The live `longhorn-default-setting` ConfigMap contains no orphan line at all — confirming it was dropped silently.
- `helm template` with the new values renders `orphan-resource-auto-deletion: "instance"` and `orphan-resource-auto-deletion-grace-period: "300"`. Previously it rendered neither.
- `instance` is accepted by the live Longhorn validator; the comma form is not.
- The rendered `VolumeSnapshotClass` is `deletionPolicy: Delete`, `driver.longhorn.io`, `type: snap`.
- `deletionPolicy` is patchable in place on both the class and existing contents.
- All 26 orphans are `engine-instance` on healthy nodes; zero `replica-data`.
- `crowdsec-ui` PVC is `Bound`; its destination snapshot still holds the as-source-protection finalizer.
- technitium is still deadlocked on both clusters (state quoted above).

**Predicted, not yet observable — these need a post-merge check:**
- A VolSync sync completes and leaves no residual Longhorn snapshot.
- `orphan-resource-auto-deletion` becomes non-empty and orphan count trends to zero.
- The `signal: killed` respawn loop quiets on `milky-way`.

On that last one: the milky-way saturation alerts have since cleared, so the alert is no longer a usable signal. Judge #4 by **orphan count** and by the `signal: killed` lines in the instance-manager logs, not by alerts.

## Merge order

**These two PRs are independent of each other and of the two changes within them.** Merge in either order, or one cluster only.

- #1 and #4 touch different HelmReleases (`snapshot-controller` in `kube-system`, `longhorn` in `longhorn-system`) with no shared state.
- Neither depends on the other cluster.
- No conflict with eq#2994 / sgc#1746 (volsync `AGENTS.md` docs — different files), eq#2807 / sgc#1267 (cross-repo sync), or HO#513/#512.

## Also found while checking (not fixed here)

Three more `defaultSettings` keys in `values.yaml` are **also** silently dropped by chart 1.12.0 — same failure mode as `orphanAutoDeletion`, confirmed absent from the live ConfigMap:

- `guaranteedInstanceManagerCpu` → chart key is `guaranteedInstanceManagerCPU` and takes a per-engine map like `{"v1":"12","v2":"12"}`, not `5`. **This weakens a claim in vault#123**: I attributed the ~474m instance-manager request to this setting, but the setting has never been applied — the observed value is the chart default. #5 needs rethinking on that basis.
- `nodeDownPoddeletionPolicy` → should be `nodeDownPodDeletionPolicy` (capital D).
- `volumeAttachmentRecoveryPolicy` → no longer a key in 1.12.0.

Left alone deliberately; they are node-resource and pod-lifecycle behaviour, not mine to change unilaterally, and each is a real behaviour change once it starts applying.

<!-- crew:agent=seraph -->
