### PR TITLE
fix(openebs): stop marking openebs-hostpath as a default StorageClass

### DIFF
--- a/kubernetes/apps/openebs-system/openebs/values.yaml
+++ b/kubernetes/apps/openebs-system/openebs/values.yaml
@@ -5,7 +5,21 @@ localpv-provisioner:
   hostpathClass:
     enabled: true
     name: openebs-hostpath
-    isDefaultClass: true
+    # NOT default. `longhorn` is the sole default StorageClass on this cluster.
+    #
+    # Both classes used to carry storageclass.kubernetes.io/is-default-class=true.
+    # With two defaults the API server picks the most recently created one, so
+    # which class an unqualified PVC binds to depended on cluster history and
+    # could flip silently on any recreate (Helm upgrade, Flux prune-and-reapply,
+    # cluster rebuild). openebs-hostpath is node-local: no replication, no
+    # Longhorn snapshots, no VolSync coverage -- and the PVC still binds and the
+    # pod still starts, so nothing surfaces the difference until a node is lost.
+    #
+    # Setting this false makes the chart omit the annotation entirely; Helm's
+    # three-way merge removes it from the live StorageClass. The class itself
+    # stays available for anything that asks for it by name.
+    # See david-driscoll/vault#113.
+    isDefaultClass: false
     basePath: *basePath
 openebs-crds:
   csi:


### PR DESCRIPTION
Implements David's decision on david-driscoll/vault#113: *"Let's remove the default from openebs-hostpath"*.

## The problem

Equestria had **two** StorageClasses marked default:

```
longhorn           default=true   driver.longhorn.io   created 2026-05-09
openebs-hostpath   default=true   openebs.io/local     created 2026-03-09
```

With multiple defaults the API server picks the **most recently created** one, so which class an unqualified PVC binds to depends on cluster history rather than intent — and flips silently if either class is recreated (Helm upgrade, Flux prune-and-reapply, cluster rebuild).

`openebs-hostpath` is node-local: no replication, not reschedulable, invisible to Longhorn snapshots, not covered by any VolSync `ReplicationSource`. The PVC binds, the pod starts, everything reads healthy — and the data is unprotected until a node is lost or drained.

## The audit

**Zero PVCs and zero PVs on `openebs-hostpath` in this cluster.**

```
PVC by storageClassName          PV by storageClassName
  52 longhorn                      52 longhorn
  39 longhorn-cache                39 longhorn-cache
   4 longhorn-local                 4 longhorn-local
   4 nfs-csi                        4 nfs-csi
```

No accidental bindings and no intentional ones — so there is **nothing to migrate** and no follow-up issue is needed. The `openebs-localpv-provisioner` pod is running and has never provisioned a volume.

Nothing depends on the class being *default*: the only `openebs-hostpath` references in this repo are the chart value itself and a comment in `crowdsec/values.yaml` describing this very bug. Nothing requests the class by name.

`longhorn` (created later) is already the winning default, which is why the audit is clean. This change makes that deterministic rather than accidental.

## The change

`isDefaultClass: true` → `false` in the openebs Helm values. At `false` the chart omits the `storageclass.kubernetes.io/is-default-class` annotation entirely, and Helm's three-way merge removes it from the live StorageClass. The class stays available for anything that asks for it by name — this removes default status, not the class.

In git rather than `kubectl patch`, since Flux would revert an imperative patch on the next reconcile.

## Risk

Effectively nil. No existing volume changes class (StorageClass is immutable on a bound PVC regardless), no workload requests openebs by name, and the effective default for new PVCs is `longhorn` both before and after.

Does not interact with `snapshotMaxCount: 5` (sticky per-volume at creation) or the `deletionPolicy: Retain` fix in #2995.

## Merge order

Independent of the sgc twin (david-driscoll/stargate-command-cluster#1752) — same change, separate clusters, either order.

## Acceptance

- [x] Audit of PVCs bound to `openebs-hostpath` — none exist
- [x] Confirmed nothing depends on it being default
- [ ] Exactly one default StorageClass after merge — verified post-reconcile
- [x] No follow-up migration issue needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)