### PR TITLE
fix(openbao): RollingUpdate — without it #3072's reloader annotation is inert

### DIFF
--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -41,6 +41,20 @@ spec:
       # listener toggle sat in the mounted file for 15h while every request
       # still 403'd. Reloader (estate-wide convention) watches the mounted
       # ConfigMap and rolls the StatefulSet when it changes.
+      #
+      # RollingUpdate is the other half, and without it the annotation above is
+      # inert: the chart defaults to updateStrategyType OnDelete, under which
+      # the StatefulSet controller never replaces a pod on its own — not even
+      # when the pod template changes, which is exactly what reloader patches.
+      # (`kubectl rollout restart` also refuses outright on an OnDelete
+      # StatefulSet, so that workaround was never going to work either.)
+      #
+      # OnDelete is the right default for upstream Vault, where a Shamir-sealed
+      # server needs a human to unseal every restarted pod. That reasoning does
+      # not apply here: this cluster auto-unseals through the transit seal
+      # against bao-transit, so a restarted pod comes back unsealed on its own.
+      # With 3 HA replicas replaced one at a time, rolling is safe.
+      updateStrategyType: RollingUpdate
       statefulSet:
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Why this is needed

#3072 added `reloader.stakater.com/auto` to close the config-doesn't-reach-the-pods trap. It cannot work on its own, and I found this only after that PR merged.

The chart defaults to **`updateStrategyType: OnDelete`**:

```
$ kubectl -n kube-system get sts openbao -o jsonpath='{.spec.updateStrategy}'
{"type":"OnDelete"}
```

Under `OnDelete` the StatefulSet controller **never replaces a pod on its own — not even when the pod template changes**. Reloader triggers a reload precisely *by* patching the pod template. So the annotation fires, the template updates, and still nothing restarts. Same for the chart's own `server.configAnnotation` checksum, and `kubectl rollout restart` refuses outright on an OnDelete StatefulSet — so the manual workaround in the original issue could not have worked either.

## Why RollingUpdate is safe here

`OnDelete` is the right default for **upstream Vault**, where a Shamir-sealed server needs a human to unseal every restarted pod — an automatic roll would leave you with a sealed cluster.

That reasoning does not apply to this deployment: it auto-unseals through the **transit seal** against `bao-transit`, so a restarted pod comes back unsealed unaided (proven repeatedly during Phase 3 bring-up). With 3 HA replicas replaced one at a time in ordered succession, rolling is safe.

## Verification

- `helm template … --set server.updateStrategyType=RollingUpdate` renders `updateStrategy.type: RollingUpdate` on the StatefulSet ✅
- Reloader is confirmed live and capable: stakater/reloader v1.4.20 in `kube-system`, cluster-wide, and `kubectl auth can-i patch statefulsets.apps/openbao -n kube-system --as=system:serviceaccount:kube-system:reloader` → **yes** ✅
- The end-to-end proof (trivial config change → pods roll) needs this merged; it is also the step that unblocks the stalled OIDC bootstrap, since the generate-root toggle is still not live on the running pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)