### PR TITLE
feat(longhorn): add snapshot-delete recurring job to bound snapshot chains

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/recurringjob.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/recurringjob.yaml
@@ -14,3 +14,26 @@ spec:
   retain: 0
   concurrency: 2
   labels: {}
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/longhorn.io/recurringjob_v1beta2.json
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: snapshot-delete
+  namespace: longhorn-system
+spec:
+  name: snapshot-delete
+  groups:
+    - default
+  # snapshot-cleanup only removes system-generated snapshots. CSI snapshots
+  # created by VolSync are userCreated=true, so nothing reclaimed them and they
+  # accumulated at ~1 per volume per day. snapshot-delete trims user-created
+  # snapshots beyond `retain` and purges, keeping the chain bounded.
+  task: snapshot-delete
+  cron: "0 11 * * *"
+  # VolSync syncs daily at 14:00 and clones the snapshot before reading it, so
+  # 3 days is well clear of any in-flight sync while staying under the
+  # snapshot-max-count setting of 5.
+  retain: 3
+  concurrency: 2
+  labels: {}


### PR DESCRIPTION
Follow-up to [vault#123](https://github.com/david-driscoll/vault/issues/123) and #2995.

## Why

#2995 changed `longhorn-snapclass` from `deletionPolicy: Retain` to `Delete`. That only affects **newly created** `VolumeSnapshotContent` objects — `deletionPolicy` is copied onto each VSC at creation and never re-read from the class — so it does nothing for the existing backlog, and nothing for the underlying Longhorn snapshots.

Investigating that backlog turned up the actual reason snapshot data accumulates: the existing `snapshot-cleanup` recurring job (added in `0b3b05082`) only removes **system-generated** snapshots. CSI snapshots created by VolSync are `userCreated: true`, so nothing ever reclaimed them. They were building up at roughly one per volume per day — the live chain showed a clean daily series at 14:00 matching the VolSync sync schedule.

## What

Adds a second `RecurringJob` with `task: snapshot-delete`, which trims user-created snapshots beyond `retain` and purges them.

- `retain: 3` — well clear of the 14:00 VolSync window (the mover clones the snapshot before reading it, so an in-flight sync is never at risk), and under the `snapshot-max-count` setting of `5`.
- `cron: "0 11 * * *"` — after the 10:00 `snapshot-cleanup`, well before the 14:00 sync.
- `concurrency: 2` — matches the existing job, keeps Longhorn control-plane load bounded given past instance-manager CPU saturation on `milky-way`.

## Validation

- `kubectl kustomize` builds clean; both documents render.
- `kubectl apply --dry-run=server` against the live cluster: `recurringjob.longhorn.io/snapshot-delete created (server dry run)`.

## Note on `snapshot-max-count`

The setting is `5`, but volumes were observed carrying 9–10 snapshots. Nothing is currently failing (all 39 equestria ReplicationSources synced on 2026-08-02), but the gap is worth a look separately — this PR brings the steady state back under the limit.

<!-- crew:agent=seraph -->