### PR TITLE
feat(openbao): Phase 5 break-glass replication — nightly dump + monthly restore test

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
   - ./headlamp/ks.yaml
   - ./multus/ks.yaml
   - ./openbao/ks.yaml
+  - ./openbao-replica/ks.yaml

--- a/kubernetes/apps/kube-system/openbao-replica/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/externalsecret.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# PG_URI for the nightly dump — the same generated `openbao-postgres` uri the
+# openbao app itself consumes, read through ClusterSecretStore/database.
+# Referenced, never copied: it rotates with the role and nothing here needs a
+# second edit (see the openbao app's externalsecret.yaml for the full
+# reasoning, including why this is not a bootstrap cycle).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-replica-db
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: openbao-replica-db
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        PG_URI: "{{ .uri }}"
+  dataFrom:
+    - extract:
+        key: openbao-postgres
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# The estate's rclone SFTP client key. This is the SAME keypair
+# home-operations' DockgeLxc seeds onto every dockge host: its public half is
+# already in /opt/stacks-data/rclone-sftp/keys/authorized_keys on dockge-as,
+# which the bao-standby dump receiver mounts read-only — so shipping dumps
+# needs no new key material anywhere.
+#
+# Store ref is onepassword-connect, deliberately: 1Password stays the
+# authoritative store until Phase 11, and ClusterSecretStore/openbao does not
+# exist until the Phase 6 ESO cutover. Swap the ref then, with all the others.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-replica-sftp
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  target:
+    name: openbao-replica-sftp
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        # OpenSSH refuses a key file without a trailing newline; DockgeLxc
+        # appends one for the same reason (DockgeLxc.ts:247).
+        id_ed25519: |
+          {{ .private_key }}
+  dataFrom:
+    - extract:
+        key: "Rclone SFTP Key"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _

