### PR TITLE
feat(openbao): unsuspend — take the transit seal live

### DIFF
--- a/kubernetes/apps/kube-system/openbao/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao/ks.yaml
@@ -61,7 +61,7 @@ spec:
   # creates the StatefulSet, which will initialise the `openbao` database and
   # take the transit seal live. Reverting after that point is no longer just a
   # `git revert` — the database will have been written to.
-  suspend: true
+  suspend: false
   prune: true
   wait: true
   force: false


### PR DESCRIPTION
Flips `suspend: true` → `false` on the openbao Kustomization. One line.

**This is the go-live.** Reconciling creates the StatefulSet, initialises the `openbao` database, and takes the transit seal live. From here rollback is no longer just a `git revert` — the database will have been written to.

## The gap from the last PR is now closed

equestria-cluster#3052 shipped with one thing unverifiable: the egress port could not be tested before merge. It has now been tested, and it turned out to need a **second** fix that only became visible once the port existed.

The egress Service declaring port 8200 was necessary but not sufficient. The `tailnet-inbound` ProxyGroup devices carry `tag:egress`, and no tailnet grant covered `tag:egress → tag:dockge` on 8200 — the `tag:management → tag:dockge` grant lists 22/5001/2022/2375/8082/4000/53443/2049/111, and nothing else came close. So the packets were being forwarded by the proxy and then dropped in the ACL, which looks exactly like a misconfigured seal address.

Fixed in home-operations `61c0075e` (`baoTransit: ["tcp:8200"]` + an `openbao-transit-unseal` grant, modelled on the existing `home-assistant-wyoming` grant). Kept as its own port set rather than folded into `dockgeManagement`, which is granted broadly — this is the key that unseals the estate.

With both in place, from a pod in `kube-system`:

```
http://dockge-as.opossum-yo.ts.net:8200/v1/sys/seal-status -> 200, first try
```

## Preconditions, all verified

| | |
|---|---|
| `bao-transit` initialised and unsealed | seal type `static`, recovery 3-of-5 |
| transit key + policy exist | `openbao-equestria-unseal`, `equestria-unseal` |
| seal token works and is scoped | encrypt/decrypt only; cannot list, read, or export |
| token survives | orphan, renewable, period 768h, no max TTL, `renew-self` OK |
| `openbao` DB role exists | `task update` already run; secret live in `database` ns |
| connection URL wired | `externalsecret.yaml` → `uri` key, not a copy |
| egress port declared | `dockge-as` Service has `bao=8200` |
| **tailnet grant present** | **`tag:egress → tag:dockge` on 8200** |

`flate test all` — 327 passed, 2 skipped, 0 errors.

## What to watch after merge

```
kubectl -n kube-system get pods -l app.kubernetes.io/name=openbao -w
kubectl -n kube-system logs -l app.kubernetes.io/name=openbao --tail=50
```

Expect the StatefulSet to come up and unseal without manual intervention — a static-seal-backed transit unseal means no `bao operator unseal` step. If it crash-loops, the seal is the first place to look; the reachability check above is the one to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)