### PR TITLE
fix(openbao): correct the transit seal address and source the DB URL

### DIFF
--- a/kubernetes/apps/kube-system/openbao/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/openbao/externalsecret.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# BAO_PG_CONNECTION_URL, taken from the generated `${APP}-postgres` secret
+# rather than copied into secret.sops.yaml. `task update` writes that role's
+# password once, in passwords.sops.yaml; a second hand-maintained copy would
+# fork from it the next time the role rotates and nothing would catch the
+# mismatch until OpenBao failed to reach its own storage.
+#
+# The `uri` key is already exactly the form the Postgres backend wants:
+#   postgres://openbao:<pw>@postgres-rw.database.svc.cluster.local:5432/openbao?sslmode=disable
+#
+# This does NOT reintroduce the bootstrap cycle the ks.yaml comment warns about.
+# ClusterSecretStore/database is a `kubernetes` provider reading the `database`
+# namespace directly — it is not backed by 1Password and will not be backed by
+# OpenBao, so OpenBao is never a link in the chain that starts OpenBao. The only
+# new coupling is ordering: external-secrets must be running first, which is why
+# it is now a dependsOn in ks.yaml.
+#
+# The transit token has no such source and stays in secret.sops.yaml.
+#
+# Named `-storage`, not `-postgres`: the generated secret this reads from is
+# already called `openbao-postgres` over in the `database` namespace, and two
+# different objects under one name across two namespaces is a trap.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-storage
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-storage
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        pg-connection-url: "{{ .postgres_uri }}"
+  dataFrom:
+    - extract:
+        key: ${APP}-postgres
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -72,15 +72,29 @@ spec:
           seal "transit" {
             // token comes from VAULT_TRANSIT_SEAL_TOKEN.
             //
-            // The address is not secret — it is the alpha-site Tailscale IP
-            // already carried in shared-secrets — so Flux postBuild substitutes
-            // it here instead of it costing another secret key.
+            // The address is not secret, and it is deliberately a MagicDNS name
+            // rather than a tailnet IP. Pods here have no route to the tailnet —
+            // both 100.111.10.9:8200 and 100.111.10.200:8200 were probed from a
+            // pod in this namespace and neither is reachable. Tailnet hosts are
+            // reached only through the tailscale-operator egress Services in
+            // tailscale-system, and the operator's nameserver resolves the
+            // MagicDNS name to that egress proxy's ClusterIP: from a pod,
+            // dockge-as.opossum-yo.ts.net and
+            // dockge-as.tailscale-system.svc.cluster.local both answer
+            // 10.196.81.163. The egress proxy forwards only the ports declared
+            // in the Service's spec.ports, so 8200 is declared for dockge-as in
+            // apps/tailscale-system/services/Update.cs.
+            //
+            // This previously read "http://${ALPHA_SITE_TAILSCALE_IP}:8200",
+            // which was wrong twice: that variable is the alpha-site Proxmox
+            // host, while bao-transit runs in the dockge-as LXC — and a raw
+            // tailnet IP could not have worked from a pod regardless.
             //
             // Careful: leaving the address unset would NOT be harmless. The
             // wrapper falls back to api.DefaultConfig(), which reads BAO_ADDR /
             // VAULT_ADDR — pointing the seal at this pod's own listener and
             // deadlocking the unseal. It must be set explicitly.
-            address    = "http://${ALPHA_SITE_TAILSCALE_IP}:8200"
+            address    = "http://dockge-as.${TAILSCALE_DOMAIN}:8200"
             key_name   = "openbao-equestria-unseal"
             mount_path = "transit/"
             disable_renewal = "false"
@@ -89,13 +103,20 @@ spec:
           // Lets OpenBao label its own pods active/standby so the chart's
           // -active and -standby Services route correctly.
           service_registration "kubernetes" {}
-      # Sourced from secret.sops.yaml, NOT from external-secrets. OpenBao would
-      # otherwise need a working SecretStore in order to start, and after the
-      # 1Password cutover the only SecretStore is OpenBao itself. SOPS is the
-      # one source guaranteed available before OpenBao is.
+      # Two different sources, on purpose.
+      #
+      # The connection URL comes from externalsecret.yaml, which reads the
+      # generated `openbao-postgres` secret through ClusterSecretStore/database
+      # — a `kubernetes` provider, not 1Password and not OpenBao, so this is not
+      # the bootstrap cycle. One source of truth for that password means it
+      # rotates without a second edit.
+      #
+      # The transit token comes from secret.sops.yaml because nothing in the
+      # cluster can produce it: it is minted against bao-transit on alpha-site.
+      # SOPS is the one source guaranteed available before OpenBao is.
       extraSecretEnvironmentVars:
         - envName: BAO_PG_CONNECTION_URL
-          secretName: openbao-seal
+          secretName: openbao-storage
           secretKey: pg-connection-url
         - envName: VAULT_TRANSIT_SEAL_TOKEN
           secretName: openbao-seal

--- a/kubernetes/apps/kube-system/openbao/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao/ks.yaml
@@ -16,22 +16,51 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/kube-system/openbao
   # Storage is the shared CNPG cluster, so postgres has to be up first.
-  # external-secrets is NOT a dependency: OpenBao's own server config comes from
-  # secret.sops.yaml, never from a SecretStore. Booting the secret store from a
-  # secret store is the loop this whole migration exists to remove.
+  #
+  # external-secrets IS a dependency, for the Postgres connection URL only. That
+  # is not the loop this migration exists to remove: ClusterSecretStore/database
+  # is a `kubernetes` provider reading the `database` namespace directly, so it
+  # is not backed by 1Password today and will not be backed by OpenBao later —
+  # OpenBao is never a link in the chain that starts OpenBao. The seal token,
+  # which genuinely has no in-cluster source, still comes from secret.sops.yaml.
+  #
+  # tailscale-services is a dependency because the unseal path runs through it:
+  # these pods reach bao-transit on alpha-site only via the tailscale-operator
+  # egress Service for dockge-as, and that Service forwards port 8200 only
+  # because it is declared in apps/tailscale-system/services/Update.cs. Without
+  # this ordering the pods can come up before the port exists and sit
+  # crash-looping on a seal they cannot reach.
   dependsOn:
     - name: postgres
       namespace: database
-  # SUSPENDED UNTIL BOOTSTRAP IS COMPLETE. Unsuspend only after all three hold:
-  #   1. `bao-transit` is running on alpha-site and its transit key exists
-  #      (migration Phase 2) — without it these pods cannot unseal.
-  #   2. `task update` has been run, so the `openbao` role exists in
-  #      kubernetes/apps/database/postgres/app/resources/values.yaml and its
-  #      password in passwords.sops.yaml. The components entry below is what
-  #      makes components/postgres/Update.cs discover this app.
-  #   3. secret.sops.yaml exists here (see kustomization.yaml).
-  # Reconciling before then leaves a StatefulSet crash-looping against a
-  # database that does not exist.
+    # The stores ks, not the controller ks — ClusterSecretStore/database is
+    # defined there. Note it currently dependsOn onepassword-connect, so until
+    # Phase 11 drops that, OpenBao transitively waits on 1Password Connect at
+    # boot. Irritating but not circular, and it resolves itself at cutover.
+    - name: external-secrets-stores
+      namespace: kube-system
+    - name: tailscale-services
+      namespace: tailscale-system
+  # SUSPENDED UNTIL BOOTSTRAP IS COMPLETE. All four preconditions now hold:
+  #   1. DONE — `bao-transit` is initialised and unsealed on alpha-site, with
+  #      the transit key `openbao-equestria-unseal` and the `equestria-unseal`
+  #      policy in place (migration Phase 2).
+  #   2. DONE — `task update` has been run: the `openbao` role exists in
+  #      kubernetes/apps/database/postgres/app/resources/values.yaml, its
+  #      password in passwords.sops.yaml, and the generated `openbao-postgres`
+  #      secret is live in the `database` namespace. The components entry below
+  #      is what makes components/postgres/Update.cs discover this app — do not
+  #      remove it as a tidy-up, it silently drops the whole database.
+  #   3. DONE — secret.sops.yaml exists here with the transit token, and
+  #      externalsecret.yaml supplies the connection URL.
+  #   4. DONE — port 8200 is declared on the dockge-as egress Service, so these
+  #      pods can actually reach bao-transit. Verified by port-scanning the
+  #      egress proxy from a pod in this namespace.
+  #
+  # What remains is the deliberate go-live decision. Flipping this to `false`
+  # creates the StatefulSet, which will initialise the `openbao` database and
+  # take the transit seal live. Reverting after that point is no longer just a
+  # `git revert` — the database will have been written to.
   suspend: true
   prune: true
   wait: true

--- a/kubernetes/apps/kube-system/openbao/kustomization.yaml
+++ b/kubernetes/apps/kube-system/openbao/kustomization.yaml
@@ -7,25 +7,24 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./definition.yaml
-  # - ./secret.sops.yaml
+  - ./externalsecret.yaml
+  - ./secret.sops.yaml
   #
-  # Deliberately not listed yet — the file does not exist. It carries a Secret
-  # named `openbao-seal` with exactly two keys:
+  # The two secret-bearing values arrive by different routes, and the split is
+  # deliberate:
   #
-  #   pg-connection-url  postgres://openbao:<password>@postgres-rw.database.svc.cluster.local:5432/openbao
-  #                      → BAO_PG_CONNECTION_URL. Password is the one `task
-  #                        update` writes into
-  #                        kubernetes/apps/database/postgres/app/passwords.sops.yaml
-  #                        for the `openbao` role.
+  #   externalsecret.yaml  pg-connection-url → BAO_PG_CONNECTION_URL, read from
+  #                        the generated `openbao-postgres` secret via
+  #                        ClusterSecretStore/database. Not copied, so it
+  #                        rotates with the role.
   #
-  #   transit-token      The OpenBao token for bao-transit on alpha-site
-  #                      → VAULT_TRANSIT_SEAL_TOKEN. Should be an orphan
-  #                        periodic token with only update on
+  #   secret.sops.yaml     transit-token → VAULT_TRANSIT_SEAL_TOKEN. An orphan
+  #                        periodic token carrying only update on
   #                        transit/encrypt/openbao-equestria-unseal and
-  #                        transit/decrypt/openbao-equestria-unseal.
+  #                        transit/decrypt/openbao-equestria-unseal. Minted
+  #                        against bao-transit; nothing here can regenerate it,
+  #                        so it is mirrored at
+  #                        vault/bootstrap/openbao/transit-token.sops.yaml per
+  #                        that repo's INVENTORY.md.
   #
   # Everything else about the server config is plaintext in helmrelease.yaml.
-  #
-  # Uncomment this and drop `suspend: true` from ks.yaml in the same commit —
-  # the pods cannot unseal without it. Mirror both values into
-  # vault/bootstrap/openbao/ per that repo's INVENTORY.md.

--- a/kubernetes/apps/kube-system/openbao/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/openbao/secret.sops.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/secret.json
+#
+# The one value OpenBao needs that nothing in the cluster can produce for it.
+#
+#   transit-token -> VAULT_TRANSIT_SEAL_TOKEN  (go-kms-wrapping transit_client.go:31)
+#
+# Minted against bao-transit on alpha-site by vault/bootstrap/openbao/bao-transit.sh
+# and mirrored at vault/bootstrap/openbao/transit-token.sops.yaml. It is orphan
+# and periodic (768h); the transit wrapper renews it itself via a LifetimeWatcher,
+# so it does not expire while any pod is running.
+#
+# BAO_PG_CONNECTION_URL is NOT here — see externalsecret.yaml. Copying that
+# password into this file would fork it from the generated `openbao-postgres`
+# secret and silently drift the next time the role is rotated.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-seal
+type: Opaque
+stringData:
+  transit-token: ENC[AES256_GCM,data:g0sDOtTT1jlHHyQSNWFw10V6QdHDeVTa0yM=,iv:/HNJkcKkQOPgsNGbozDYlcKEOpMWms5mBclA9H22moE=,tag:MPhF+RXQ/4gCV56zC3JXwg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0UFhBRytjTEZFSjNUa242
+        VURuK1p1cmo5RFUrRVlaY2NYRnFVYmUwY2gwCk5ubHhJRzRaN0Z3WUJUWHR6cFZ2
+        U1FBSC9rYXNWVWRYenY1ZTV2MVJLQTAKLS0tIEIzWlppSUtnSUZYOGVOMENiQVpq
+        bTBjRTFFbExSUmFpRkhndXJwZFZ6SEEKthjxpzj2kBA/72gz/ob5tfmjCCyTIp0j
+        U/mAW2+V5XbB96SU3UHOWJzNqomrVI7eN2QGrRBTvziR6V/7FCiVJg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjSTFmMmxGSndJY2RKVGwv
+        cm56RitUMzFFV0FLbmczMkhHYzB6SnBPelFzCnVTM2k5MmFMYkh0T0E0LzJsbzVy
+        WlAzWEtEaSsvWjE0MXdyMVJtdWlFN00KLS0tIHZvRzAwVjdPWGZYOGxVSVNBc3R0
+        elgrVVRhWjY5a0xXZjVxd0o5dU5rVzAKvcZYESCS9KS7qqatulU40Ahn/PV32hJd
+        R4fUe2JriRXxJ5zBd3m4X0JyJXYPiakR91gUgya8inlPPCyYnVVXeA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxU25EYUIzL3R4dHdUZXpI
+        OUlHd29VaW5EaDdINjlvN1lvVWpPaGVPRGdRCm13aEpBNTBMaTQzc1gxemhtbFE1
+        UEpkTG9YeFowb1ltQWFRaUZQVEo2YVUKLS0tIFlNQ1NudUxaZmErSzU3eVhmdlps
+        SWRHUEZGVWdxUkJ1N29Ha0Z0L25KT2cK6pDzml+8vmhymFb6rvW9EABdCRinP1fM
+        Cdk9/vFMeP93ZYe1QdPWxfpQq/L7B+a/6ywrD8bIkBJW1Y9mMPG7kQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-07T17:22:26Z"
+  mac: ENC[AES256_GCM,data:11kHY48I0RNRy8iSX2mhvKTU+8pr88kNx228bjJgDOTJDLz9lD3dw9QigIbe8N+vtXxkCd4qIt9aJZX/yx3Fwk8HN0QQbIBcRMFEuf3gk51DHJlHShWEpifIwWYFZiDi0jmTYNiV4zMLoGN9RnOuwzxKPUFsF83vhJZUVUXTB9Y=,iv:KQgPngAAadZgqFDmtNPCtMTxRaVREVLrDqfOYnoWM2o=,tag:QyvDZ92i90UYhuMHa7QmYg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/tailscale-system/services/Update.cs
+++ b/kubernetes/apps/tailscale-system/services/Update.cs
@@ -71,10 +71,19 @@ var extraPorts = new Dictionary<string, Dictionary<ServiceKind, PortDef[]>>
   {
     [ServiceKind.Proxmox] = [new("nut", 3493, false, null)],
   },
-  // as hosts a primary adguard host on 4000
+  // as hosts a primary adguard host on 4000, and bao-transit — the estate's
+  // seal root — on 8200. OpenBao in kube-system dials 8200 through this egress
+  // service to auto-unseal; pods have no route to tailnet IPs directly, so
+  // without this port declared the cluster can never unseal. No probe: the
+  // probe helper always builds an https:// URL and bao-transit runs
+  // tls_disable, so a probe here would report a false failure. Its health is
+  // already covered by the Gatus check in the bao-transit stack definition.
   ["as"] = new()
   {
-    [ServiceKind.Dockge] = [new("adguard", 4000, false, null)]
+    [ServiceKind.Dockge] = [
+      new("adguard", 4000, false, null),
+      new("bao", 8200, false, null),
+    ]
   },
   // luna hosts the Home Assistant voice pipeline: llama.cpp (gemma-4-E2B) on
   // 8080 and wyoming whisper/piper STT/TTS on 10300/10200. HA runs on this

--- a/kubernetes/apps/tailscale-system/services/as.yaml
+++ b/kubernetes/apps/tailscale-system/services/as.yaml
@@ -22,6 +22,9 @@ spec:
     - name: adguard
       port: 4000
       targetPort: 4000
+    - name: bao
+      port: 8200
+      targetPort: 8200
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe


### PR DESCRIPTION
Unblocks unsuspending OpenBao. Depends on david-driscoll/vault#147, which mints the transit token this consumes — **merge that first.**

Still `suspend: true`. Unsuspending is a deliberate go-live and is left as its own commit.

## The seal address was wrong twice over

Both found by probing from inside the cluster, not by reading the manifest.

**Wrong host.** `ALPHA_SITE_TAILSCALE_IP` is `100.111.10.200`, the alpha-site *Proxmox host*. `bao-transit` runs in the `dockge-as` LXC and publishes on `100.111.10.9:8200`.

**Wrong form.** A raw tailnet IP could not have worked regardless — pods here have no route to the tailnet. Both addresses were probed from a pod in `kube-system`; neither is reachable. Tailnet hosts are reached only through the tailscale-operator egress Services, which forward just the ports declared in `spec.ports`. Port-scanning the `dockge-as` egress from a pod:

```
443=OPEN  22=OPEN  4000=CLOSED  8200=CLOSED
```

So 8200 is now declared on that Service, and the seal dials `http://dockge-as.${TAILSCALE_DOMAIN}:8200`. The MagicDNS name resolves in-cluster to the egress proxy's ClusterIP — from a pod, `dockge-as.opossum-yo.ts.net` and `dockge-as.tailscale-system.svc.cluster.local` both answer `10.196.81.163`.

`as.yaml` is generated, so the port went in through `Update.cs`. I ran that one generator alone rather than `task update`, which fires *every* `Update.cs` in the repo — it touched exactly one file, +3 lines. No probe on the port: the probe helper always builds an `https://` URL and bao-transit runs `tls_disable`, so it would report a false failure. Health is already covered by the Gatus check in the bao-transit stack definition.

`ALPHA_SITE_TAILSCALE_IP` is deliberately left defined — Phase 5's replication CronJob needs it.

## The Postgres URL is referenced, not copied

The plan had `pg-connection-url` hand-written into `secret.sops.yaml`, with the password also mirrored into the vault repo. `task update` regenerates that password, so both copies would have drifted silently on the next rotation and nothing downstream would have caught it until OpenBao could not reach its own storage.

`externalsecret.yaml` now pulls the ready-made `uri` key out of the generated `openbao-postgres` secret via `ClusterSecretStore/database`, which already carries exactly the right form.

**This is not the bootstrap cycle the `ks.yaml` comment warns about.** `ClusterSecretStore/database` is a `kubernetes` provider reading the `database` namespace directly — not backed by 1Password today, and not by OpenBao later. OpenBao is never a link in the chain that starts OpenBao.

The only new coupling is ordering, so `dependsOn` now covers `external-secrets-stores` and — because the unseal path runs through it — `tailscale-services`.

One wrinkle: `external-secrets-stores` currently `dependsOn` `onepassword-connect`, so until Phase 11 drops that, OpenBao transitively waits on 1Password Connect at boot. Irritating, not circular, and it resolves itself at cutover.

The transit token stays in `secret.sops.yaml` — nothing in the cluster can mint it.

## Validation

- `flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets` — **327 passed, 2 skipped, 0 errors** (up from 325/3; the openbao skip is gone), run with `suspend` flipped locally so the app actually renders
- `eso-values-lint` — 37 files checked, **0 findings**
- rendered `openbao-storage` / `openbao-seal` names line up with the HelmRelease env wiring
- `${TAILSCALE_DOMAIN}` confirmed in scope via the global `substituteFrom` patch in `kubernetes/flux/cluster/ks.yaml`

## One thing that could not be verified in advance

The egress port could not be tested before merge — patching the live Service was declined by the sandbox, and Flux will not create the port until this lands. **The first real proof that the unseal path works is the pods coming up.** If they crash-loop on the seal, check in this order:

```
kubectl -n tailscale-system get svc dockge-as -o jsonpath='{.spec.ports[*].name}'   # expect a `bao` port
nc -z dockge-as.opossum-yo.ts.net 8200                                              # from a pod
```

then the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)