--- a/kubernetes/apps/kube-system/openbao-replica/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/helmrelease.yaml
@@ -1,0 +1,253 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# Phase 5 break-glass replication — two cronjobs, one trust boundary:
+#
+#   dump          nightly: pg_dump the `openbao` database, age-encrypt it to
+#                 the three estate recipients, ship it to the bao-standby dump
+#                 receiver on alpha-site over SFTP, prune to 30 days.
+#
+#   restore-test  monthly: pull the newest dump BACK from alpha-site, decrypt,
+#                 restore into a scratch Postgres sidecar, start a throwaway
+#                 bao against it, let it unseal via transit, read a canary key
+#                 with a purpose-made AppRole, and report to Gatus. An
+#                 unverified backup is not a backup (RUNBOOK Scenario D).
+#
+# Both run HERE, not on alpha-site, and that placement is load-bearing: the
+# dump must never be decryptable on alpha-site alone (that host also holds the
+# transit key), so no age identity may ever land there. The cluster already
+# holds an age identity (Flux's sops-age), so decrypting here adds no new
+# exposure — and the restore test doubles as proof the dump actually left the
+# building and can be fetched back.
+#
+# Both containers use the OpenBao image: the restore test needs the `bao`
+# binary anyway, the dump job gets an image the estate already pins, and the
+# missing client tools (pg_dump/psql 17, age, rclone, curl, jq) are installed
+# at runtime — the same pattern as the postgres-backup cronjob in
+# database/postgres/backups.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app openbao-replica
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: openbao
+      namespace: kube-system
+    - name: external-secrets
+      namespace: kube-system
+  values:
+    controllers:
+      dump:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: cronjob
+        cronjob:
+          # PLAN §E: nightly at 03:00, an hour after the general postgres
+          # backup at 02:00 so the two never contend for the database.
+          schedule: "0 3 * * *"
+          backoffLimit: 3
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 300
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          suspend: false
+        containers:
+          main:
+            image: &baoImage
+              repository: ghcr.io/openbao/openbao
+              tag: 2.6.1@sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
+              pullPolicy: IfNotPresent
+            # Root: apk needs it. kube-system is a privileged-PSS namespace.
+            securityContext: &rootCtx
+              runAsUser: 0
+              runAsGroup: 0
+            envFrom:
+              # PG_URI — the generated `openbao-postgres` uri, referenced via
+              # ClusterSecretStore/database exactly like the openbao app itself.
+              - secretRef:
+                  name: openbao-replica-db
+            env:
+              SFTP_HOST: dockge-as.${TAILSCALE_DOMAIN}
+              SFTP_PORT: "2023"
+              SFTP_KEY_FILE: /secrets/sftp/id_ed25519
+              RETENTION_DAYS: "30"
+              GATUS_URL: https://uptime.${ROOT_DOMAIN}
+              # Pods have no route to the tailnet and no DNS answer for
+              # uptime.${ROOT_DOMAIN} that they can reach — Gatus is reported
+              # to through the dockge-as egress on 443, with --connect-to
+              # keeping the Host/SNI intact so Traefik routes and the LE cert
+              # validates.
+              GATUS_CONNECT_TO: uptime.${ROOT_DOMAIN}:443:dockge-as.${TAILSCALE_DOMAIN}:443
+              GATUS_TOKEN: openbao-break-glass_nightly-dump
+            command:
+              - /bin/sh
+              - -c
+              - >-
+                set -eu;
+                apk add --no-cache bash postgresql17-client age rclone curl
+                && exec bash /scripts/dump.sh
+            resources:
+              requests:
+                memory: 256Mi
+                cpu: 20m
+              limits:
+                memory: 512Mi
+                cpu: 500m
+
+      restore-test:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: cronjob
+        cronjob:
+          # Monthly, two hours after that night's dump.
+          schedule: "0 5 1 * *"
+          backoffLimit: 2
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 3600
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          suspend: false
+        initContainers:
+          # Native sidecar (restartPolicy: Always on an init container): stays
+          # up while main runs, dies with the pod, and — unlike a plain second
+          # container — does not stop the Job from ever completing.
+          postgres:
+            image:
+              # Same major as the CNPG cluster (17.5) so the restored dump is
+              # read by the engine version that wrote it.
+              repository: docker.io/library/postgres
+              tag: 17.5-alpine@sha256:6567bca8d7bc8c82c5922425a0baee57be8402df92bae5eacad5f01ae9544daa
+              pullPolicy: IfNotPresent
+            restartPolicy: Always
+            env:
+              # Scratch database, lives exactly as long as this pod, holds
+              # only ciphertext OpenBao already encrypted. The password guards
+              # nothing an attacker inside the pod does not already have.
+              POSTGRES_USER: &scratchUser openbao
+              POSTGRES_PASSWORD: &scratchPw restore-test
+              POSTGRES_DB: &scratchDb openbao
+            resources:
+              requests:
+                memory: 256Mi
+                cpu: 50m
+              limits:
+                memory: 1Gi
+                cpu: "1"
+        containers:
+          main:
+            image: *baoImage
+            securityContext: *rootCtx
+            env:
+              SFTP_HOST: dockge-as.${TAILSCALE_DOMAIN}
+              SFTP_PORT: "2023"
+              SFTP_KEY_FILE: /secrets/sftp/id_ed25519
+              GATUS_URL: https://uptime.${ROOT_DOMAIN}
+              GATUS_CONNECT_TO: uptime.${ROOT_DOMAIN}:443:dockge-as.${TAILSCALE_DOMAIN}:443
+              GATUS_TOKEN: openbao-break-glass_restore-test
+              # The estate age identity, from the same Secret/sops-age the
+              # common component stamps into every namespace for Flux. The
+              # cluster already holds this material; mounting it here adds no
+              # new exposure — and it is exactly the key RUNBOOK Scenario B
+              # says a human will use, so the test exercises the real path.
+              AGE_KEY_FILE: /secrets/sops-age/age.agekey
+              # A dump older than this is treated as a FAILED test even if it
+              # restores cleanly — it means replication has silently stopped
+              # and the "latest" backup is stale.
+              MAX_DUMP_AGE_DAYS: "3"
+              SCRATCH_PG_URI: postgres://openbao:restore-test@localhost:5432/openbao
+              SCRATCH_PG_USER: *scratchUser
+              SCRATCH_PG_PASSWORD: *scratchPw
+              SCRATCH_PG_DB: *scratchDb
+              # Same transit path the real cluster unseals through.
+              TRANSIT_ADDR: http://dockge-as.${TAILSCALE_DOMAIN}:8200
+              CANARY_PATH: secrets/data/shared/cloudflare-driscoll-tech
+              VAULT_TRANSIT_SEAL_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    # Owned by the openbao app — referenced, not copied, so a
+                    # re-minted token never needs a second edit here.
+                    name: openbao-seal
+                    key: transit-token
+              BAO_ROLE_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: openbao-replica-restore
+                    key: role-id
+              BAO_SECRET_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: openbao-replica-restore
+                    key: secret-id
+            command:
+              - /bin/sh
+              - -c
+              - >-
+                set -eu;
+                apk add --no-cache bash coreutils postgresql17-client age rclone curl jq
+                && exec bash /scripts/restore-test.sh
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 50m
+              limits:
+                memory: 1Gi
+                cpu: "1"
+
+    persistence:
+      scripts:
+        type: configMap
+        name: openbao-replica-scripts
+        defaultMode: 493
+        globalMounts:
+          - path: /scripts
+      sftp-key:
+        type: secret
+        name: openbao-replica-sftp
+        defaultMode: 256
+        advancedMounts:
+          dump:
+            main:
+              - path: /secrets/sftp
+          restore-test:
+            main:
+              - path: /secrets/sftp
+      sops-age:
+        type: secret
+        name: sops-age
+        defaultMode: 256
+        advancedMounts:
+          restore-test:
+            main:
+              - path: /secrets/sops-age
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      pgdata:
+        type: emptyDir
+        advancedMounts:
+          restore-test:
+            postgres:
+              - path: /var/lib/postgresql/data

