### PR TITLE
fix(openbao): let reloader roll the StatefulSet on config changes (unblocks the OIDC go-live)

### DIFF
--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -33,6 +33,17 @@ spec:
     ui:
       enabled: true
     server:
+      # The whole config below is delivered as a ConfigMap, and OpenBao reads it
+      # once at process start. A config-only change therefore leaves the
+      # StatefulSet's pod template untouched, so nothing rolls and the running
+      # servers keep serving the OLD config indefinitely — Flux reports success
+      # the entire time. That bit us on the OIDC bootstrap: the generate-root
+      # listener toggle sat in the mounted file for 15h while every request
+      # still 403'd. Reloader (estate-wide convention) watches the mounted
+      # ConfigMap and rolls the StatefulSet when it changes.
+      statefulSet:
+        annotations:
+          reloader.stakater.com/auto: "true"
       ha:
         enabled: true
         replicas: 3


### PR DESCRIPTION
## The trap

OpenBao's config arrives as a ConfigMap and is read **once at process start**. A config-only change leaves the StatefulSet's pod template untouched, so nothing rolls, the running servers keep serving the **old** config — and Flux reports success the whole time.

This is not hypothetical. It stalled the OIDC go-live: the `disable_unauthed_generate_root_endpoints = false` toggle from #3067 has been sitting in the mounted file for ~15h while the API still returns 403, because the pods predate the change:

```
currentRevision = openbao-575d676db8
updateRevision  = openbao-575d676db8   # identical — never rolled
$ kubectl -n kube-system exec openbao-0 -- bao operator generate-root -status
Code: 403. permission denied
```

(The toggle *is* in the pod's config file — `grep` finds it. The process just never re-read it.)

## The fix

`reloader.stakater.com/auto: "true"` on `server.statefulSet.annotations` — the estate-wide convention (238 other uses in this repo). Reloader watches the mounted ConfigMap and rolls the StatefulSet when it changes.

Verified with `helm template`: the annotation lands on the **StatefulSet object**, which is what reloader watches (not the pod template).

## Why this matters beyond today

**#3070 — the revert of that same toggle — would hit the identical trap.** Merging it without this fix would leave the unauthenticated generate-root endpoint live on the running pods indefinitely while the manifest claimed otherwise. This PR must merge **before** #3070 for the revert to actually take effect.

## Suggested order

1. **This PR** → pods roll, toggle finally becomes live
2. Run `vault:bootstrap/openbao/equestria-init.sh oidc` (steps 3–5 of the runbook in vault#152)
3. **#3070** → pods roll again, toggle closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)