### PR TITLE
revert(openbao): drop TEMPORARY generate-root toggle — MERGE IMMEDIATELY AFTER OIDC BOOTSTRAP (follow-up to #3067)

### DIFF
--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -60,22 +60,6 @@ spec:
             // TLS terminates at the internal gateway and this listener is only
             // reachable in-cluster, matching the other kube-system services.
             tls_disable = true
-
-            // ██ TEMPORARY BOOTSTRAP TOGGLE — REVERT AFTER THE OIDC BOOTSTRAP ██
-            //
-            // OpenBao >= 2.5.3 disables the unauthenticated sys/generate-root/*
-            // endpoints by default — they 403 even from localhost inside the
-            // pod, so the recovery shares alone cannot mint a root token (see
-            // vault:docs/openbao-migration/STATUS.md, "Facts established the
-            // hard way"). The OIDC setup run
-            // (vault:bootstrap/openbao/equestria-init.sh oidc) regenerates a
-            // root token from those shares and needs this toggle live to do it.
-            //
-            // REVERT THIS LINE in a follow-up commit as soon as the OIDC
-            // bootstrap completes — do not leave generate-root reachable
-            // unauthenticated. The pods must roll for the revert to take
-            // effect, same as for this commit.
-            disable_unauthed_generate_root_endpoints = false
           }
 
           storage "postgresql" {


### PR DESCRIPTION
## What

Reverts the `disable_unauthed_generate_root_endpoints = false` line that #3067 added to the OpenBao tcp listener stanza. Nothing else — the Authentik OAuth2 client that #3067 added to `definition.yaml` stays exactly as merged.

16 deletions, one file: `kubernetes/apps/kube-system/openbao/helmrelease.yaml`.

## Why this is a draft

**This PR is the second half of #3067 and must not merge before the OIDC bootstrap has actually run.** It is a draft purely so that cannot happen by accident.

#3067 opened the unauthenticated `sys/generate-root/*` endpoints because OpenBao >= 2.5.3 403s them by default, and the OIDC setup run needs to mint a root token from the recovery shares. That is the *only* reason the toggle exists. Until `vault:bootstrap/openbao/equestria-init.sh oidc` has completed successfully against the live cluster, merging this would break the bootstrap. After it completes, every minute this stays unmerged is unnecessary exposure on the estate's secrets store.

## Ordering

The go-live sequence (`vault:docs/openbao-migration/STATUS.md`):

1. ~~Merge #3067 → Flux rolls the pods with the toggle live~~ (merged 2026-08-08)
2. Run the home-operations `applications` Pulumi stack → creates the Authentik provider + the `equestria-openbao-oidc-credentials` 1Password item
3. Run `vault:bootstrap/openbao/equestria-init.sh oidc`
4. **← this PR.** Mark ready, merge, let the pods roll again
5. Verify OIDC UI login for an `admins` member and a `family` member

## Merge checklist

- [ ] `equestria-init.sh oidc` has completed successfully
- [ ] `equestria-init.sh status` shows the `oidc` auth method enabled with the `admin` and `family` roles bound
- [ ] Mark this PR ready for review, then merge
- [ ] Confirm the pods rolled and `sys/generate-root/attempt` 403s again

Refs #3067.