--- a/kubernetes/apps/kube-system/openbao-replica/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/ks.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openbao-replica
+  namespace: &namespace kube-system
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/openbao-replica
+  # Break-glass replication (migration Phase 5): a nightly age-encrypted
+  # pg_dump of the `openbao` database shipped to alpha-site, and a monthly
+  # restore test that proves the dump is actually usable. See
+  # vault/bootstrap/RUNBOOK.md Scenarios B and D.
+  #
+  # NO `components: - ../../../components/postgres` here, deliberately: this
+  # app reads the existing `openbao` database with the credential the postgres
+  # generator already provisions for the openbao app. Adding the component
+  # would make components/postgres/Update.cs provision a SECOND database
+  # named after this app.
+  dependsOn:
+    # The database being dumped, and the app that owns it. Depending on the
+    # openbao ks (not just postgres) means we never dump a half-initialised
+    # database during a bootstrap.
+    - name: openbao
+      namespace: kube-system
+    # ClusterSecretStore/database (the dump credential) and
+    # ClusterSecretStore/onepassword-connect (the SFTP key — dual-run: 1Password
+    # is still authoritative for estate credentials until Phase 11).
+    - name: external-secrets-stores
+      namespace: kube-system
+    # Both jobs cross to alpha-site only through the dockge-as egress Service:
+    # port 2023 (dump receiver), 8200 (transit unseal for the restore test) and
+    # 443 (Gatus heartbeat reports) are declared in
+    # apps/tailscale-system/services/Update.cs.
+    - name: tailscale-services
+      namespace: tailscale-system
+  prune: true
+  wait: false
+  force: false
+  suspend: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/openbao-replica/kustomization.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./secret.sops.yaml
+configMapGenerator:
+  - name: openbao-replica-scripts
+    files:
+      - dump.sh=./resources/dump.sh
+      - restore-test.sh=./resources/restore-test.sh
+      - age-recipients.txt=./resources/age-recipients.txt
+generatorOptions:
+  disableNameSuffixHash: true
+#
+# Credential routing, because three different trust roots meet here:
+#
+#   externalsecret.yaml   PG_URI from the generated `openbao-postgres` secret
+#                         via ClusterSecretStore/database (same reasoning as
+#                         the openbao app: referenced, never copied), and the
+#                         SFTP private key from 1Password ("Rclone SFTP Key" —
+#                         the same keypair DockgeLxc seeds into every
+#                         rclone-sftp receiver). Dual-run: the store ref moves
+#                         to OpenBao at Phase 6, the key itself is already
+#                         migrated data.
+#
+#   secret.sops.yaml      The restore-test AppRole (minted by
+#                         vault/bootstrap/openbao/restore-test.sh —
+#                         placeholders until that runs). SOPS because it has
+#                         no other in-cluster source.
+#
+#   Referenced, not copied: the transit seal token comes from the existing
+#   `openbao-seal` Secret owned by the openbao app, and the age identity for
+#   decrypting dumps comes from the `sops-age` Secret the common component
+#   already stamps into this namespace.

--- a/kubernetes/apps/kube-system/openbao-replica/resources/age-recipients.txt
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/age-recipients.txt
@@ -1,0 +1,11 @@
+# The three estate age recipients — the same set as .sops.yaml in this repo,
+# vault, and stargate-command-cluster. MUST stay identical to those files: a
+# divergent set is how a dump becomes undecryptable by the one key that
+# survives (vault/bootstrap/RUNBOOK.md, "Things that will bite you").
+#
+# No alpha-site-resident key is ever added here. The whole point of this
+# layer is that the host holding the ciphertext (and the transit key) cannot
+# decrypt it alone.
+age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6

--- a/kubernetes/apps/kube-system/openbao-replica/resources/dump.sh
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/dump.sh
@@ -19,7 +19,7 @@
 #   GATUS_URL, GATUS_CONNECT_TO, GATUS_TOKEN   heartbeat reporting
 #
 # NOTE for editors: this file is delivered through a Flux-substituted
-# ConfigMap. Keep every shell variable lowercase or $unbraced — a ${UPPERCASE}
+# ConfigMap. Keep every shell variable lowercase or $unbraced — a $${UPPERCASE}
 # that collides with a cluster substitution variable would be rewritten at
 # deploy time.
 set -Eeuo pipefail

