### PR TITLE
feat(openbao): OIDC login — Authentik client + TEMPORARY generate-root listener toggle

### DIFF
--- a/kubernetes/apps/kube-system/openbao/definition.yaml
+++ b/kubernetes/apps/kube-system/openbao/definition.yaml
@@ -9,7 +9,29 @@ spec:
   category: Applications
   description: Secrets management — source of truth for the estate
   url: https://bao.${CLUSTER_DOMAIN}
-  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/vault.svg
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/openbao.svg
+  access_policy:
+    groups:
+      - admins
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        # The UI login callback. The path segment appears twice by design:
+        # /auth/<mount-path>/oidc/callback with the default mount path "oidc".
+        - url: "https://bao.${CLUSTER_DOMAIN}/ui/vault/auth/oidc/oidc/callback"
+        # `bao login -method=oidc` runs a local listener on 8250 for the CLI flow.
+        - url: "http://localhost:8250/oidc/callback"
+      propertyMappings:
+        - email
+        - openid
+        # profile carries the `groups` claim, which the OpenBao roles bind on:
+        # admins -> policy admin, family -> policy viewer (see
+        # vault:bootstrap/openbao/equestria-init.sh `oidc`).
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
   gatus:
     # Probe the health endpoint rather than the UI root, which redirects.
     # standbyok=true so a standby answering the probe reports 200 instead of

--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -60,6 +60,22 @@ spec:
             // TLS terminates at the internal gateway and this listener is only
             // reachable in-cluster, matching the other kube-system services.
             tls_disable = true
+
+            // ██ TEMPORARY BOOTSTRAP TOGGLE — REVERT AFTER THE OIDC BOOTSTRAP ██
+            //
+            // OpenBao >= 2.5.3 disables the unauthenticated sys/generate-root/*
+            // endpoints by default — they 403 even from localhost inside the
+            // pod, so the recovery shares alone cannot mint a root token (see
+            // vault:docs/openbao-migration/STATUS.md, "Facts established the
+            // hard way"). The OIDC setup run
+            // (vault:bootstrap/openbao/equestria-init.sh oidc) regenerates a
+            // root token from those shares and needs this toggle live to do it.
+            //
+            // REVERT THIS LINE in a follow-up commit as soon as the OIDC
+            // bootstrap completes — do not leave generate-root reachable
+            // unauthenticated. The pods must roll for the revert to take
+            // effect, same as for this commit.
+            disable_unauthed_generate_root_endpoints = false
           }
 
           storage "postgresql" {


### PR DESCRIPTION
## What

Two pieces enabling human OIDC login to OpenBao (`admins` → policy `admin`, `family` → read-only `viewer`):

1. **ApplicationDefinition**: Authentik OAuth2 client for openbao — confidential, redirect URIs for the UI callback (`/ui/vault/auth/oidc/oidc/callback`) and the CLI's localhost:8250 listener, `email`/`openid`/`profile` mappings (profile carries the `groups` claim the OpenBao roles bind on), claims in the id_token, `subMode: user_email`. Access groups: `admins`, `family`.
2. **HelmRelease — ⚠️ TEMPORARY listener toggle**: `disable_unauthed_generate_root_endpoints = false`. OpenBao ≥ 2.5.3 403s generate-root by default, and the one-time OIDC bootstrap needs a root token regenerated from the recovery shares. **This must be reverted in a follow-up commit immediately after the bootstrap completes** (step 4 of the runbook below).

## Go-live order (also in vault repo STATUS.md, 'OIDC bootstrap — ready to execute')

1. Merge this PR → Flux rolls the openbao pods with the toggle live
2. Run/reconcile the home-operations `applications` Pulumi stack → Authentik provider + `equestria-openbao-oidc-credentials` item
3. `vault:bootstrap/openbao/equestria-init.sh oidc` with `OPENBAO_OIDC_CLIENT_ID`/`_SECRET`/`_DISCOVERY_URL` from that item
4. **Revert the toggle commit**, pods roll again
5. Verify UI login as an `admins` member and a `family` member

## Verification

flux-local (`--skip-invalid-kustomization-paths`): 226 passed; the 19 failures are identical on unmodified baseline (flux-local 8.2.0 mishandles digest-pinned OCI refs) — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)