### PR TITLE
feat(itsaplan): migrate the upstream compose stack to app-template

### DIFF
--- a/kubernetes/apps/database/postgres/app/passwords.sops.yaml
+++ b/kubernetes/apps/database/postgres/app/passwords.sops.yaml
@@ -6,45 +6,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:SMklSyf3mgU=,iv:ZAFx01unyhJ48NIJrkI6xfJDHLz/Kb6/DH/c+kS+d0M=,tag:VY7NhVp6561tGZXXGolxMQ==,type:str]
-  database: ENC[AES256_GCM,data:tsGRSMkJlTE=,iv:FazOBeGsminCoItw2bd55KAUcsVnfA2tgoPECO2K4Mo=,tag:P98nM0Hz12iZUd2rNWuo6Q==,type:str]
-  port: ENC[AES256_GCM,data:4O638A==,iv:Q0FjCrnLnvQwG7rOybL5LvqJavBXTevzq8UMHmVnKX0=,tag:iVm8NHOE15D/DIYJBcUITg==,type:str]
-  hostname: ENC[AES256_GCM,data:chaF8DX+b/wUW75lluyq+cRVlwC98EujcxJLJECVNqyFfV+paOw=,iv:4i5pdteFYMqDJwjtI4OaP448tn90xCxXSrO13XWHrQI=,tag:wKIrIR9XphS3Qmxty3zT4A==,type:str]
-  password: ENC[AES256_GCM,data:urH3HkwB+Mh+rQ4+mXsbQMeZuYFdt6zVqHlSIJI4TDs=,iv:1gzjWC5nCTJuwPA3zlpbrHLxDwYwb0+XIcwnUV7V5DY=,tag:S+qmC+XyVyY8Ed3PdynVEw==,type:str]
+  username: ENC[AES256_GCM,data:AepmH/wEHz0=,iv:Nkq7xq2boFfy2S1vaTaVOt7MvN1YIODI7231GDY/w0A=,tag:wTrD4P5g37WopvoXKjmU8Q==,type:str]
+  database: ENC[AES256_GCM,data:LLEQTZOiED0=,iv:zekHT49AvnG6YT1XusJtZAu/B4w7saKNUBtPm/Dusiw=,tag:lGJLYOkAhurhg0wYVHJtHQ==,type:str]
+  port: ENC[AES256_GCM,data:go+rZQ==,iv:tfBiGO+nPX+2HaT+z0ZUcjYKTjS0EAdVAYbDQwPxM0k=,tag:Ii3yRzeB2VQepdohyy7Ekw==,type:str]
+  hostname: ENC[AES256_GCM,data:1HPD1f0DpYhfrlUFc231+YFGekpD3oKojOFZjoSRut5O/Foo8mE=,iv:MGKpj3d5xxaBzSOGNLrp87HChvzgTq+oTgT7UswOgoQ=,tag:3ubYbkghfw6NcqWt3TaAuA==,type:str]
+  password: ENC[AES256_GCM,data:jPKjZ4dXCU9qFBFfhCWkyObmR2EsjvcdOUzod0QpHi8=,iv:Sp9NNhBlKfWPlAQt8w74Xe7IS6dzOJW6WhhAU+DUIx0=,tag:craihb3mdykRO0N8yd0gog==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -54,45 +54,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:dJtIQsJ11g==,iv:Qahgux33pZzfRn7ps8hsi39wTi7o2T7yiGlwf6uPGew=,tag:Uq0PPZojT9r/iGgYdDOKHA==,type:str]
-  database: ENC[AES256_GCM,data:V2FG3Jgq5g==,iv:Wl2BHnv45c580rEYYHUJcQRPqTy2NePzJBbL2/oLJLg=,tag:K22WZveHrwVjZkCAV5FOHw==,type:str]
-  port: ENC[AES256_GCM,data:5+Yy0w==,iv:hx7YR2WIqy1TeuGGDYNbBj6W/0P6TVjV+jBVfFvBi8E=,tag:yhgRqvF0CxsYSG5ADxrdlg==,type:str]
-  hostname: ENC[AES256_GCM,data:TJXQ1J0FYGrWc7dN/XuhgPLDj54HlT/ssvuOZWtvxoZhDyomqnU=,iv:V20r/vcgo0GLFVRMu1ViKjE4Wq/PjQPqqM3akrlcEDE=,tag:c3e1xG7e129vlUYaXOC7iw==,type:str]
-  password: ENC[AES256_GCM,data:/hjBTEhopFbEWG7ZQT7jxzjS52EAbkUhe3NXS3WEVDw=,iv:no1nl9HdFrOC9ZstEVvC9+3zQ9/QASjG6B6xX7n9t7U=,tag:P/Bdkqz8PtbJKXqcnpo/Lw==,type:str]
+  username: ENC[AES256_GCM,data:HvZfGWxLrg==,iv:VmYt6FiXR/evWvHUDye/Yx2yES2Ff/VrnJCwZuWeYJA=,tag:nNQPE8/ek21xb4Zn4p0ehQ==,type:str]
+  database: ENC[AES256_GCM,data:bU/dL58lfQ==,iv:UiFZPYCP0arfL5q5VyDc306SBZf2wPCB0JnL9IO3OPA=,tag:UAyD6y5JzX1lWdYhaR9o/g==,type:str]
+  port: ENC[AES256_GCM,data:HeDPsg==,iv:G6uDAB9AHEUjZK0MPAVzztBoxQ9xvmFWqfBxiUx8AlQ=,tag:inZXzMEEHtZ3vWugD8wL1w==,type:str]
+  hostname: ENC[AES256_GCM,data:hveLPc5I9iaYml9n3gLNyb+S1dKMh3zyQUnFxOVcaBOmxf6dTSc=,iv:Ifqmx3/s0ZZJqek/caBhsrKBnC+WOqgmWEF6l/g43CU=,tag:xlfsDVmt0KP6Cw6aEa2sIw==,type:str]
+  password: ENC[AES256_GCM,data:rmHzYMvhrZCmr5P425xV6q76nfLq4r0UDccZqC+tWJA=,iv:X1NYmButOwM1ggbLNkabtcI0H3v1bpgEjX3/l2SWHU8=,tag:q4F0/wek3gdPEOHim7AWmw==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -102,45 +102,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:afWPNIwGyQ==,iv:qLGix6+0v3IrwEx2StUkrz7UDeYe+9HBbYrdsVa7Wyk=,tag:jQ/O0Ho6N9XEXDejz6F4qw==,type:str]
-  database: ENC[AES256_GCM,data:lwNesFWOHw==,iv:Tsm+0wsaz/lyAUlpa8vER766m4FPQ/JOsp3memFBjYI=,tag:vzSQU3zbXLx1JeT4TvdeDw==,type:str]
-  port: ENC[AES256_GCM,data:f/3kJQ==,iv:uXiSUnfh1ckvIah/9EAQ22CL5NedKwj1I56hZUvnsW8=,tag:clR0BJgZDiVUVJAfCvrEDQ==,type:str]
-  hostname: ENC[AES256_GCM,data:yTXFAsh2DTm5xs6d/CsXzquACn6+gw1X6/o2qnNcvA2GARUjBMo=,iv:TXyqRUHWd3F1CH1uw/6HYaarLL1OUicK2Q9YcyDAjZ8=,tag:F+3yPT05FR4MSMyH6qu8KA==,type:str]
-  password: ENC[AES256_GCM,data:D7uLo6ocWl79belvkPDEAIsST9cpEEGq8Qk47gEn1qk=,iv:7KN5HRNo4lXKalouVsgbm4f8zGbBE078W/QvPrAOI5w=,tag:DtCnny9WE5LMd96U6j0reg==,type:str]
+  username: ENC[AES256_GCM,data:hnrThl12uA==,iv:Jf10RcJZcXyMVX+/SB6EZ+wJsSdA/sMqvMD/AY49tn0=,tag:GJd/NYbF5Ym54RasCdjmDg==,type:str]
+  database: ENC[AES256_GCM,data:G0hFOaMeOw==,iv:+9tKku+1A5BCS0UnltZBSAExVKz4XFSOsGiF9onNjZA=,tag:VTOuf/1naEPF0L2kcUMv0A==,type:str]
+  port: ENC[AES256_GCM,data:U43GBA==,iv:Br3pPiWGD9/XbDnXMDEpEdIobbX5/YhAZ+7Lqggsi38=,tag:nCtGuLmB1KdIbDItIc/F4A==,type:str]
+  hostname: ENC[AES256_GCM,data:pYqkCsxk5OuMgS4LRpHOlRcucjZxeY4hRrr+58/iAj38jXCUVvQ=,iv:6Unngxv2ZfOJc+/4n1hXaddJPBTb3G/gobiX8xS3n9U=,tag:y7jME2tIeGOYBT+modWnZQ==,type:str]
+  password: ENC[AES256_GCM,data:Z3OwZINrZZ+Wpw6hd28efLWjYOcQHxiS5YivX6GKJdk=,iv:DQdG68VfTZ8FSWwO6fdVh1HxYIXsCTpFruAuv2wrppk=,tag:mz8h0zw6kZWXSYnZUsDRLQ==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -150,45 +150,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:6h6c2S+o,iv:tUbtXynfKPiODOfVarRhegmeqPNOo04lRBffNEwUcj0=,tag:RXNi166y8RJcZ7hIQ5QL4A==,type:str]
-  database: ENC[AES256_GCM,data:pynmIuKz,iv:mX3Txenz26AGTPz+oGCdvUUidkFtis+BO05IkYzPcpc=,tag:gLQQrBib4Axu+UmNdl1pMg==,type:str]
-  port: ENC[AES256_GCM,data:B7qnQg==,iv:wH9p0M2JcWYiCjY5gJ3flNMTKhnbpjMcrZuwPDCCswo=,tag:zlIk8ISaRQQxIQLfeWH0Wg==,type:str]
-  hostname: ENC[AES256_GCM,data:PyQ+M1LWLMblAyRLGef4MrBmWa0SEP0dk6bcvahdZWTjrNjsVCQ=,iv:6HMmiC/xp/f4xrc+L+TeXJI7Db+oMNQEDglS4E+GcgI=,tag:fcJGsbVpboVQwVFAore18w==,type:str]
-  password: ENC[AES256_GCM,data:KNafhcMRBzSLsRuSvFJgOgzDtGtLoam99LDX5WRM64c=,iv:xhd+fc9RF2vN5h8Bg7ZqRkFZqDKSs03V1wBsnEpmKd0=,tag:wacKQpY2xCNlYNzNz07YUQ==,type:str]
+  username: ENC[AES256_GCM,data:Hw7LtUB6,iv:GUBGxdNSgzM8Z+Nmm6L+KSFfvxZ9N+1wZ5NWUsfHYc0=,tag:sYmrcuBzy1X56HGDPimQPA==,type:str]
+  database: ENC[AES256_GCM,data:BCcPhuWF,iv:Q7ff9AbBbDqtR0INuFwQaj+t4DSlyVB5VkdFk626ax0=,tag:CWPgFNgmLVqDQmVha/SXug==,type:str]
+  port: ENC[AES256_GCM,data:C00R+g==,iv:F2wv4b3o+8K37Me6ec0mww9wiVA6npZl9wVQf5DzZ3U=,tag:LtLlrm+GZVhb1RnWZ+WkwA==,type:str]
+  hostname: ENC[AES256_GCM,data:vNT45vHOmNbxwIvqUZS61REsgyNsMYmVgl+YAz/yG6CfWi2VuTM=,iv:GHNKiXpcQUdCwNYKmIt+kPma1TEQwP4BZQfPS/Ifxx0=,tag:Aq29/p43Kg3Gas69Meuk2A==,type:str]
+  password: ENC[AES256_GCM,data:Qs9ulMKcqoa9OaktrI4gGJWO9hQH6cGJvii0wteF5ZI=,iv:rD4IRNyJUxwg7iLu3OuwmbRpB+HnqWwcMbcJf8UVhNk=,tag:DgStyTQmVgZDs0XYU7bIYA==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -198,45 +198,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:hvg6F+EkPw==,iv:K1OC75IGZkoCogISPmQ5LViYZahSP7W4vQo5YW3+Jv8=,tag:HTH5eSM711e43IwLJG7I1g==,type:str]
-  database: ENC[AES256_GCM,data:z0ANI4Mlvw==,iv:ttMHhBe40Q5seRDLdQnHefV6hx2eXuUXVNi0H5sqzFw=,tag:i8XD7Y0I/EJXdqN9MCdEjQ==,type:str]
-  port: ENC[AES256_GCM,data:Gl40vw==,iv:OjGQctfuYZROIAFVcPibyBWSigqar3jH8gI8iKWqtwM=,tag:aS463uXVLcD9g53qF2ci8w==,type:str]
-  hostname: ENC[AES256_GCM,data:cb7cxUGkDiU4l5SaTiqmSAdk1cwPZG5KBfGJ1oXQucSfRRqBYX0=,iv:OPUZuf9W+t9sMp/jW9opjaQMv+FUvAxSFm46TTMFai8=,tag:xAR6Ok+sIn0TcTLpbBdpHw==,type:str]
-  password: ENC[AES256_GCM,data:/+Mt489Kh2UfDaj1npbLhNbHniCZA6m5gJRHb7zGzPs=,iv:ohB8GpF/slPRbZ2Ow7akRaMrYzQPO2q4IZhrDIxPZfA=,tag:/r1VuGDlpjlyObOInyP+Ow==,type:str]
+  username: ENC[AES256_GCM,data:JfFiuyI2KQ==,iv:ykybLUrrIMAz2kgx9hamSt4CsWhKvBkPqA9ZRUnNBjQ=,tag:cAtE9Xtw2QqXlDPydZr/0A==,type:str]
+  database: ENC[AES256_GCM,data:PchTad2QBA==,iv:e4DLkSCf0qdaTm6Gkyy6JdNrPrNvTtoipZegcToDcYA=,tag:opvzS23W1niC18eeTAyoVg==,type:str]
+  port: ENC[AES256_GCM,data:EHhf1A==,iv:VV/hOfftA8InsWrcw97mU8WjXNXCIuNR9fi/gM4FPxc=,tag:Pd0b+Nc9Ry5G06cD45txdg==,type:str]
+  hostname: ENC[AES256_GCM,data:oeBfBjxsKnZL4YLF2etoChH+upYamribDnUPX/dRC+vfVqApzgk=,iv:tQ3fmzFDhvaTvk5ftcWT3+QUM40+9o9jMr5MEXcHkdQ=,tag:9N54bddjODqepZwqIxvzPg==,type:str]
+  password: ENC[AES256_GCM,data:gaiaDrjoehUeCriCdvbehcGiH5ReXYtXapMJtNQc1ck=,iv:xHUhQYZ72pNNhOUl/DGVlwWDWand+dpSx0aGCwZPJIM=,tag:sMjlEE/aHP3oKljzDbAx2g==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -246,45 +246,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:UmMsarIH+0w=,iv:IZnfWiLdnvr1auet248rIYHjyXk4+HVrRQVr88gJd8g=,tag:C93K5mosbuNBYfl65DAgZA==,type:str]
-  database: ENC[AES256_GCM,data:9QYZ5IDqzLw=,iv:waqGCaLhM3cKgp1kBXV8PRivHRUEhL7pT/GdDWhg6LM=,tag:VfC+Du+M37eMkmI/NB+Iqw==,type:str]
-  port: ENC[AES256_GCM,data:Ym8sTQ==,iv:30099XqTeSNA0XDtxqNRB1JEZDz4sxYMqaYskT1NWqA=,tag:HlYTFRQq0QkSMzf+r3S7Ug==,type:str]
-  hostname: ENC[AES256_GCM,data:0AhBFYMo6+ZnyJZ/mzt7JG8ZKqp2SZIygHyBch7O8G1e5yC6YSI=,iv:yKJeiKP5HoP01Fy78ySDdpsCkob13jPYSgGj1etX/40=,tag:GSy9UQ3bAao+hxywySthHw==,type:str]
-  password: ENC[AES256_GCM,data:LzxnimQbnG5f6BMZlT780L/1gG/Nb3bsY/pk/Hxhhw0=,iv:eruSjJ21FyRgXcx/JKt+MD1+XkjauBNlVDj8CZyq2LI=,tag:bDxQF8i0ERZY9DCEXmGCwg==,type:str]
+  username: ENC[AES256_GCM,data:G9RDkiy95CE=,iv:2G7AagBQ0hZ5JrvVoMGjL+1IthUl03nsOqoyWgSzsAA=,tag:5l1ablw3XIXIr1RgMrltig==,type:str]
+  database: ENC[AES256_GCM,data:sYwzVFVa2C0=,iv:jhf9Yu+hKGftB6rGEdnW2ObnsIB40WfoC/QvUSKuzZ4=,tag:s9LlGEnLqyD8NPHMyxda3Q==,type:str]
+  port: ENC[AES256_GCM,data:ejtVDQ==,iv:MVHxBzzkRrQ5XjURMAiOshvSPht9ZCX1yPUlLgXQVU0=,tag:lP+zOcZBWHmNndQwMX/dWg==,type:str]
+  hostname: ENC[AES256_GCM,data:fVqOna8k57vwv7d1I8c3a6s6IIqSGQ/nmIWKwu5+4h8OP+QyZa0=,iv:1HNPyEW/OMXKTUyc0jh/mZYGaiPtIiJ1L6ZRxeeUIAk=,tag:1113TkOpwTK007MB7hy1tg==,type:str]
+  password: ENC[AES256_GCM,data:65Ft2Sqg1CUSqioS1K3vTvHzpHaR+Q7/ZCG+kgXCwfM=,iv:6FYBcHQytqXnLVbmT1UQ8PvXJpdGtwAqnqRJRI0n0LI=,tag:Qogy+hvI4/0kGM9j9c7tFw==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -294,45 +294,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:lvfdwBhAvZ8=,iv:7JYVAVawoZk4bBwOTIkairPPQnuW/K+4MX5oCgn+NBQ=,tag:FhS4lGqs1D3t/4NFNaCjXA==,type:str]
-  database: ENC[AES256_GCM,data:h72Eu9O1IaI=,iv:TXWnnnAmB7iswVYCzdk9YfKepfGGX0xXQ8kzFhwxPDQ=,tag:JP6/aOvhL19ot6B0cYyzng==,type:str]
-  port: ENC[AES256_GCM,data:ACE3Dg==,iv:S1lZWb38rA+0MJKVk5gYSKPdNveqcT3MxseQnDGef9Q=,tag:GPh1WasUAXM3JzkhrBIhHg==,type:str]
-  hostname: ENC[AES256_GCM,data:xoSxi5qGg9a667J+cjYf4s642x5y77mCYNA/NL4vIsFG12+mpqo=,iv:hrJi7MWNslo2IvJCLKN6BO3YyhQ46c/Dsp3LfLp1gIo=,tag:XFyhUh45LWCgDqlwJ4d7hQ==,type:str]
-  password: ENC[AES256_GCM,data:a3VIy70ou6HYqhS1GbGRw6HDFqRavnd2KSXP+k31BEo=,iv:U755K8TEFsK0Hy6bD937rYGwmp8eYx1txhmhYIrI1U0=,tag:SyLJKRFzl8jQ23XkhlfVOQ==,type:str]
+  username: ENC[AES256_GCM,data:rcrOg3tY4oI=,iv:b5juBVPn0bSZap80W8FTxHER8BC8thBi9NJiShnSgAU=,tag:7z9sdlRDW1nrLOR0k5arKg==,type:str]
+  database: ENC[AES256_GCM,data:INBh+XFDnOM=,iv:C52Z4ZTE7G0lK8oqLMDiqTe+rnn6+MDyNlW7ZxzlOMc=,tag:yG8+zKbpAE887MYe+O0ZVA==,type:str]
+  port: ENC[AES256_GCM,data:vQtDaw==,iv:VVeN7wl/gNydopDzy+iSoCN8HqtauXMZcvaBrDL4MK8=,tag:C4M0uWbo6xoGf0t4hwaaxg==,type:str]
+  hostname: ENC[AES256_GCM,data:TFPsOMAvA4emXUjYhpd0joeRe2zrEuDPh+Gt3oTJYJ0wCgZLVa4=,iv:4+tx3tESKNU66wM/kqyKcM2Hoe9vnL+5xa5HRZYjFdo=,tag:lJlq8hFF4Ccp2PgG3/WMtA==,type:str]
+  password: ENC[AES256_GCM,data:fvRfdFR5dMloWhFEWvA3rhp2mjzIe7lJisiP+5ygeyM=,iv:DspVJDxNkHHh6/hNe8IA4dyHtcq8WNB1BCF0gWcK/Qc=,tag:DwbFNCmcxZ/F0d/CziBJsQ==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -342,45 +342,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:p2ds,iv:LNpbBo5GYS8synUMudZarJlsawL6JF1N7AyQWlPfx5Y=,tag:fdYPFCyrHNWXo5WN46NZlA==,type:str]
-  database: ENC[AES256_GCM,data:iglt,iv:sjVgI10yvtsj9lwZz9sHRUfmg2u7LiHEFN20ebJMq5A=,tag:mvZDVCLWHB8bguRivvDibQ==,type:str]
-  port: ENC[AES256_GCM,data:nTA6zg==,iv:pk6bCiGcHT1Ia3UTLTaMCsFeeQGBJkmLn00L5qu3ydc=,tag:X1xnAdP8xc0ABKkSHysgAQ==,type:str]
-  hostname: ENC[AES256_GCM,data:pECiSKreHaDNTJh080FIF5p/taNn24tsL0XKdPVnQeakiAntjgw=,iv:n4Dfj0KELcXpleJtFqoRpcqrCyvH9ryVdXzQwkw1k4s=,tag:100SDTSpf+qznOBKVWQKKw==,type:str]
-  password: ENC[AES256_GCM,data:9P7ulajkVWDm8e9GYIGMI5T5x7aSk8z7JT/VdRLGVo0=,iv:Er2UFetmfGMtMvVkyIR+uK7K9xVZ4/LdWidkU/rQ2t0=,tag:tRish5Tmb8XYndkQsYMfog==,type:str]
+  username: ENC[AES256_GCM,data:il4x,iv:gbnUaGMgjFPPgQJvop1Csm7LUmAU2/oJ/hAbX3FTyAQ=,tag:KnPl9SzblZ0/AplLLqF22g==,type:str]
+  database: ENC[AES256_GCM,data:KbSt,iv:aci6qe04XM9TufuxEmP7IlnDT14bkDO6ddso53wj4vQ=,tag:PByuZsSs96pmCcTG8avgrw==,type:str]
+  port: ENC[AES256_GCM,data:adK4Fw==,iv:F/H6ypPZAGmWK3g36jLkkIzoFld/7DWbTwyrdbGAJpM=,tag:IADaaJf5sD88GoZP81HHcw==,type:str]
+  hostname: ENC[AES256_GCM,data:UYgXynD/AuvH9XwBwFTZNYQDAyMntOpe3Txrf0Su8cenaCPvmMA=,iv:G9denmJyvLTOqu6GYqIq/63E9TVzceliubZ9VT8CjbQ=,tag:O03xK4pTz/HroKcxjvGPgA==,type:str]
+  password: ENC[AES256_GCM,data:SxpgPNfwejOYPrMBDqr0HU++bebiidg9NEjudhDgQwM=,iv:87pibjl9CNwgHfb84yhhDA5IMVJHQH1zQh6PsnQ+tOU=,tag:ztOvDYVATnWSSLLxxnYsng==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -390,45 +390,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:LQZ91NKREA==,iv:lpC1hMFXYo7PwXuSN22+uSkXKmziBXOGja7gOInJlSs=,tag:eXdCm172tZrsRHrUMmjzcg==,type:str]
-  database: ENC[AES256_GCM,data:EOy1V0MljA==,iv:8URqc3jl/28xeln5SN1H1BI8DnF8YFtBoYUt466L/9s=,tag:4GaER9TqzdfN1AjUbZ5mcQ==,type:str]
-  port: ENC[AES256_GCM,data:7MoSWA==,iv:Btnep7upyD0F13VbuPxxw2KTrVEMjaUWIbehtbZ5H9Y=,tag:T8e3MJcyjNAptmp14ldy+g==,type:str]
-  hostname: ENC[AES256_GCM,data:47zIEAI1N7iRp4QGO3qsH6f9OnhxqSt5oO8GrgrTQcrOBU/bIww=,iv:nFZZY3QOuFCS6uI4GoRuR86BelmJcpkdTytHkskLC9M=,tag:ugwHE1hdVqv9Z0b6R4fzdA==,type:str]
-  password: ENC[AES256_GCM,data:YZyIXqfly1ptz8oTSuiZTgHpDjnDEjXIjrQ8gE4/khI=,iv:2o/EWYctBOzbYBMdslB6+13Puea+oRYNGsQu84g8PdY=,tag:D8Wk7KYmgDm3fiEBiJ9hpw==,type:str]
+  username: ENC[AES256_GCM,data:kxKNq2OpEA==,iv:7aK+v5grTnQMIoZMyr3ugm54sv806mw/mQ6GSA0fUMM=,tag:VHsyEe2FMvEYZQhG817ajg==,type:str]
+  database: ENC[AES256_GCM,data:rF5rkLDV5A==,iv:5Hu9YUvnz/ylVNrvMkcEK9h1Y/DFQIsCUTEKVdzsjA0=,tag:9h6H6GKMmVsMRYuvbylxlQ==,type:str]
+  port: ENC[AES256_GCM,data:lqv36g==,iv:kH2bK7f8dPjyyHZtlOxDSPppXYVMLG1LUAPetm/oRUI=,tag:HQ/vEtgKhlXf67ZzvIa6oQ==,type:str]
+  hostname: ENC[AES256_GCM,data:Nfed+gLQRt+E2vr/VsTXA6su8i5a78LVI1U6IDdHcHaX4vIQGMY=,iv:aQwwn9dZ3IUDEOKAK6Jawjja+Mskwofc3fFTe0U2Je8=,tag:72i3dm3RiRRAEavFZrNAhw==,type:str]
+  password: ENC[AES256_GCM,data:L8sdrdri+flb8woZgcLQ0IhXg2GfLIt3aRq2YZKyjac=,iv:Iphqazs83dfT6k0ObGakPmec5p1CRLXB17iLBJQT2iY=,tag:inWtsnvtqPMfejnime0Amg==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -438,45 +438,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:CmEDgr9ILw==,iv:BtUrkxJtRPQ3Tj8PLSGr7Ocw7StyTVisNIArhqZaEqA=,tag:FVeUKVh3OKUnE4KuurXKWw==,type:str]
-  database: ENC[AES256_GCM,data:Q53bPmlwCQ==,iv:LlAFCqntcFK0yN1D+7oVv9JfUajLSJTf2SXLXpZK42U=,tag:nFXqU48bZxIcDO88/Glb0g==,type:str]
-  port: ENC[AES256_GCM,data:4MJhjg==,iv:QtSmPm/TFqBWyxQyVgPpjCmapNFm5M2ZV+LLIQYT8wA=,tag:XZbouTid3sVMjI41+bKxwg==,type:str]
-  hostname: ENC[AES256_GCM,data:K28LqRsxSYx6ETU1jHxDr/HGXi/nx/59jU071/eCXZofYtmQhGU=,iv:yf7BNdUtnU3OvDTBo/Nt5+uRxmN5JAWMw1O+8bImav4=,tag:TUcRVa/eOHok+VRyyrgdaA==,type:str]
-  password: ENC[AES256_GCM,data:OWfh1fbrkECyNb7ff/kO4PWNJauRNNF0Jyk5pkIe1bI=,iv:6FV2vniDfl3JsWGDkC/CCpHvFD/3WJRxgOmUcbmZWo4=,tag:2UXNGA76gnbDIexia9M7fg==,type:str]
+  username: ENC[AES256_GCM,data:o8IpW1MJJA==,iv:ErnNYE4v7Tmt4Qtx9cdpkJY+3TeTC+NJg7abNaElTJo=,tag:2rXsaLv0fKegn63W7hjJkQ==,type:str]
+  database: ENC[AES256_GCM,data:Ebk++eMSrg==,iv:6jBVp8Dx/6Ceh4GKPpVy0QH6tlxyZ/+X9++dc8YSc+s=,tag:WKkRdhkBPGfF+YZ+kz7shQ==,type:str]
+  port: ENC[AES256_GCM,data:9X9fCw==,iv:RDYdEJyNQFj9RC8cd2LZWO8+P1yMSFE58fR5a1AoajI=,tag:p3PaDU30x6oFT4Qp+cOacA==,type:str]
+  hostname: ENC[AES256_GCM,data:eXSNLxfOwFct5QZA5BXScRHjc2zp/QnVhpCdWExL9WQ3bKLJcbA=,iv:tTnUVXVoYX4XLUzaW2L9JrJeXrBFhOZyYohte1C6wNs=,tag:uK7jpDj2m6u+UrH3D76qtg==,type:str]
+  password: ENC[AES256_GCM,data:BxZF/2rGZOc9RDJSIXVFI9YXBu09ckvb+P2G1wTYyPo=,iv:yQ9iWW4bbAZfXXOjFt7rodVQFEeHcIHQ5T2FxPQZl2Y=,tag:rT7/YFl6Wdc2z8E/U9QbXA==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -486,45 +486,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:U3gqPTmjDC0=,iv:LZaBLAehUazGIpXtDA3zX3X7MnirZADzOTjc3UBXpRE=,tag:LImwfTKnxFRzqojCtF2gKg==,type:str]
-  database: ENC[AES256_GCM,data:CFI/s9xjyQw=,iv:7oKzo8ObzuEzbZdcx4VVDkxZ96UTN+tFskFTFHqI/IQ=,tag:RQlYOBHJaLUmRREXZz3HWw==,type:str]
-  port: ENC[AES256_GCM,data:Isu/5w==,iv:z3qfXeRS75gRdiGD4bixLZNyOMQvCjiDDADXmxNg1Mk=,tag:m7jGgoKcf/F5g0YN1Bxbfg==,type:str]
-  hostname: ENC[AES256_GCM,data:4uT3JVByNIOhrRrWixpVQKHgEYwihV1bE8N83b4e1egaWpptqck=,iv:7z96BzLkN1Cy0XZ2QtPhZUf1PrziTRhw8kZJ1Tt97Hk=,tag:3hOAkoPg7z3k78aRcG6p0w==,type:str]
-  password: ENC[AES256_GCM,data:cyKMtsXwHnymcrhaGkOIoCphyPhpSrvfB8MjALQWXNY=,iv:bd4eBDb89FrF764EzvxG+v9e2oLDPhyJrunFZ0K3avo=,tag:IpSrKgQh+RsnYaqKx5Vc2Q==,type:str]
+  username: ENC[AES256_GCM,data:vcj/MVhiMUY=,iv:idiALjgb7J5642D7zy7TcILHGHSpZJPhx5MTASl6T28=,tag:vUFB5nSM24TtGYLoUYCEKw==,type:str]
+  database: ENC[AES256_GCM,data:8C9E198KDn4=,iv:eAJylPKvzXS0ZPuo4T8I8xu/kq932QGlclwGFmJFMMY=,tag:UoZgi5eVpbwW/Vk+VKT1uw==,type:str]
+  port: ENC[AES256_GCM,data:EhJ0yg==,iv:dqsIuD27CZw49kHabnJUg4blCVsxoQ01OW15OAV7czw=,tag:uZlJGu/Tx9EBDvgHqKkM0g==,type:str]
+  hostname: ENC[AES256_GCM,data:gwX3H8GvmIy2Fa5EkcCa+yL27W2esIzWxdSMBdyWJ6VoRZw537g=,iv:Ob6QkzAygJ6ZXx+ZYrvp/7maiorRHp+Y8y4yAmdjkvM=,tag:VzioHmIaT5IShYWgxCLlDw==,type:str]
+  password: ENC[AES256_GCM,data:OyrQIw9XKAEQrmSJh8aCu59Ue858H+84ZsnUCE6/R0A=,iv:B6XgR6A7wgRK89EL+ZsUmGUeyyObsdkIBEMKMkSTgNE=,tag:4YIEhDYKHolSPonPE5DE0g==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -534,45 +534,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:XW/gNqeV,iv:WwI+4H7m549lt6l2Nf9hl4sTBe9Xg3mSWAzxWX/HKH0=,tag:jtKa8xLCBXSQge2y/yDnnA==,type:str]
-  database: ENC[AES256_GCM,data:NTC4meQq,iv:G+XKDGlA5186FLNx068sFT2SamCx15Fq5XEZfdjXN74=,tag:lIhS7rA7ts+SlvXuF6v39A==,type:str]
-  port: ENC[AES256_GCM,data:bdY69A==,iv:om2yNxLUwVto6DFuJz6e5HkWdjQGpPcBoKElZhN0a1w=,tag:9a3zZAQF+eD/AhkVuFf8jQ==,type:str]
-  hostname: ENC[AES256_GCM,data:ZLVE7GkrsfC0ZTa1MWDas4QHIcgTdy8LADvz2s/l82Kg/TY2vBU=,iv:cEZFEkuddCp8yETZkrLGFEIU7OqjWko5Q0/H+KRnNhs=,tag:E9iCQWFqn/Ez86MvVijH6g==,type:str]
-  password: ENC[AES256_GCM,data:t6lqqIqUXtv1ze7msWkvdifwwH+a0cUs3nXRt9m1acg=,iv:WbL3PkT2vQlAzTRM6U6upPdHljhL0oFk+dlrbON5k7k=,tag:ih5la/pxw9JbvbPhjORJvg==,type:str]
+  username: ENC[AES256_GCM,data:PAJ1F47V,iv:ridIH63EIN9QUsLVswBuGaR3MJx3FBPfoT2Aed19xIw=,tag:XXr0CSVzcplYu4n1BPBfUg==,type:str]
+  database: ENC[AES256_GCM,data:4/ZlUE7O,iv:e5sQNkcY+A2fEQ23xblMYWjnm7AJY+2WyVJ/ZqBR8TQ=,tag:351/oD9ifYr/YOHqtE+Edg==,type:str]
+  port: ENC[AES256_GCM,data:U+uVeg==,iv:qQPIlvgcR1TIvCR9O4Eo1SD5T5UuNVpyaDy8ijzekcs=,tag:6rSsLL6/NQhWu/3gY7eIgg==,type:str]
+  hostname: ENC[AES256_GCM,data:Ct1cfshPjBjkro0u7hvayuLsgL1TS6WRzfXMO1u1wEkW4VMwCVU=,iv:IvNsYiabrS+Vza8UHWwbdYoYZg00XgRoLTzmu0x4224=,tag:DNwg6tijWbgT0Gst4lgraA==,type:str]
+  password: ENC[AES256_GCM,data:7Pvq/DGNhObCms3c4XgEE0iWILF71dQ6058/s8p2zWg=,iv:5pmg7ciYg3uO0Kzrw5uMb1jEHTlX9XMOm9Y9kdoJrPU=,tag:B/q6HcI3de5Oin3079z6JQ==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -582,45 +582,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:7Nqa4rBH+dA=,iv:WZnsVyJHps5pE+2cBNZRCyxoGeqJoGWP7kuQnTeyFxo=,tag:JjA1xzO/TC44PS40flBLow==,type:str]
-  database: ENC[AES256_GCM,data:P6aKZNvJM4E=,iv:xsn4zQeEev8KdcKqJyl1NyyohxgatAQ0nxfSijiEpgg=,tag:cJfnsaRhjOzSzWTrz2rEkw==,type:str]
-  port: ENC[AES256_GCM,data:jEOypg==,iv:ZjqeMX4Z8tbu8HzyD8vWSS4UFFnH4PtlP00fqkeKheM=,tag:WKKdsTNX0/RfX/G7nVNyzg==,type:str]
-  hostname: ENC[AES256_GCM,data:aTjMNTwwkTB+eyf9iWIG54/0tiCNh0/7fZEh4V6sGkjkgI9FVwo=,iv:pj/m7LNplnWXX5sE5j0u0hX67vAI9VxoToAKNHVpfQk=,tag:sbCWiOyCl1SxZLeWLkAgxQ==,type:str]
-  password: ENC[AES256_GCM,data:ZgwaZi4pz0GpkSEXQ3kQw5Z93z1Jt2PDUoahvkJ3PuA=,iv:paiX34+iIYUFP3CnTElNKKM+BjK7rZA1plo001nvhxc=,tag:dILrM8uFygSxV1ph67xk3A==,type:str]
+  username: ENC[AES256_GCM,data:1byojBHk2So=,iv:NzOfAwmxQOBtl77A/qPZKBK/aXqDANjz1VCozh+vPFY=,tag:Tf0RHKyKuqp2sbYJ0uHv2Q==,type:str]
+  database: ENC[AES256_GCM,data:tXkxRzn9Er0=,iv:HYk+IyJOdvYExzDGNNMXvVvU4hu7N09HKd+Tp7nvNuQ=,tag:ZsZd5ahVbF0zb4nJ4r5Gvw==,type:str]
+  port: ENC[AES256_GCM,data:ojjSzg==,iv:ihitS8hEYOxQmBNiDBWdvTihSKNKv5D+vGGRd0Gpr5A=,tag:f3Dc6S6obUK1qfUH6JPpYg==,type:str]
+  hostname: ENC[AES256_GCM,data:Ss9+GG8KxEVtOLoDUC1tDCcsJqgCbg9SxleGK2jpf9+VuIY1SAs=,iv:Tn2wDvk3j1fX55RmWa8uyV9gy7wUG31Nn2MHNI/E8l0=,tag:/FebvYw85MxkUnF4xM7gLA==,type:str]
+  password: ENC[AES256_GCM,data:z2Z+jNmo1I1J9j6J6VPxyUtbwetVEC2J5DVztRGH86o=,iv:ttvbK8sHxBhNGP19f4o3EpK2fiuQ4QXOKdCpbSfaA1I=,tag:RAhweIKRdehCeXW/NfEtww==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -630,45 +630,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:Hp/Ogg==,iv:YRu5KDEwnhsESznaagyuiBCb18v0XXnEgqWt/UQiTOM=,tag:1oyFTqer8aJ1suBfpCfSUg==,type:str]
-  database: ENC[AES256_GCM,data:HUelzg==,iv:A0/2UxRZZXEA+4pQPWlLrLxGw1IyORPCpYE7BcV1xC8=,tag:xsu534U7J8PyLWw0WCwxHQ==,type:str]
-  port: ENC[AES256_GCM,data:y9KS0Q==,iv:qIweE0VwvYG90KQ7KJP0T1nXhOoNjqg7/55FjWzSBtM=,tag:pa/IFeqjmzRGkxJwRSieWQ==,type:str]
-  hostname: ENC[AES256_GCM,data:NnBvTSpaInfS3WNm1oijGgfKq6sjUibzWPEWNLneNhoeZDQ5URk=,iv:ahyh1z9NyCFfrbS+AC5ROliLl/0euRO0xYfLvx1hG0M=,tag:0bTe8N/jCVRGD6JFpkAtjA==,type:str]
-  password: ENC[AES256_GCM,data:EzMzsbdtlXVLKvS9DVcy1m7ZtwRdeTpZrIrmJgfIugU=,iv:KdLzczR/b5cGSmFJNXK2uIYw/icOW9h54slKIgWmNKQ=,tag:74Il6Pi49yWjlR/UgWCjRQ==,type:str]
+  username: ENC[AES256_GCM,data:ZA8QCQ==,iv:1qES2weVYF1ENgvvWIA5s53GgVbR0V9HqU11bbX0tis=,tag:4fBX0cH0ImZxwte9IdtN/g==,type:str]
+  database: ENC[AES256_GCM,data:IIMN8Q==,iv:1qg/jKivDA8QX56uwkkAkqwHrtCnnT6p38D1nxeFHL4=,tag:PB8XuOvqxXK35kmTEOZRVw==,type:str]
+  port: ENC[AES256_GCM,data:AIrx8g==,iv:PftV17iXoauDE65PomCKCFneo1YQCc+6Z5P90lukaHQ=,tag:y7j3GAPazIfIgl/9aDq4pA==,type:str]
+  hostname: ENC[AES256_GCM,data:bFX6CJaVz/CPnxjgdCqLFYl6g+GaXj/IlQ0J9gVbAJgGbW+yNqU=,iv:BtDWxeb1fh7OH4f5Qt+2BWHoMpmEfDQCCtUoitK8G4s=,tag:9nOWAgEGMpYzGhpr2TQdbg==,type:str]
+  password: ENC[AES256_GCM,data:fXo+FZosqx+6NWf9PVuM1VXtlxxmtS52nlt2pK9ba0c=,iv:nhGa5j5TPCKqamBGv+P8+oiLkVQECjeooAel40mzz64=,tag:svCI4SM6I/fPDSFMWWZPtQ==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -678,45 +678,93 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:C+PzN2VhGw==,iv:044NfiLqOe5nR7EVjsEz0tVaGir5fbWYROF19RfUByg=,tag:tJLbpX2MAb1LYL+G8WOP8Q==,type:str]
-  database: ENC[AES256_GCM,data:PfzQuQCElg==,iv:BohydwLg7aVwmhSU9YfugnSg3nxShdidCXiMr30UmuU=,tag:EvTyopn1vk/rAk3An1efcg==,type:str]
-  port: ENC[AES256_GCM,data:5zTmfw==,iv:XE1NPAruUDxAv6DR5dkkpdYokWGgnqzjLcZKp7eZGcg=,tag:qS4MABqvfcNjwoUaVy58IA==,type:str]
-  hostname: ENC[AES256_GCM,data:cAqRtoYRIWtpCMZQIRUoj4qn5Nn8C9c/d/qF46ykCSK9wmjXFRI=,iv:21+L/eK7HSCcAVO+PKc4uQ8KUVo9LZ8+vYhSz623AV4=,tag:2camqdOklIYqQ7XM945aBw==,type:str]
-  password: ENC[AES256_GCM,data:11k0frx0Irpq+VVgBd3jkVkvzS6xOIXGDCteeMthBXw=,iv:0XWlTfEw9n+6VNYRhWw5sxLqKH5m51AcYAqUH2NjSvA=,tag:oJ0LlUQMvFixoRY2lGyo2Q==,type:str]
+  username: ENC[AES256_GCM,data:0lmC79Tpbg==,iv:QOJgmeTVzRTjcb/REsjKg8zVQxdPl4Qg+dIrP3VLWXE=,tag:YQ/bhpaps/ZEhzc4VNcjug==,type:str]
+  database: ENC[AES256_GCM,data:2O4X1NNPHA==,iv:btHM7hai0q9PM4CxySrfLJd22QlOMGAdhLJN0qSGK4I=,tag:FRKrSygSO4QB41Ho1ZktLg==,type:str]
+  port: ENC[AES256_GCM,data:awueAg==,iv:4ApdxAjAcurEk5ywDVcyhMbElFtjyuwBUe7GDTx8fb8=,tag:xCl4ErVWEJ8PBiKmk65DdA==,type:str]
+  hostname: ENC[AES256_GCM,data:yTuARMV9LSalQy2mwPl7o9jrkEyMZq2EWXNqGSHCOcE8cw/g284=,iv:ooX/OombvVh4NA1kvk5L7m5ZdWcl1P1SXbB2U//GImQ=,tag:kzEIouJJ5FpUw+LVDGBDeQ==,type:str]
+  password: ENC[AES256_GCM,data:7x2gx59H8TqsyD11/CQUbXwwO62aReCdhUOe2OpRN60=,iv:+gt5gAphcrarTgqupFBDCEh5x4J/zgGTr36iVbVrQHM=,tag:DvvD5aTA7LuaRF/Hy0k4rA==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: itsaplan-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:1w6kfWpZ8x4=,iv:BigrW+p/YTYJK3jHAzX/lgCpkR2CAXTHMwjUpsZQMvg=,tag:U0+WA+ttb3XmozYt4c5J2g==,type:str]
+  database: ENC[AES256_GCM,data:MQBwhQpxDXw=,iv:9Ws8CIobsywm0iuWdab15CebFpsc4NI23redairNLS0=,tag:HNZ/fxqx5cLOm+Za9VZqmg==,type:str]
+  port: ENC[AES256_GCM,data:iJXi+g==,iv:zzsuWk61QiO6B4PCSuv19btwprK6HjE0Wzy2CVQlGoI=,tag:ohKWMKCw69JuN/i2E4CgpQ==,type:str]
+  hostname: ENC[AES256_GCM,data:SaprRlhSXkrXqQMOoqeSakGLZ9SBgMUhVzc6kQ0OZtPlbLglxVQ=,iv:3EvpRUM3tQT8eS7/hdWHEqNrzjwZhiMadT0aMEPxR/k=,tag:NEEp5ytWr/EWWmxg4UTbeQ==,type:str]
+  password: ENC[AES256_GCM,data:S41NAE3yyPJAw+196qA+XZ7iIjOJC57QH0yn9fjLPs4=,iv:DSONtUz58wh6nECmGhY1tpLjzoyoWD6HrWkq7YMp7rE=,tag:PXn1mz2kwZVVGRAaSLx80w==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -726,45 +774,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:PAtNafDa3NivnN+F+HccnA==,iv:AU222XnuJtspDov6MEFieHW+JzElU+M9jv1jraLpbGM=,tag:RN/fG/sipJesl8pmPWELCg==,type:str]
-  database: ENC[AES256_GCM,data:5dkZF5+Epc0=,iv:Z8wJxB1UWQkJuIkALRzWXiMwyfM8UtY1LwcvdrOVRaA=,tag:DDj6T+qt9H2jGHZUhT76vw==,type:str]
-  port: ENC[AES256_GCM,data:g0HrNg==,iv:zXCbHFzDQA60kh8aQgcBNpUgYiFMBCGrx0IsvCLBJg4=,tag:DYWjb1grf+Yp6ez6o9LNCQ==,type:str]
-  hostname: ENC[AES256_GCM,data:KpP9dQ5jSwO9FGSlxk/yMZNrbTfcuc/NrqC2TzrnFJNQ9vaTZ2U=,iv:ypOXHm83WFP7ZfCTVxWOCBrv6acztQBFoRRZp5fvTsk=,tag:KYV+Y7lnP3y0qRNDCsiAAg==,type:str]
-  password: ENC[AES256_GCM,data:shMoRFSPuXkIel381RDlw6MQ1CAJnNOp8GNJy7tDRvY=,iv:vGVyhyL/so+g7nuLoE75QjYgRbHtC47nZ0HpMp1JNLo=,tag:frBpI575V3wqJeeY5WF+Eg==,type:str]
+  username: ENC[AES256_GCM,data:ZPefzhCaShdd1DTnEuOT9Q==,iv:JHE6JloBgl8/QcsciQxGwvu1I71dmRo/eTNVAG+a5F0=,tag:EwGLJADGerD+fmnWv2Ew2w==,type:str]
+  database: ENC[AES256_GCM,data:PvTCumbLGjg=,iv:/57vwlr/bjlmkwSKJLWPJwC8gbdO0koIoWUklrCY9VQ=,tag:2xnSNKdqUn1cEPNRlpV1RQ==,type:str]
+  port: ENC[AES256_GCM,data:oxhfNg==,iv:SJxclrGCjed8YavEhEolyngk5DeyixxxpDLu1thSUjc=,tag:bowznSha/LnHQOeduPw+Pw==,type:str]
+  hostname: ENC[AES256_GCM,data:/HZJyyvHG8rad4FSLd8sSvvdDqzJayakqM+bdaOwsUyPvcI1dTY=,iv:c9QpJIbn5z6jRgp8CKoQ3LgnTwG2TdtZO2L3sKTJ2Ns=,tag:/oPsmU8Dm8v6haNBtiVj/g==,type:str]
+  password: ENC[AES256_GCM,data:Dgi9I4wqlIWr35UfO/wo4X0Lb0hBWFsmA2mqKjFulJE=,iv:BRFh+fe4SP68vgapPUOvpG8VMoy5sI4YTvlHE+ZGDZ8=,tag:4rwcY0sRgLPng34Taa8y1A==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -774,42 +822,42 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:Tvm7GiA/mJIEly0M0CIOWKay,iv:UpptOgYx+wsud6GM4q80y7gVOYD+Gu2GO1bu52L3oAI=,tag:Zks0HCJ4xJe1rF9wcvlmKA==,type:str]
-  database: ENC[AES256_GCM,data:NBPafsMQCZE=,iv:8Lx/cULNv3y9461s5iUPjep1wQSVd8VbTC8numM3hgk=,tag:kaC/RsOPmN/6L+pqTywyRg==,type:str]
-  port: ENC[AES256_GCM,data:2RL1Xw==,iv:mHj8fdwUsKjNfFHMc2r8aZzipiIy2Lsy48s17tZYEss=,tag:q+RSgHkfhgF8kaZT7b+QxA==,type:str]
-  hostname: ENC[AES256_GCM,data:ENrTzH/BPEke+w9K5PYDmWlnQe59W17Y+UOY/AQVH89YNbePZU8=,iv:WSRMP8Ds+qADDYNp9vXIHSPvYQNlxs6NqPmJPJUbGI0=,tag:aMb9m7Uht4NyvMH3WPq1sg==,type:str]
-  password: ENC[AES256_GCM,data:/qssRBgRmu3dIcruFkVaGSJ6UvhXOK+U/5lxAt6QjRE4vjidzQjsdoDgleOdsbfvxcxem5iyjebL8daVmUHU1Q==,iv:aAju0K5CvLqu+g1BRfXx52CAIEjgVjH3FBsj/62nfmQ=,tag:EvVPgWieoE6u/3sWKIqBuA==,type:str]
+  username: ENC[AES256_GCM,data:qNiwK8mCNs4dWok1jZMqNgvl,iv:Wb9yDnoZOO8b3cEc8ofrPzU7Qmyvo/M3Vg4ax4/AClc=,tag:AFUHNkHFbChavDhv92R+6Q==,type:str]
+  database: ENC[AES256_GCM,data:u/xckRVnrMc=,iv:benecUC1LBjFDH5nd1Iqjhw7CPz1BgrnHGWzj08VOp8=,tag:oZ+uD0EeuvWRgFp4imTfCA==,type:str]
+  port: ENC[AES256_GCM,data:8CjMgw==,iv:qZV47Xm/VssetvIKdSGSoTriA9uf9ffiD7T5a/KsJDw=,tag:OlokTgN/MwJsnqNgnyVfJQ==,type:str]
+  hostname: ENC[AES256_GCM,data:o5SxMSpwG68ZOq8o8boJJPM9mPbHnpaaFoqjBVfrIQgB2Ontzsk=,iv:OACKDnU6TRHS4sgTB1fxcSke2E75kej6tcNcqpjU4s8=,tag:5ztIa6UAVRWP33zdYywHnA==,type:str]
+  password: ENC[AES256_GCM,data:x+EjOz3zdS5ovKO0nxQWNoLRpvptVnHjdnG/8xaR7HhCoqAuWnP0E+PU9l5TIjwq8fN0CkoCAa8KiZsfVhRi0g==,iv:TFVGpUdH/qa18K46FKxKOejNeWNZF/Nk3kA6kKar4uo=,tag:J8ydGws9pfpHjIGKw16n7A==,type:str]
 sops:
   age:
-    - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhekc3QzI1ZmpVMWM0d1R3
-        djhsV0pHSWR0b1A5Nitwd1FGZG9qMVladlNFCjRERWt6dG52Z3EranJRYmpPTU81
-        WVY2ZXFoaWpnUC9jeTcvK1IzWUhtNTAKLS0tIGpFMnI2YklHaDZsUUZuL2ZsYlY0
-        Qmsxc3l4M2xvN2c0WnBZMUpxRXc5bUkKkkNqF2IZVt8KT1KeH9GdsSa13flmSpPs
-        KW1zcXH21Fg+VZQfo0Da0gH2/Ok9xNgzjk+9TyMaubeoOoNXdolOJA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcWszeEwyNHhaaGlMNEJk
+        d1lVR3RkWEF4dkw0aExOUGZPTjkyK0RvV2dVCllYRzBRbnRaVW1HZlErWTJIek1z
+        MFVnZTYwdTZLM3g0K1BTeUFlRmZIVFkKLS0tIGRQWEhSVURmZkJzRFc2VGpMWDBq
+        K1B5SVhETzVPRDQ0UUlLbjY3S1ZuUWcK0joYRUx/fMscA5vPz3f/ZNTCIdnf6/SR
+        TuWag7OhNiym0DVx/mMIJbx3Vh8/+iwsc6ronI0zE2j53mOU1lbK9w==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-      enc: |
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDR0JMMWl3Ri9hcUhJajNH
-        aFFOZytTM2lCb0ozMGRQcEZrUmx1VXFDZHgwCjd5WU5oS05PNm8rNGphbFlING45
-        TjBIcWozUXJKcWxhYXRhQncrcFdMZGMKLS0tIHBIK2EvWlZtWm96d0pJZUdRM0Mz
-        WEpEOEdTNzJESDAwRG52ZFl1QjJNb0UKnSw7JtrTvTVF5GCIt0uzZ/HVApbPoPPb
-        WJGNtdxPjPCsr4LTFGeeN43c56svWlQKnoATR9eh8BI7BGZu/JQRlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlhwa08wOVpDVWM0UzBa
+        dTBFUlZqQTMrL3hqMzUwaHpJSnUvcER5dTFRCkVOTlhzRGNsQlVOUEpjWXpYcFZj
+        YWVyZjVRN3RUY2k1NkM4c0VtckJta28KLS0tIGYrc2psY3hmWCtIRDlpb05mMmkw
+        YlVIajBOM0ZWLzQySHJJTWEwYUtiNTQK7IC/Xjnr/VKedKRojIDdj7PO6iE6R/B3
+        Vv9Prwp/rYeAEgUGscYm3DHmtQraCB/6H5DI2szd/Xw0vfEsaqr+Cw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-      enc: |
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMWFjTmJobHNhQ01BTktq
-        bTJvaWxlemk4czZRMmJUaHpCQlg4TVVaTFE4CmdST2lFTGZuZ2lIalJRbEpnNVk2
-        L29HSHhacmtkOVVOWk50YmlTQXE4b1kKLS0tIDNlY1NaTW8wWWo4NUZnUHVyZ0l5
-        L0p6YTRRdmNidzZzbXlBS3dEdE5HTTgK9XU5ZIewx91fLLr9+KB5VLMT36yx9ww5
-        pzXLm7zEO1ky7iIdZTEUdWjpkOc72hwBD9oyIeV+7kQB8Zipb4NiDg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWYTJYcUkxalV6MWk3VmVR
+        Vm5uUE10YzcraFR3b1BsZWxxWldpMDlXR25jCi90TmFHVytJWkwzN3YvdUdZK1NB
+        NVovUnhwN0Q1MU9QK2tDSjRHY1RxT1kKLS0tIFZnckJnYWtVbDh1TFN2TzFLMjcx
+        ZE8xbVp0dldUN25MY0FmZXpLV1kwRDgK28j7VtMrhm5dQmzqJWjdcYU6n6+hKboh
+        a6ZVbxFWZFsTM31yeQlYjwvaJfMmkCZlnou8M+kJe8WajbAKCZVSMg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-28T00:16:37Z"
-  mac: ENC[AES256_GCM,data:R7+uz3HL4DECBxi8lVT09p/ADh4BOfX5Tg+EawjsR8P3Bck43b/ec13XnXumGO7r/GRY+UcYr7D8eHjYCeYyHmdMAo7nk0nyP1/BDIHhToFG0dx/R6Xsi/UDi9Zd5mMtlZFzC/0LPR+VDNWFnFg9Hfv8JP3uDUIgBNIyiOPAnyU=,iv:0smYtcRegm453VdaNLJ79I3aihz28G7mSzq1K/Eim7c=,tag:u9B1R/+g834eK1xYt7KTOA==,type:str]
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T21:13:00Z"
+  mac: ENC[AES256_GCM,data:ZZ5AfN/hQnK0XIZN0L5IsbRnoxAiexVPuJCraGGFFDDcfiipAbAW8oHoulWlzSUrYDASJXkVO0qgsHjxqAGl5uvlFjTsFCF6UF2FglyHJIpQi6S3Ar6A3YT+MKRpgbjAPNEX2QEIwtseGDxBxpVZSpq/NS0OgqWoPA3jK6XJcEk=,iv:ZPymMAhPncrSbj87A/Qu/BObE85GWD5d7HT6scNURZA=,tag:xHjAqWw1cJk+TGXM1dk8VA==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.2

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -174,6 +174,12 @@ cluster:
     superuser: false
     passwordSecret:
       name: pulsarr-postgres-password
+  - name: itsaplan
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: itsaplan-postgres-password
   monitoring:
     enabled: true
     podMonitor:

--- a/kubernetes/apps/database/postgres/app/users.yaml
+++ b/kubernetes/apps/database/postgres/app/users.yaml
@@ -1291,6 +1291,98 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: &name itsaplan-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "itsaplan-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app itsaplan
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: itsaplan
+  owner: itsaplan
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: itsaplan
+    - ensure: present
+      name: itsaplan
+      owner: itsaplan
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: &name postgres-user
   annotations:
     reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/database/postgres/postgres-push-secrets/push-secrets.yaml
+++ b/kubernetes/apps/database/postgres/postgres-push-secrets/push-secrets.yaml
@@ -2131,6 +2131,158 @@ spec:
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
+  name: itsaplan-postgres-push-secret
+spec:
+  deletionPolicy: None
+  refreshInterval: 24h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-connect
+  selector:
+    secret:
+      name: itsaplan-postgres
+  data:
+    - match:
+        secretKey: username
+        remoteRef:
+          remoteKey: &key ${CLUSTER_CNAME}-itsaplan-postgres
+          property: username
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: *key
+          property: password
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: hostname
+        remoteRef:
+          remoteKey: *key
+          property: hostname
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-hostname
+        remoteRef:
+          remoteKey: *key
+          property: public-hostname
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: port
+        remoteRef:
+          remoteKey: *key
+          property: port
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: database
+        remoteRef:
+          remoteKey: *key
+          property: database
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: pgpass
+        remoteRef:
+          remoteKey: *key
+          property: pgpass
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: jdbc-uri
+        remoteRef:
+          remoteKey: *key
+          property: jdbc-uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: uri
+        remoteRef:
+          remoteKey: *key
+          property: uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: uriql
+        remoteRef:
+          remoteKey: *key
+          property: uriql
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-jdbc-uri
+        remoteRef:
+          remoteKey: *key
+          property: public-jdbc-uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-uri
+        remoteRef:
+          remoteKey: *key
+          property: public-uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-uriql
+        remoteRef:
+          remoteKey: *key
+          property: public-uriql
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: connection-string
+        remoteRef:
+          remoteKey: *key
+          property: connection-string
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-connection-string
+        remoteRef:
+          remoteKey: *key
+          property: public-connection-string
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
   name: postgres-user-push-secret
 spec:
   deletionPolicy: None

--- a/kubernetes/apps/equestria/home/itsaplan/AGENTS.md
+++ b/kubernetes/apps/equestria/home/itsaplan/AGENTS.md
@@ -1,0 +1,172 @@
+# itsaplan
+
+Self-hosted project management / issue tracking, migrated from the upstream
+`docker-compose.yml` at [croffasia/itsaplan](https://github.com/croffasia/itsaplan)
+v0.5.0 (AGPL-3.0). Four processes — `api`, `worker`, `bot`, `web` — plus a MinIO
+object store for issue attachments.
+
+## THE BLOCKER: upstream publishes no images
+
+This is the one thing that separates itsaplan from every other app in this
+directory, and it is not a detail.
+
+- `.github/workflows/release.yml` upstream is release-please plus a `release`
+  branch mirror. There is **no docker build and no registry push**. `ghcr.io`
+  appears zero times in the repository.
+- All four services are `build:` from the checkout in `docker-compose.yml`.
+- `web` is worse than the other three: `apps/web/Dockerfile` takes
+  `NEXT_PUBLIC_API_URL` as a **build arg** and Next.js inlines it into the
+  browser bundle. The image is therefore bound to the api origin it was built
+  for. Even a hypothetical upstream image could not be used unmodified.
+
+**Nothing in this directory can reconcile until the four
+`ghcr.io/david-driscoll/itsaplan-*` images exist.** That is why
+`../kustomization.yaml` does not yet list `./itsaplan/ks.yaml`.
+
+## How the images get built
+
+A small standalone repo, `david-driscoll/itsaplan-images`, modelled on the
+existing `david-driscoll/github-runner-az-dotnet` (the estate already builds and
+publishes `github-arc-runner-az-dotnet` this way, so this is not a new pattern).
+It holds no application source — only a pinned upstream version and a workflow.
+
+```
+itsaplan-images/
+  versions.env                     ITSAPLAN_VERSION=v0.5.0
+  .github/workflows/build.yaml
+```
+
+`versions.env`:
+
+```sh
+# renovate: datasource=github-releases depName=croffasia/itsaplan
+ITSAPLAN_VERSION=v0.5.0
+```
+
+`.github/workflows/build.yaml` (GitHub-hosted runners — the estate's own ARC
+runners are `containerMode: kubernetes` and have no docker daemon):
+
+```yaml
+name: build
+on:
+  push: { branches: [main], paths: [versions.env, .github/workflows/build.yaml] }
+  workflow_dispatch:
+permissions: { contents: read, packages: write }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [api, worker, bot, web]
+    steps:
+      - uses: actions/checkout@v5
+      - id: ver
+        run: cat versions.env >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
+        with:
+          repository: croffasia/itsaplan
+          ref: ${{ steps.ver.outputs.ITSAPLAN_VERSION }}
+          path: src
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: src
+          file: src/apps/${{ matrix.app }}/Dockerfile
+          push: true
+          # web only: the api origin is inlined into the browser bundle here.
+          build-args: |
+            NEXT_PUBLIC_API_URL=https://itsaplan-api.<ROOT_DOMAIN>
+          tags: |
+            ghcr.io/david-driscoll/itsaplan-${{ matrix.app }}:${{ steps.ver.outputs.ITSAPLAN_VERSION }}
+```
+
+### Who rebuilds, and on what trigger
+
+1. Upstream cuts a release. Renovate (already configured org-wide via
+   `local>david-driscoll/.github:renovate-config`) sees the `github-releases`
+   annotation in `versions.env` and opens a PR in `itsaplan-images` bumping
+   `ITSAPLAN_VERSION`.
+2. Merging that PR **is** the rebuild trigger — the workflow pushes four new
+   tags to `ghcr.io`.
+3. Renovate in *this* repo then sees the new tag on the four
+   `ghcr.io/david-driscoll/itsaplan-*` packages through the ordinary `docker`
+   datasource, and opens the HelmRelease bump PR here with a pinned digest, like
+   every other image in the estate.
+
+Two PRs per upstream release, both reviewable, no manual step, no cron nobody
+watches.
+
+### Why not the estate's zot
+
+`docker/celestia/zot` and `kube-system/registry` are both configured purely as
+**pull-through mirrors**: `extensions.sync` with `onDemand: true` against
+docker.io/ghcr.io/quay.io/etc., no `auth` block and no `accessControl`, and a
+retention policy (`deleteUntagged: true`, `gc: true`) tuned for a cache rather
+than an artifact store. They are also behind the internal Gateway's
+`internal-network` ipAllowList, so a GitHub-hosted runner cannot reach them at
+all. Publishing to ghcr.io keeps working *with* them — the mirror proxies
+ghcr.io, so in-cluster pulls still get cached.
+
+### Why not build in-cluster (kaniko / buildkit Job)
+
+Worse on every axis that matters here. The ARC runners are
+`containerMode: kubernetes` with no docker daemon, so it needs a
+privileged-or-rootless build path the estate does not have today; a
+`bun install` + `next build` is a heavy job competing with real workloads on
+Talos nodes; registry push credentials would have to live in-cluster; and
+Renovate cannot see any of it, so the rebuild trigger degrades to a CronJob with
+no PR trail. The only thing it buys is independence from GitHub Actions, which
+this estate already depends on.
+
+### Renovate visibility, stated plainly
+
+The estate convention — digest-pinned upstream images that Renovate updates — is
+**preserved from this repo's point of view**: these are ordinary published
+images and Renovate tracks them normally. What changes is that the estate is the
+publisher, and an extra Renovate-driven PR upstream of that (in
+`itsaplan-images`) is what produces a new tag. If `itsaplan-images` is ever
+deleted or its workflow breaks, this app silently stops receiving updates and
+nothing here will say so.
+
+### Changing the api origin means rebuilding
+
+`API_URL` in `helmrelease.yaml` and `NEXT_PUBLIC_API_URL` in the web build arg
+are the same value and must be changed together. Editing only the HelmRelease
+leaves the browser bundle pointing at the old origin, and the symptom is a web
+UI that loads and then fails every XHR with a CORS error.
+
+## First deploy
+
+1. Create the 1Password item **`Itsaplan`** with five fields, each
+   `openssl rand -base64 32`:
+   `better auth secret`, `app encryption key`, `worker internal token`,
+   `s3 access key id`, `s3 secret access key`.
+   `app encryption key` is effectively **write-once**: it encrypts stored
+   AI-provider credentials with AES-256-GCM and there is no re-wrap path, so
+   changing it makes every stored credential undecryptable.
+2. Run the postgres generator so the `itsaplan` role, database and push secret
+   exist (`task update`, or `dotnet run .mise/tasks/do-update.cs`). The
+   `components/postgres` entry in `ks.yaml` is what it keys off.
+3. Uncomment `../../../../components/volsync-restore` in `ks.yaml` for the
+   first reconcile only — see the comment there for why, and remove it once
+   `kubectl -n equestria get replicationdestination itsaplan-dst` reports a
+   `lastSyncTime`.
+4. Uncomment `./itsaplan/ks.yaml` in `../kustomization.yaml`.
+5. After the first account is created, set the instance registration mode to
+   `closed` (or `invite`) in god mode. It defaults to **open**.
+
+## Storage note
+
+`snapshotMaxCount` is `5` cluster-wide in `longhorn-system/longhorn/values.yaml`
+and is **sticky per-volume at creation time**, so the `itsaplan` volume inherits
+5 and keeping it is not a later decision. The steady-state ReplicationSource
+runs once daily with `copyMethod: Snapshot`, creating and releasing one snapshot
+per run, so 5 is ample — but if this volume is ever put on a tighter schedule,
+or if manual snapshots are taken alongside the backup, that ceiling is what will
+deadlock it. Two volumes hit exactly that in 2026-07.

--- a/kubernetes/apps/equestria/home/itsaplan/definition.yaml
+++ b/kubernetes/apps/equestria/home/itsaplan/definition.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: "It's a Plan"
+  category: Applications
+  description: "Self-hosted project management and issue tracking"
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/kanban.svg
+  access_policy:
+    groups:
+      - family
+  # No `authentik:` block on purpose. itsaplan authenticates with better-auth
+  # (email/password, passkeys, magic links, Google) and has no generic OIDC
+  # client, so there is nothing for an Authentik provider to bind to. A forward-
+  # auth proxy in front of it would double-prompt rather than sign users in.
+  # Access control is the internal-only Gateway plus the app's own registration
+  # mode, which defaults to `open` and MUST be set to `closed` or `invite` in
+  # god mode immediately after the first account is created.
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"
+    - group: "Applications"
+      url: https://${APP}-api.${ROOT_DOMAIN}/
+      method: GET
+      conditions:
+        - "[STATUS] == 200"
+        - "[BODY].status == ok"

--- a/kubernetes/apps/equestria/home/itsaplan/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/itsaplan/externalsecret.yaml
@@ -1,0 +1,137 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# api secret: everything the api process needs. The api is the only component
+# that talks to MinIO and the only one that holds APP_ENCRYPTION_KEY.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        # search_path is pinned to public on purpose. The drizzle migrations in
+        # packages/db/drizzle are written unqualified, and postgres resolves an
+        # unqualified CREATE TABLE against the default search_path of
+        # '"$user", public'. components/postgres/database.yaml creates a schema
+        # named after the role, so without this pin every table would land in
+        # schema "itsaplan" instead of "public" -- which is exactly the shape
+        # that stalled the windmill 1.722 upgrade, where a migration created a
+        # SECURITY DEFINER function with a hardcoded 'SET search_path = public'
+        # and could not see its own tables. postgres.js passes any unrecognised
+        # URI query parameter straight through as a startup-packet parameter
+        # (src/index.js parseOptions), so this reaches the server on every
+        # connection, including the migration runner's.
+        DATABASE_URL: "{{ .postgres_uri }}&options=-c%20search_path%3Dpublic"
+        # better-auth session signing key.
+        BETTER_AUTH_SECRET: "{{ .itsaplan_better_auth_secret }}"
+        # AES-256-GCM key for stored AI-provider credentials at rest.
+        # CHANGING THIS MAKES EVERY STORED CREDENTIAL UNDECRYPTABLE -- there is
+        # no re-wrap path in the app. Rotating it means re-entering every
+        # provider key by hand afterwards. Treat the 1Password field as
+        # write-once.
+        APP_ENCRYPTION_KEY: "{{ .itsaplan_app_encryption_key }}"
+        # Shared bearer token for the api's /internal/* routes. The worker and
+        # the bot present the same value; see externalsecret-internal.yaml.
+        WORKER_INTERNAL_TOKEN: "{{ .itsaplan_worker_internal_token }}"
+        # MinIO root credentials. The same pair is consumed by the MinIO
+        # sidecar and the mc bucket-creation init container in the api pod.
+        S3_ACCESS_KEY_ID: "{{ .itsaplan_s3_access_key_id }}"
+        S3_SECRET_ACCESS_KEY: "{{ .itsaplan_s3_secret_access_key }}"
+  dataFrom:
+    - extract:
+        key: 'Itsaplan'
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "itsaplan_$1"
+
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# worker/bot secret: deliberately narrower than ${APP}-env. The worker needs the
+# database and the internal token; the bot needs only the internal token (it
+# reaches the api over http and never opens a database connection). Neither
+# needs APP_ENCRYPTION_KEY or the MinIO credentials, so they do not get them.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-internal-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-internal-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        # Same search_path pin as above -- the worker writes to the same tables.
+        DATABASE_URL: "{{ .postgres_uri }}&options=-c%20search_path%3Dpublic"
+        WORKER_INTERNAL_TOKEN: "{{ .itsaplan_worker_internal_token }}"
+  dataFrom:
+    - extract:
+        key: 'Itsaplan'
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "itsaplan_$1"
+
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/equestria/home/itsaplan/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/itsaplan/helmrelease.yaml
@@ -1,0 +1,484 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# itsaplan -- self-hosted project management / issue tracking (AGPL-3.0).
+# Migrated from the upstream docker-compose.yml at croffasia/itsaplan v0.5.0.
+#
+# IMAGES: upstream publishes none. Every service in the compose file is a
+# `build:` from the checkout, and `ghcr.io` appears nowhere in that repository.
+# The four `ghcr.io/david-driscoll/itsaplan-*` images referenced below are built
+# by the estate. See AGENTS.md in this directory for the build contract, the
+# rebuild trigger, and what must exist before this HelmRelease can reconcile.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app itsaplan
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  # Longer than the estate default: the api applies drizzle migrations before it
+  # listens, and `wait: true` on the Kustomization holds the whole app until
+  # that pod is Ready.
+  timeout: 15m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: *app
+
+    controllers:
+      # ── api ────────────────────────────────────────────────────────────────
+      # Applies database migrations on startup, then serves the API. Also hosts
+      # the MinIO object store as a native sidecar, because MinIO has no network
+      # exposure of its own: the api streams attachment bytes through itself, so
+      # MinIO is reachable only over the pod loopback and there is no Service,
+      # no route, and no console for it anywhere.
+      api:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        # The MinIO PVC is ReadWriteOnce, so two api pods can never overlap.
+        strategy: Recreate
+        initContainers:
+          # `restartPolicy: Always` makes this a native sidecar (KEP-753): it is
+          # started before the regular containers, kept running for the life of
+          # the pod, and torn down after them. The next init container does not
+          # start until this one's startupProbe passes, which is what gives
+          # minio-init the "MinIO is listening" guarantee that upstream gets
+          # from `depends_on: service_healthy`. A plain init container could not
+          # do this -- it would have to exit first.
+          minio:
+            restartPolicy: Always
+            image:
+              repository: docker.io/minio/minio
+              tag: RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+              pullPolicy: IfNotPresent
+            args: ["server", "/data"]
+            env:
+              TZ: "${TIMEZONE}"
+              # No console, no browser UI, nothing to expose. Upstream keeps the
+              # console on :9001 inside the compose network; dropping it removes
+              # the port instead of merely not publishing it.
+              MINIO_BROWSER: "off"
+              MINIO_ROOT_USER:
+                secretKeyRef:
+                  name: ${APP}-env
+                  key: S3_ACCESS_KEY_ID
+              MINIO_ROOT_PASSWORD:
+                secretKeyRef:
+                  name: ${APP}-env
+                  key: S3_SECRET_ACCESS_KEY
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /minio/health/live
+                    port: &minio-port 9000
+                  periodSeconds: 3
+                  timeoutSeconds: 3
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /minio/health/live
+                    port: *minio-port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+          # One-shot equivalent of upstream's minio-init service. Ordered after
+          # the sidecar by `dependsOn`, so it runs against a MinIO that is
+          # already answering its health check.
+          minio-init:
+            dependsOn: minio
+            image:
+              repository: docker.io/minio/mc
+              tag: RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
+              pullPolicy: IfNotPresent
+            command: ["/bin/sh", "-c"]
+            args:
+              # `mc alias set` rather than MC_HOST_local: the credentials are
+              # `openssl rand -base64 32` output, which contains +/= and cannot
+              # be embedded in a URL userinfo without escaping. --config-dir
+              # points at the tmp emptyDir because the container has no writable
+              # home.
+              - |
+                set -eu
+                mc --config-dir /tmp/.mc alias set local \
+                  "http://127.0.0.1:9000" "$S3_ACCESS_KEY_ID" "$S3_SECRET_ACCESS_KEY"
+                mc --config-dir /tmp/.mc mb --ignore-existing "local/$S3_BUCKET"
+                echo "bucket ready: $S3_BUCKET"
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            env:
+              S3_BUCKET: &bucket planner-attachments
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+        containers:
+          api:
+            image:
+              repository: ghcr.io/david-driscoll/itsaplan-api
+              tag: v0.5.0
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            env:
+              TZ: "${TIMEZONE}"
+              NODE_ENV: production
+              API_PORT: &api-port 3000
+              # Two public origins, each entered once. API_URL is the api origin
+              # (better-auth handler, email links, and the origin baked into the
+              # web bundle at image build time). APP_URL is the web origin (CORS
+              # trusted origins, passkey RP, email links).
+              API_URL: "https://${APP}-api.${ROOT_DOMAIN}"
+              APP_URL: "https://${APP}.${ROOT_DOMAIN}"
+              # COOKIE_DOMAIN is intentionally unset: better-auth derives the
+              # parent domain from APP_URL, which is correct for a single-label
+              # subdomain under ${ROOT_DOMAIN}. It only needs overriding for
+              # multi-label TLDs or deeper subdomains.
+              #
+              # MinIO over the pod loopback -- same pod, no Service, no route.
+              S3_ENDPOINT: "http://127.0.0.1:9000"
+              S3_BUCKET: *bucket
+              S3_REGION: us-east-1
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+            probes:
+              # The container runs `bun packages/db/src/migrate.ts` and only
+              # then `bun apps/api/src/index.ts`, so nothing is listening while
+              # migrations apply. Upstream allows 90s (compose start_period);
+              # this allows 300s (60 x 5s) before the kubelet gives up, and the
+              # liveness probe is gated behind it so it cannot kill the process
+              # mid-migration. tandoor crash-looped on exactly this mistake.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *api-port
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+              liveness: &api-probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *api-port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 4
+              readiness: *api-probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+      # ── worker ─────────────────────────────────────────────────────────────
+      # Webhook delivery, notification delivery, agent schedules and agent runs.
+      # Shares the database with the api; no ports, no probes to hang one on.
+      worker:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          worker:
+            image:
+              repository: ghcr.io/david-driscoll/itsaplan-worker
+              tag: v0.5.0
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: ${APP}-internal-env
+            env:
+              TZ: "${TIMEZONE}"
+              NODE_ENV: production
+              SERVICE_URL_API: &api-svc "http://${APP}-api.${NAMESPACE}.svc.cluster.local:3000"
+              # Anonymous telemetry off (TELEMETRY.md); either variable set to
+              # anything but 0 disables it.
+              TELEMETRY_DISABLED: "1"
+              DO_NOT_TRACK: "1"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+      # ── bot ────────────────────────────────────────────────────────────────
+      # Telegram long polling. The bot token lives in the database and is edited
+      # in god mode, so it is not an environment variable here.
+      #
+      # EXACTLY ONE REPLICA, STRUCTURALLY. Telegram hands each getUpdates call
+      # to a single caller, so a second instance steals updates from the first
+      # and messages disappear at random. `replicas: 1` alone does not achieve
+      # this -- a RollingUpdate deliberately runs the new pod alongside the old
+      # one, so every rollout would briefly run two bots. `strategy: Recreate`
+      # is what makes it structural: the old pod is fully terminated before the
+      # new one is created. Do not change this to RollingUpdate, and do not
+      # scale this controller.
+      bot:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        containers:
+          bot:
+            image:
+              repository: ghcr.io/david-driscoll/itsaplan-bot
+              tag: v0.5.0
+              pullPolicy: IfNotPresent
+            env:
+              TZ: "${TIMEZONE}"
+              NODE_ENV: production
+              SERVICE_URL_API: *api-svc
+              # The bot has no database access; it reads its token and writes
+              # account links through the api's internal routes, so the internal
+              # token is the only secret it gets.
+              WORKER_INTERNAL_TOKEN:
+                secretKeyRef:
+                  name: ${APP}-internal-env
+                  key: WORKER_INTERNAL_TOKEN
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+      # ── web ────────────────────────────────────────────────────────────────
+      # Next.js standalone build. NEXT_PUBLIC_API_URL is inlined into the
+      # browser bundle at IMAGE BUILD TIME, so this image is bound to the api
+      # origin it was built against: changing API_URL above means rebuilding and
+      # re-tagging the web image, not just editing this file. See AGENTS.md.
+      web:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          web:
+            image:
+              repository: ghcr.io/david-driscoll/itsaplan-web
+              tag: v0.5.0
+              pullPolicy: IfNotPresent
+            env:
+              TZ: "${TIMEZONE}"
+              NODE_ENV: production
+              PORT: &web-port 3001
+              HOSTNAME: "0.0.0.0"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            probes:
+              # /login renders without a session and without reaching the api,
+              # so it stays green even while the api is applying migrations.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /login
+                    port: *web-port
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 24
+              liveness: &web-probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /login
+                    port: *web-port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 4
+              readiness: *web-probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    persistence:
+      # MinIO data. advancedMounts scopes the volume to the api controller only,
+      # so the worker/bot/web pods never reference this ReadWriteOnce claim and
+      # stay freely schedulable. Claim is created by components/volsync.
+      data:
+        existingClaim: ${APP}
+        advancedMounts:
+          api:
+            minio:
+              - path: /data
+      # mc needs somewhere to write its config; the container itself is
+      # read-only.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          api:
+            minio-init:
+              - path: /tmp
+      # Next.js `output: standalone` does not ship .next/cache, so the server
+      # creates it at runtime -- under a directory the image owns as root, in a
+      # pod that runs as uid 1000. Without a writable volume here the first ISR
+      # write fails with EACCES. Ephemeral on purpose: it is a render cache.
+      web-cache:
+        type: emptyDir
+        advancedMounts:
+          web:
+            web:
+              - path: /app/apps/web/.next/cache
+
+    service:
+      api:
+        controller: api
+        type: ClusterIP
+        ports:
+          http:
+            port: *api-port
+      web:
+        controller: web
+        type: ClusterIP
+        ports:
+          http:
+            port: *web-port
+      # Deliberately no MinIO Service. Upstream keeps both the S3 API (:9000)
+      # and the console (:9001) off the network entirely and the api streams
+      # attachment bytes through itself; putting MinIO in the api pod preserves
+      # that exactly.
+
+    route:
+      # Both origins are on the *internal* Gateway only. Reasons, rather than a
+      # default:
+      #   - itsaplan's registration mode defaults to `open`
+      #     (packages/auth/src/instance.ts) and is only closable afterwards from
+      #     god mode, so an internet-reachable instance accepts self-signup
+      #     until someone logs in and turns it off.
+      #   - It holds project data plus AI-provider credentials encrypted with
+      #     APP_ENCRYPTION_KEY.
+      #   - Nothing about it needs inbound reachability. The Telegram bot uses
+      #     long polling (outbound getUpdates), and webhook delivery is outbound
+      #     from the worker. Neither wants a public origin.
+      #   - Passkeys/WebAuthn and secure cookies need HTTPS and a stable RP id,
+      #     which the internal Gateway already provides with real certificates.
+      # The cost is that notification email links resolve only on the LAN or
+      # over Tailscale, which is the intended audience.
+      web:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: web
+                port: *web-port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user
+      api:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}-api.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: api
+                port: *api-port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  # local-api, not local-user: the same ipAllowList without the
+                  # error-pages middleware, which would replace the api's JSON
+                  # error bodies with HTML and break the browser client's error
+                  # handling.
+                  name: local-api

--- a/kubernetes/apps/equestria/home/itsaplan/ks.yaml
+++ b/kubernetes/apps/equestria/home/itsaplan/ks.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app itsaplan
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/itsaplan
+  prune: true
+  force: false
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 15m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: external-secrets
+      namespace: kube-system
+    - name: postgres
+      namespace: database
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+    - ../../../../components/tailscale
+    # FIRST DEPLOY ONLY -- uncomment `volsync-restore` for the very first
+    # reconcile of this app, then remove it again once
+    # `kubectl -n equestria get replicationdestination itsaplan-dst` reports a
+    # lastSyncTime. components/volsync/pvc.yaml pins
+    # `dataSourceRef -> ReplicationDestination/itsaplan-dst`, which nothing
+    # creates unless this component is present; without it the VolSync volume
+    # populator claims the brand-new PVC, Longhorn stands down, and the PVC
+    # stays Pending forever with no error (equestria-cluster#2987,
+    # stargate-command-cluster#1739). With no snapshots in the repository the
+    # restore is a successful no-op that initializes it and binds an empty
+    # volume. Leaving it in permanently is the other half of the trap: the
+    # restore-once trigger has already fired, the nightly
+    # volsync-system/restore-cleanup CronJob reaps the ReplicationDestination
+    # at 03:30, and Flux recreates it on the next reconcile -- a full restic
+    # restore plus a fresh longhorn-snapshot/longhorn-cache PVC pair, daily
+    # (the 2026-07 Longhorn incident, vault#120).
+    # - ../../../../components/volsync-restore
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      # MinIO object store for issue attachments. Attachment metadata lives in
+      # postgres; only the bytes are here.
+      VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_ACCESSMODES: ReadWriteOnce
+      # Pinned rather than inherited: the two movers read this one variable but
+      # their defaults are asymmetric (ReplicationSource 2Gi,
+      # ReplicationDestination 8Gi), so an unpinned first-deploy
+      # volsync-restore silently provisions an 8Gi longhorn-cache volume to
+      # restore an empty repository. Same pin as dynacat (#2989), crowdsec-ui
+      # (#2987) and tsiam (sgc#1739).
+      VOLSYNC_CACHE_CAPACITY: 2Gi
+      # Must match the MinIO container's runAsUser/runAsGroup below, or the
+      # restic mover writes files MinIO cannot read back.
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/equestria/home/itsaplan/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/itsaplan/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/equestria/home/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/kustomization.yaml
@@ -16,5 +16,12 @@ resources:
   # - ./karakeep/ks.yaml
   - ./meilisearch/ks.yaml
   - ./tududi/ks.yaml
+  # Left commented until the four ghcr.io/david-driscoll/itsaplan-* images
+  # exist -- upstream publishes none, every service is a `build:` from the
+  # checkout. Uncommenting before then gives four ImagePullBackOff pods and a
+  # Kustomization that never reaches Ready (`wait: true`). See
+  # ./itsaplan/AGENTS.md for the build repo, the rebuild trigger, and the rest
+  # of the first-deploy checklist.
+  # - ./itsaplan/ks.yaml
   # - ./outline/ks.yaml
   # - ./collabora/ks.yaml


### PR DESCRIPTION
Deploys [croffasia/itsaplan](https://github.com/croffasia/itsaplan) v0.5.0 (AGPL-3.0) — a self-hosted Linear alternative — migrated from its upstream `docker-compose.yml` to the estate's `app-template` pattern.

**This PR is safe to merge and will not deploy anything.** `./itsaplan/ks.yaml` is left commented out in `kubernetes/apps/equestria/home/kustomization.yaml`, the same idiom `karakeep` and `outline` already use. One line uncomments it once the blocker below is resolved.

## The blocker: upstream publishes no images

This is the decision the whole PR hangs on.

- `.github/workflows/release.yml` upstream is release-please plus a `release`-branch mirror. **No docker build, no registry push.** `ghcr.io` appears **zero** times in that repository.
- All four services (`api`, `worker`, `bot`, `web`) are `build:` from the checkout.
- `web` is worse: `apps/web/Dockerfile` takes `NEXT_PUBLIC_API_URL` as a **build arg** and Next.js inlines it into the browser bundle. The image is bound to the origin it was built for — even a hypothetical upstream image could not be used unmodified.

### Recommendation: a small `david-driscoll/itsaplan-images` build repo

Modelled on `david-driscoll/github-runner-az-dotnet`, which the estate already uses to build and publish `github-arc-runner-az-dotnet`. So this is not a new pattern, just a second instance of one.

The repo holds **no application source** — a pinned upstream version and one workflow:

```
itsaplan-images/
  versions.env                     # renovate: datasource=github-releases depName=croffasia/itsaplan
                                   ITSAPLAN_VERSION=v0.5.0
  .github/workflows/build.yaml     # matrix over [api, worker, bot, web]
```

It checks out `croffasia/itsaplan` at `$ITSAPLAN_VERSION`, builds the four Dockerfiles with `docker/build-push-action` on GitHub-hosted runners, and pushes to `ghcr.io/david-driscoll/itsaplan-{api,worker,bot,web}:$ITSAPLAN_VERSION`. Full workflow is in `kubernetes/apps/equestria/home/itsaplan/AGENTS.md`.

**Who rebuilds, and on what trigger:**

1. Upstream cuts a release → Renovate (already org-wide via `local>david-driscoll/.github:renovate-config`) opens a PR in `itsaplan-images` bumping `ITSAPLAN_VERSION`.
2. **Merging that PR is the rebuild trigger.** The workflow pushes four new tags.
3. Renovate in *this* repo then sees the new tags on the four ghcr packages through the ordinary `docker` datasource and opens the HelmRelease bump PR here, digest-pinned, like every other image in the estate.

Two PRs per upstream release, both reviewable, no manual step, no cron nobody watches.

**Renovate visibility, stated plainly.** The estate convention — digest-pinned images that Renovate updates — is preserved *from this repo's point of view*; these are ordinary published images. What changes is that the estate is the publisher, and an extra Renovate-driven PR upstream of that is what produces a new tag. If `itsaplan-images` is deleted or its workflow breaks, this app silently stops receiving updates and nothing here will say so.

### Why not the estate's zot

`docker/celestia/zot` and `kube-system/registry` are both configured purely as **pull-through mirrors** — `extensions.sync` with `onDemand: true`, no `auth` block, no `accessControl`, and a retention policy (`deleteUntagged: true`, `gc: true`) tuned for a cache, not an artifact store. They also sit behind the internal Gateway's `internal-network` ipAllowList, so a GitHub-hosted runner cannot reach them. Publishing to ghcr.io keeps working *with* them: the mirror proxies ghcr.io, so in-cluster pulls still get cached.

### Why not build in-cluster (kaniko / buildkit Job) — worse

The ARC runners are `containerMode: kubernetes` with no docker daemon, so this needs a privileged-or-rootless build path the estate does not have. A `bun install` + `next build` is a heavy job competing with real workloads on Talos nodes. Registry push credentials would have to live in-cluster. And Renovate cannot see any of it — the rebuild trigger degrades to a CronJob with no PR trail. The only thing it buys is independence from GitHub Actions, which this estate already depends on.

## What's in the PR

### Shape

One HelmRelease, four controllers:

| controller | notes |
|---|---|
| `api` | `startupProbe` `failureThreshold: 60 × 5s = 300s` (upstream allows 90s) because the container runs `bun packages/db/src/migrate.ts` before it listens; liveness is gated behind it so it cannot kill the process mid-migration. Same mistake that crash-looped tandoor. |
| `worker` | webhook/notification delivery, agent schedules. No ports. |
| `bot` | Telegram long-poll. `replicas: 1` **and `strategy: Recreate`** — `replicas: 1` alone is not enough, because a RollingUpdate deliberately runs the new pod alongside the old one and Telegram hands each `getUpdates` to a single caller. That's the structural guarantee, not a comment. |
| `web` | Next.js :3001, `/login` as the probe target (renders without a session or the api). |

### MinIO in the same pod

Per your call. It's a **native sidecar** (`initContainers.minio.restartPolicy: Always`), which solves the ordering problem the plain-initContainer approach can't: `minio-init` (`dependsOn: minio`) does not start until the MinIO sidecar's `startupProbe` passes, so `mc mb --ignore-existing` runs against a MinIO that is already listening — the same guarantee upstream gets from `depends_on: service_completed_successfully`.

MinIO has **no Service, no route, and no console** (`MINIO_BROWSER: off`). The api reaches it at `http://127.0.0.1:9000` over pod loopback. That preserves upstream's posture exactly — it isn't merely unpublished, it isn't on the network at all.

### Database

`itsaplan` added to the shared `database/postgres` CNPG cluster (15th database) — role, `Database` CR, `ExternalSecret`, `PushSecret`, sops password.

Two things worth your attention:

**1. `DATABASE_URL` pins `search_path=public`, deliberately.**

The drizzle migrations in `packages/db/drizzle` are written unqualified, and `components/postgres/database.yaml` creates a schema named after the role. Postgres resolves unqualified `CREATE TABLE` against `search_path = "$user", public`, so without a pin **every table would land in schema `itsaplan`** — which is exactly the shape that stalled the windmill 1.722 upgrade. postgres.js passes unrecognised URI query params straight through as startup-packet parameters (`src/index.js parseOptions`, verified), so `&options=-c%20search_path%3Dpublic` reaches the server on every connection including the migration runner's. No extensions are needed.

**2. I did not run `components/postgres/Update.cs`, and you should look at why.**

I ran it, inspected the diff, and reverted it. It does two harmful things today:

- **It drops the `crowdsec` role and push secret.** `kubernetes/apps/network/crowdsec/ks.yaml` deliberately removed `components/postgres` from its `components:` list (the "D4" comment in that file), so the generator no longer discovers crowdsec. Running it deletes `crowdsec` from `cluster.roles` in `app/resources/values.yaml` and shifts every entry in `push-secrets.yaml` by one.
- **It strips hand-written comments** from `app/resources/values.yaml` on its YamlDotNet round-trip — including the vault#119 barman-bucket notes merged three commits ago.

The postgres entries here are therefore hand-written and purely additive (`+6 / +92 / +152` lines, no deletions). `passwords.sops.yaml` shows a full-file diff because `sops -e -i` re-encrypts every value; verified round-trip: 18 documents, `crowdsec-postgres-password` still present, no plaintext.

### Routing — internal only

Two origins on the `internal` Gateway: `itsaplan.${ROOT_DOMAIN}` (web, `local-user`) and `itsaplan-api.${ROOT_DOMAIN}` (api, `local-api` — same ipAllowList without `error-pages`, which would replace the api's JSON error bodies with HTML).

Reasons rather than a default:

- itsaplan's registration mode **defaults to `open`** (`packages/auth/src/instance.ts:42`) and can only be closed afterwards from god mode. An internet-reachable instance accepts self-signup until someone logs in and turns it off.
- It holds project data plus AI-provider credentials encrypted at rest.
- **Nothing about it needs inbound reachability.** The Telegram bot is outbound long-poll; webhook delivery is outbound from the worker.
- Passkeys/WebAuthn need HTTPS and a stable RP id, which the internal Gateway already provides with real certs.

Cost: notification email links resolve only on the LAN or over Tailscale — which is the intended audience.

### Secrets

Two ExternalSecrets, least-privilege rather than one blob:

- `itsaplan-env` → api only: `DATABASE_URL`, `BETTER_AUTH_SECRET`, `APP_ENCRYPTION_KEY`, `WORKER_INTERNAL_TOKEN`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`.
- `itsaplan-internal-env` → worker (`DATABASE_URL` + token); the bot gets **only** `WORKER_INTERNAL_TOKEN` via `secretKeyRef`, since it has no database access at all.

Neither uses `templateAs: Values` or a `configMapGenerator`, so the `scripts/eso-values-lint` hazard is avoided by construction. Lint run locally: **0 findings**.

⚠️ **`APP_ENCRYPTION_KEY` is effectively write-once.** It encrypts stored AI-provider credentials with AES-256-GCM and the app has no re-wrap path — changing it makes every stored credential undecryptable. Called out at its definition and in AGENTS.md.

### Storage

`components/volsync`, 20Gi, `VOLSYNC_CACHE_CAPACITY: 2Gi` pinned (same reason as dynacat #2989 / crowdsec-ui #2987), `VOLSYNC_PUID/PGID: 1000` matched to the MinIO container.

`volsync-restore` is present in `ks.yaml` **commented, with the reasoning inline**: it must be uncommented for the first reconcile only (otherwise the populator claims the new PVC and it stays `Pending` forever with no error), then removed once `replicationdestination itsaplan-dst` reports a `lastSyncTime` (otherwise the 2026-07 daily-restore loop). `snapshotMaxCount: 5` is sticky at volume creation and this volume inherits it — ample for one daily `copyMethod: Snapshot` run, noted in AGENTS.md as the thing that will bite if the schedule ever tightens.

## Validation

- `flate test all` — **326 passed, 2 skipped**, no new warnings (run with `./itsaplan/ks.yaml` temporarily uncommented: `✓ Kustomization equestria/itsaplan`, `✓ HelmRelease equestria/itsaplan`; then re-commented).
- `helm template` against app-template 5.0.1 — verified the native sidecar renders with `restartPolicy: Always`, `minio-init` is ordered after it, and the ReadWriteOnce PVC is scoped to the `api` pod only so worker/bot/web stay freely schedulable.
- `scripts/eso-values-lint` — 0 findings.
- `yamllint`, `kustomize build` — clean.
- sops round-trip verified (18 docs, nothing lost, no plaintext committed).

## Deliberately deferred

- **The image build repo itself.** It's a different repo; the workflow is written out verbatim in AGENTS.md so it's a copy-paste, not a design exercise.
- **Enabling the app.** One line, after images exist.
- **The 1Password `Itsaplan` item** (five `openssl rand -base64 32` fields) — yours to create; I don't write to 1Password.
- **A long-term home for MinIO.** You said same-pod for now and I built that; it is not the shape I'd keep. Separately: `minio/minio` on Docker Hub has not shipped since `RELEASE.2025-09-07` (`:latest` resolves to that same digest today), so the pinned image is ~11 months stale and will not receive security updates.

## What you must decide

1. **Approve the `itsaplan-images` build repo**, or pick a different path. Nothing deploys until this is settled.
2. **Confirm the two hostnames** — `itsaplan.${ROOT_DOMAIN}` and `itsaplan-api.${ROOT_DOMAIN}`. The api origin gets baked into the web image at build time, so this has to be right *before* the first build; changing it later means a rebuild, not an edit.
3. **The `Update.cs` crowdsec regression** is a live footgun independent of this PR — the next person who runs `task update` for any reason will silently drop the crowdsec role. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