--- a/kubernetes/apps/kube-system/openbao-replica/resources/dump.sh
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/dump.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# dump.sh — nightly break-glass replication of the `openbao` database to
+# alpha-site (migration Phase 5; PLAN §E, RUNBOOK Scenario B).
+#
+#   pg_dump → age encrypt → SFTP to the bao-standby dump receiver → prune 30d
+#
+# The age layer is ON TOP of OpenBao's own encryption, deliberately:
+# alpha-site also hosts the transit key, so possession of that one host must
+# never be enough to read the estate's secrets. Recipients are the three
+# estate age keys plus the dedicated restore-test key — see
+# age-recipients.txt, which is the authoritative list.
+#
+# Environment (set in helmrelease.yaml):
+#   PG_URI            connection string for the openbao database
+#   SFTP_HOST/PORT    the bao-standby dump receiver on dockge-as (port 2023)
+#   SFTP_KEY_FILE     the estate rclone SFTP client key
+#   RETENTION_DAYS    prune horizon on alpha-site (30)
+#   GATUS_URL, GATUS_CONNECT_TO, GATUS_TOKEN   heartbeat reporting
+#
+# NOTE for editors: this file is delivered through a Flux-substituted
+# ConfigMap. Keep every shell variable lowercase or $unbraced — a ${UPPERCASE}
+# that collides with a cluster substitution variable would be rewritten at
+# deploy time.
+set -Eeuo pipefail
+
+report() {
+  # Report failures loudly, successes quietly. Never let the report itself
+  # fail the job (|| true): Gatus's heartbeat catches a job that could not
+  # even report.
+  local success="$1" msg="${2:-}"
+  local url="$GATUS_URL/api/v1/endpoints/$GATUS_TOKEN/external?success=$success"
+  if [ "$success" != "true" ] && [ -n "$msg" ]; then
+    url="$url&error=$(printf '%s' "$msg" | head -c 512 | od -An -tx1 -v | tr -d ' \n' | sed 's/../%&/g')"
+  fi
+  curl -sf -X POST \
+    --connect-to "$GATUS_CONNECT_TO" \
+    -H "Authorization: Bearer $GATUS_TOKEN" \
+    "$url" >/dev/null || echo "WARN: failed to report to Gatus"
+}
+
+fail() {
+  echo "FAILED: $*" >&2
+  report false "$*"
+  exit 1
+}
+trap 'fail "dump.sh aborted at line $LINENO"' ERR
+
+stamp="$(date -u +%Y%m%d-%H%M%S)"
+name="openbao-$stamp.sql.age"
+plain=/tmp/openbao.sql
+enc="/tmp/$name"
+
+# rclone remote for the dump receiver. No host-key pinning, matching the
+# estate's other rclone-over-sftp jobs (Playground.cs, backrest preSync).
+export RCLONE_CONFIG=/tmp/rclone.conf
+export RCLONE_CONFIG_BAO_TYPE=sftp
+export RCLONE_CONFIG_BAO_HOST="$SFTP_HOST"
+export RCLONE_CONFIG_BAO_PORT="$SFTP_PORT"
+export RCLONE_CONFIG_BAO_USER=sftp
+export RCLONE_CONFIG_BAO_KEY_FILE="$SFTP_KEY_FILE"
+
+# 1. Dump. --schema=openbao because that is where every OpenBao table lives
+#    (the role's search_path puts them there — see STATUS.md, "tables live in
+#    the openbao schema"). --no-owner/--no-privileges so the dump restores
+#    into a scratch server that has no CNPG roles. Plain format on purpose:
+#    RUNBOOK Scenario B pipes it straight into psql.
+pg_dump "$PG_URI" --schema=openbao --format=plain --no-owner --no-privileges > "$plain"
+
+# A dump of a healthy openbao database is never tiny. An empty-ish file here
+# means we dumped the wrong thing (or a wiped database) — do not ship it over
+# the last known-good ones.
+size="$(wc -c < "$plain")"
+[ "$size" -ge 65536 ] || fail "dump is only $size bytes — refusing to ship it"
+
+# 2. Encrypt. -R takes the recipients file; comments and blank lines are fine.
+age -R /scripts/age-recipients.txt -o "$enc" "$plain"
+rm -f "$plain"
+
+# 3. Ship, then read it back from the listing — the upload only counts if the
+#    receiver actually has it at the right size.
+rclone copyto "$enc" "bao:$name"
+remote_size="$(rclone lsl bao: --include "$name" | awk '{print $1}')"
+[ "$remote_size" = "$(wc -c < "$enc")" ] || fail "uploaded size mismatch for $name (local $(wc -c < "$enc"), remote ${remote_size:-missing})"
+
+# 4. Prune to the 30-day retention. Scoped to our own filename pattern so a
+#    stray file in the receiver directory can never be collateral.
+rclone delete bao: --min-age "$RETENTION_DAYS"d --include 'openbao-*.sql.age'
+
+count="$(rclone lsf bao: --include 'openbao-*.sql.age' | wc -l | tr -d ' ')"
+echo "shipped $name ($size bytes plaintext); $count dump(s) retained on alpha-site"
+report true

--- a/kubernetes/apps/kube-system/openbao-replica/resources/restore-test.sh
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/restore-test.sh
@@ -24,7 +24,7 @@
 # CANARY_PATH, GATUS_URL/CONNECT_TO/TOKEN.
 #
 # NOTE for editors: delivered through a Flux-substituted ConfigMap — keep
-# shell expansions $unbraced so no ${UPPERCASE} can collide with a cluster
+# shell expansions $unbraced so no $${UPPERCASE} can collide with a cluster
 # substitution variable.
 set -Eeuo pipefail
 

--- a/kubernetes/apps/kube-system/openbao-replica/resources/restore-test.sh
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/restore-test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# restore-test.sh — monthly proof that the break-glass backup works
+# (migration Phase 5; RUNBOOK Scenario D: an unverified backup is not a
+# backup).
+#
+# This is Scenario B as a drill, end to end, with nothing mocked:
+#
+#   1. fetch the NEWEST dump back from alpha-site over the same SFTP path the
+#      nightly job ships through — proving the dump left the building and is
+#      retrievable
+#   2. refuse a stale dump (older than MAX_DUMP_AGE_DAYS) — a clean restore
+#      of last month's data is still a failed backup
+#   3. age-decrypt with the estate identity — the exact key a human would use
+#   4. restore into the scratch Postgres sidecar
+#   5. start a throwaway bao against it and let it unseal via the SAME
+#      transit key on alpha-site the real cluster uses
+#   6. log in with the restore-test AppRole and read the canary key
+#   7. report to Gatus — which alerts on failure AND on silence
+#
+# Environment (set in helmrelease.yaml): SFTP_HOST/PORT/KEY_FILE,
+# AGE_KEY_FILE, MAX_DUMP_AGE_DAYS, SCRATCH_PG_URI/USER/PASSWORD/DB,
+# TRANSIT_ADDR, VAULT_TRANSIT_SEAL_TOKEN, BAO_ROLE_ID, BAO_SECRET_ID,
+# CANARY_PATH, GATUS_URL/CONNECT_TO/TOKEN.
+#
+# NOTE for editors: delivered through a Flux-substituted ConfigMap — keep
+# shell expansions $unbraced so no ${UPPERCASE} can collide with a cluster
+# substitution variable.
+set -Eeuo pipefail
+
+bao_pid=""
+
+report() {
+  local success="$1" msg="${2:-}"
+  local url="$GATUS_URL/api/v1/endpoints/$GATUS_TOKEN/external?success=$success"
+  if [ "$success" != "true" ] && [ -n "$msg" ]; then
+    url="$url&error=$(printf '%s' "$msg" | head -c 512 | od -An -tx1 -v | tr -d ' \n' | sed 's/../%&/g')"
+  fi
+  curl -sf -X POST \
+    --connect-to "$GATUS_CONNECT_TO" \
+    -H "Authorization: Bearer $GATUS_TOKEN" \
+    "$url" >/dev/null || echo "WARN: failed to report to Gatus"
+}
+
+cleanup() { [ -n "$bao_pid" ] && kill "$bao_pid" 2>/dev/null || true; }
+
+fail() {
+  echo "RESTORE TEST FAILED: $*" >&2
+  echo "Treat the backup as UNTRUSTED until this passes — RUNBOOK Scenario D." >&2
+  report false "$*"
+  cleanup
+  exit 1
+}
+trap 'fail "restore-test.sh aborted at line $LINENO"' ERR
+
+# ── 1. Fetch the newest dump back from alpha-site ───────────────────────────
+export RCLONE_CONFIG=/tmp/rclone.conf
+export RCLONE_CONFIG_BAO_TYPE=sftp
+export RCLONE_CONFIG_BAO_HOST="$SFTP_HOST"
+export RCLONE_CONFIG_BAO_PORT="$SFTP_PORT"
+export RCLONE_CONFIG_BAO_USER=sftp
+export RCLONE_CONFIG_BAO_KEY_FILE="$SFTP_KEY_FILE"
+
+latest="$(rclone lsf bao: --include 'openbao-*.sql.age' | sort | tail -1)"
+[ -n "$latest" ] || fail "no dumps found on alpha-site at all"
+echo "newest dump on alpha-site: $latest"
+
+# ── 2. Freshness gate ───────────────────────────────────────────────────────
+# The timestamp is authoritative from the FILENAME (openbao-YYYYMMDD-HHMMSS),
+# which the dump job wrote from its own clock — mtime over sftp is not
+# trustworthy enough to gate on.
+dump_date="$(printf '%s' "$latest" | sed -n 's/^openbao-\([0-9]\{8\}\)-.*/\1/p')"
+[ -n "$dump_date" ] || fail "cannot parse a date out of dump name '$latest'"
+# Epoch arithmetic instead of `date -d "-N days"` — that flag does not exist
+# in busybox and this container's date is coreutils only because the command
+# wrapper installs it.
+cutoff="$(date -u -d "@$(( $(date -u +%s) - MAX_DUMP_AGE_DAYS * 86400 ))" +%Y%m%d)"
+[ "$dump_date" -ge "$cutoff" ] || fail "newest dump $latest is older than $MAX_DUMP_AGE_DAYS days — nightly replication has stopped"
+
+rclone copyto "bao:$latest" /tmp/dump.sql.age
+
+# ── 3. Decrypt with the estate identity ─────────────────────────────────────
+age --decrypt -i "$AGE_KEY_FILE" -o /tmp/dump.sql /tmp/dump.sql.age
+size="$(wc -c < /tmp/dump.sql)"
+[ "$size" -ge 65536 ] || fail "decrypted dump is only $size bytes"
+
+# ── 4. Restore into the scratch sidecar ─────────────────────────────────────
+export PGPASSWORD="$SCRATCH_PG_PASSWORD"
+for _ in $(seq 1 60); do
+  pg_isready -h localhost -U "$SCRATCH_PG_USER" -d "$SCRATCH_PG_DB" >/dev/null 2>&1 && break
+  sleep 2
+done
+pg_isready -h localhost -U "$SCRATCH_PG_USER" -d "$SCRATCH_PG_DB" >/dev/null || fail "scratch postgres never became ready"
+
+# ON_ERROR_STOP: a partial restore that limps into a working-looking bao is
+# the worst possible outcome for a verification job.
+psql "$SCRATCH_PG_URI" -q -v ON_ERROR_STOP=1 -f /tmp/dump.sql
+tables="$(psql "$SCRATCH_PG_URI" -tA -c "select count(*) from information_schema.tables where table_schema='openbao'")"
+echo "restored $tables table(s) into schema openbao"
+entries="$(psql "$SCRATCH_PG_URI" -tA -c "select count(*) from openbao.openbao_kv_store")"
+[ "$entries" -gt 0 ] || fail "openbao_kv_store restored empty"
+echo "openbao_kv_store has $entries rows"
+
+# ── 5. Throwaway bao, unsealed via the real transit path ────────────────────
+# Single node, no HA, no service registration. connection_url and the transit
+# token arrive via BAO_PG_CONNECTION_URL / VAULT_TRANSIT_SEAL_TOKEN — the
+# same env-beats-config behaviour the production config relies on.
+cat > /tmp/config.hcl <<EOF
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = true
+}
+storage "postgresql" {
+  table      = "openbao_kv_store"
+  ha_enabled = "false"
+}
+seal "transit" {
+  address    = "$TRANSIT_ADDR"
+  key_name   = "openbao-equestria-unseal"
+  mount_path = "transit/"
+}
+EOF
+export BAO_PG_CONNECTION_URL="$SCRATCH_PG_URI?sslmode=disable"
+bao server -config=/tmp/config.hcl &
+bao_pid=$!
+
+# Auto-unseal happens during startup; then there is a window where non-status
+# requests 500 while the (single) node elects itself — the same ~30s window
+# equestria-init.sh waits out. Gate on health 200 = initialised, unsealed,
+# active.
+export BAO_ADDR=http://127.0.0.1:8200
+unsealed=""
+for _ in $(seq 1 90); do
+  code="$(curl -s -o /tmp/health.json -w '%{http_code}' "$BAO_ADDR/v1/sys/health" || true)"
+  if [ "$code" = "200" ]; then unsealed=yes; break; fi
+  kill -0 "$bao_pid" 2>/dev/null || fail "bao server exited during startup — transit seal unreachable or restored keyring unusable"
+  sleep 2
+done
+[ -n "$unsealed" ] || fail "bao never reached health 200 (last: $(cat /tmp/health.json 2>/dev/null || echo none)) — transit unseal of the RESTORED data failed"
+echo "throwaway bao is unsealed and active (via $TRANSIT_ADDR)"
+
+# ── 6. Canary read with the restore-test AppRole ────────────────────────────
+# The AppRole lives INSIDE the backup (minted against the live cluster by
+# vault/bootstrap/openbao/restore-test.sh), so a successful login also proves
+# the auth backends survived the round trip.
+token="$(curl -sf -X POST "$BAO_ADDR/v1/auth/approle/login" \
+  -d "{\"role_id\":\"$BAO_ROLE_ID\",\"secret_id\":\"$BAO_SECRET_ID\"}" | jq -r '.auth.client_token // empty')"
+[ -n "$token" ] || fail "approle login failed against the restored instance — was vault/bootstrap/openbao/restore-test.sh ever run?"
+
+canary="$(curl -sf -H "X-Vault-Token: $token" "$BAO_ADDR/v1/$CANARY_PATH" | jq -r '.data.data | length')"
+[ -n "$canary" ] && [ "$canary" -gt 0 ] || fail "canary read of $CANARY_PATH returned no data"
+echo "canary read OK ($canary field(s) at $CANARY_PATH)"
+
+# ── 7. Report ───────────────────────────────────────────────────────────────
+cleanup
+echo "restore test PASSED: $latest restores, unseals via transit, and serves reads"
+report true

--- a/kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/secret.json
+#
+# The restore-test AppRole: read-only on the single canary path, used by the
+# monthly restore test to prove a restored dump actually serves reads
+# (RUNBOOK Scenario D). Minted by vault/bootstrap/openbao/restore-test.sh
+# against the LIVE cluster — the credential rides along inside every nightly
+# dump, which is exactly why logging in with it against the restored copy is
+# a meaningful check.
+#
+# The values below are PLACEHOLDERS until that script runs; the job fails
+# loudly at approle login (and Gatus alerts) until they are replaced:
+#
+#   sops set kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml \
+#     '["stringData"]["role-id"]' '"<role_id>"'
+#   sops set kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml \
+#     '["stringData"]["secret-id"]' '"<secret_id>"'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-replica-restore
+type: Opaque
+stringData:
+  role-id: ENC[AES256_GCM,data:zXcCBzVTQgXXt56vU1OD2jdfHixpu9OIBoz13dm+3ITmP9jHWisFNQS3yjbasx0s35EjsMZXejU=,iv:akVoVDWtN1/31dCvbs0Ityha3DRd6tlDq2XWQ0DcRxo=,tag:OZbClq/8v8Eby/xEXpe2iw==,type:str]
+  secret-id: ENC[AES256_GCM,data:phod3WakLg88JBh4rnrMzKP1i4XKB3FYEHJMRQ9q2yfoWStd0jV0zULx8JITbRX8EIXqArSRdWo=,iv:Tvt8HxRyf1uzNskfHA9U/cQyU83DxTrOyXCYJ5HsXYU=,tag:G3e0NZVMmxwzf2N0MpMang==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQcEdxT1A0OFJYeGN5VEQ1
+        UXBuY1ord0hDZFFteG5Jc2RvN1lSbStWaTBNCkp3RFExSmwrQU8wMFlBU2hQeXY2
+        UnF0VTJDMU4vYnFkd0pNQ29jcHlkdEEKLS0tIHVtd0JtNGNVcVZ6Y2Jnai9kQmJt
+        eVluZEhJaUFIdDZQSDhnSmZvelFjaUEKNX1YI5fsKSmc9B6V7zSg+EWL5yH3xXkJ
+        TOj2Ft0wgMa/kwW/nlD1guJjfslBhoBPP1xdvoXFsxMP4+koCK85/g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvdzRSamRTTGc4UEt6VTkz
+        a09jYWttR1d1UHVNZ21acXBCTEY5V0JxS1FnClZGaGN1bVF1M2ZldjdmVzRVZGVq
+        VGdkK09LQklEbklDb1VHY3JWaWVEK00KLS0tIHN3TjExaHFQZjk3c0Z6MmY4M1FO
+        M2N4Qno5RmNkV3IzNGxjOEl0b1B1QjAKF8MRqmW4Va31vDB2EToT5PIUP+z1McHj
+        1UEYEQXXPd8MsTtqyYag2h9zRtv6U7uD4r9HF+XBHxCn/LxtI2iWhw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5ckR0Q05mSWRhSFUzdlo2
+        OWtlbUE0TlBjbWg3Qzk2cExGamo1VTZ3L1VnCkNQMDJ4SmJKdlVQQUdzT0t4Nkla
+        OTV5MEtWdHlUQTBUVEpNRnNtREROU0kKLS0tIEtsc3ducG9tNnZRMERzYWtoaWor
+        OGJaSnRHT0VqeEFvWXl4VlRrbDVjR0EKNSxgvIa18g6jgfvEcsVzIkcgD6iZJ5jC
+        NR6fa95f3gUBRg5wDALUO3znqsjZd1dpdIH2n/vTYpr6kL1cRkCiBQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T15:38:28Z"
+  mac: ENC[AES256_GCM,data:f1+5jgM9sBDjPjgA1Hv27Gckc5J2vWsAoP9dU1MARKLhyTbbNPuc6fRx1J+EnHM5/3spJi9UQodZCTjc3DRR7kpubLsmtwgJgOkmqvuw4SucYwpsiZOXrbpy53DqzU/E0Q3z85EzOMgpRQPpsFG9G0tqW6sD954dzgC6yrlZToc=,iv:IaGGhYf+nG5JTFYU0z4Ci7PRlJiVH8Ev0smlFr3YJzI=,tag:jyijli91qVXwX33uu0BWsg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/tailscale-system/services/Update.cs
+++ b/kubernetes/apps/tailscale-system/services/Update.cs
@@ -78,11 +78,19 @@ var extraPorts = new Dictionary<string, Dictionary<ServiceKind, PortDef[]>>
   // probe helper always builds an https:// URL and bao-transit runs
   // tls_disable, so a probe here would report a false failure. Its health is
   // already covered by the Gatus check in the bao-transit stack definition.
+  //
+  // 2023 is the bao-standby dump receiver (rclone serve sftp) — the
+  // openbao-replica cronjobs in kube-system ship the nightly age-encrypted
+  // pg_dump through it and the monthly restore test pulls the dump back.
+  // No probe, same reasoning as 8200 (plain TCP, not https); liveness is the
+  // Gatus tcp check in the bao-standby stack definition plus the heartbeat
+  // the jobs themselves report.
   ["as"] = new()
   {
     [ServiceKind.Dockge] = [
       new("adguard", 4000, false, null),
       new("bao", 8200, false, null),
+      new("bao-dumps", 2023, false, null),
     ]
   },
   // luna hosts the Home Assistant voice pipeline: llama.cpp (gemma-4-E2B) on

--- a/kubernetes/apps/tailscale-system/services/as.yaml
+++ b/kubernetes/apps/tailscale-system/services/as.yaml
@@ -25,6 +25,9 @@ spec:
     - name: bao
       port: 8200
       targetPort: 8200
+    - name: bao-dumps
+      port: 2023
+      targetPort: 2023
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe


### PR DESCRIPTION
## What

Phase 5 of the OpenBao migration (PLAN §E): OpenBao's data can now survive losing the equestria cluster.

New app `kubernetes/apps/kube-system/openbao-replica/` — two app-template CronJobs on the OpenBao 2.6.1 image, following the existing postgres-backup pattern:

- **`dump`** (nightly 03:00): `pg_dump --schema=openbao` via the generated `openbao-postgres` uri (referenced through `ClusterSecretStore/database`, never copied) → `age -R` to the three estate recipients → rclone SFTP to alpha-site → size-verified upload → prune `--min-age 30d`. **Refuses to ship a <64KB dump.**
- **`restore-test`** (monthly, 1st 05:00): pulls the *newest* dump back, **fails if it is older than 3 days**, decrypts with the in-cluster `sops-age` Secret, restores into a `postgres:17.5-alpine` sidecar, starts a throwaway `bao` that unseals through the **real** transit path (`dockge-as:8200`), AppRole-logs-in and canary-reads `secrets/shared/cloudflare-driscoll-tech`, then reports to Gatus.

Also: port `2023` (`bao-dumps`) added to the dockge-as egress Service via `tailscale-system/services/Update.cs` — pods have no tailnet route, same precedent as the 8200 entry added for the transit seal.

The age layer is **on top of** OpenBao's own encryption, deliberately: alpha-site holds the transit key, so ciphertext and key must never co-locate. See PLAN §E.

## Deliberate design decisions

1. **The restore test runs in equestria, not on alpha-site.** Decryption needs an age identity, which must never land on alpha-site; the cluster already holds `sops-age`. Pulling the dump back also proves off-site *retrievability*, not just delivery. (PLAN §E left the location unstated.)
2. **The SFTP key ExternalSecret uses `onepassword-connect`** — dual-run-correct until Phase 6; noted in-file.

## Before the first green restore test (both documented, both fail loudly until done)

- `chown 65534:65534 /opt/stacks-data/bao-standby/dumps` on dockge-as
- `vault:bootstrap/openbao/restore-test.sh init` (the secret ships with sops-encrypted placeholders)

## Verification

`flate test all` → **329 passed, 2 pre-existing skips, 0 errors**. Both scripts shellcheck-clean. HelmRelease values rendered against app-template 5.0.1 and inspected (sidecar, mounts, envs).

Pairs with home-operations#684 (the alpha-site `bao-standby` stack + Gatus heartbeats) and vault#151 (RUNBOOK Scenarios B and D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)