### PR TITLE
feat(coder): deploy Coder to a dedicated namespace at code.driscoll.tech

### DIFF
--- a/kubernetes/apps/coder/coder/definition.yaml
+++ b/kubernetes/apps/coder/coder/definition.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Coder
+  category: Applications
+  description: Self-hosted Cloud Development Environments
+  url: &url https://code.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/coder.svg
+  # Coder OSS has no IdP role sync, so Authentik decides who may sign in at all
+  # and every login lands as a Coder member. Admins are promoted in-app.
+  access_policy:
+    groups:
+      - admins
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: "https://code.${ROOT_DOMAIN}/api/v2/users/oidc/callback"
+        - url: "https://code.${TAILSCALE_DOMAIN}/api/v2/users/oidc/callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+
+  gatus:
+    - group: "Applications"
+      url: https://code.${ROOT_DOMAIN}/healthz
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/coder/coder/externalsecret.yaml
+++ b/kubernetes/apps/coder/coder/externalsecret.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-pguser-secret
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-pguser-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        uri: "{{ .postgres_uri }}"
+  dataFrom:
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-oidc-secret
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-oidc-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        issuer: "{{ .oidc_issuer }}"
+        client_id: "{{ .oidc_client_id }}"
+        client_secret: "{{ .oidc_client_secret }}"
+  dataFrom:
+    - extract:
+        key: '${APP}-oidc-credentials'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: cluster
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/coder/coder/helmrelease.yaml
+++ b/kubernetes/apps/coder/coder/helmrelease.yaml
@@ -1,0 +1,101 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: coder-v2
+spec:
+  interval: 1h
+  url: https://helm.coder.com/v2
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app coder
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: coder
+      version: 2.36.0
+      sourceRef:
+        kind: HelmRepository
+        name: coder-v2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    coder:
+      annotations:
+        reloader.stakater.com/auto: "true"
+      # TLS is terminated by Traefik on the internal Gateway, so the pod serves
+      # plain HTTP. Do not set coder.tls.* or any CODER_TLS_* / CODER_HTTP_ADDRESS
+      # here — the chart owns those.
+      service:
+        type: ClusterIP
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 2Gi
+      # Equivalent of the failover/fast-node-eviction component, which only
+      # applies to app-template charts.
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      env:
+        - name: CODER_ACCESS_URL
+          value: https://code.${ROOT_DOMAIN}
+        - name: CODER_WILDCARD_ACCESS_URL
+          value: "*.code.${ROOT_DOMAIN}"
+        - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+          value: "false"
+        - name: CODER_PG_CONNECTION_URL
+          valueFrom:
+            secretKeyRef:
+              name: coder-pguser-secret
+              key: uri
+        - name: CODER_OIDC_ISSUER_URL
+          valueFrom:
+            secretKeyRef:
+              name: coder-oidc-secret
+              key: issuer
+        - name: CODER_OIDC_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: coder-oidc-secret
+              key: client_id
+        - name: CODER_OIDC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: coder-oidc-secret
+              key: client_secret
+        - name: CODER_OIDC_SCOPES
+          value: openid,profile,email,offline_access
+        - name: CODER_OIDC_SIGN_IN_TEXT
+          value: Sign in with Authentik
+        - name: CODER_OIDC_ICON_URL
+          value: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg
+        # Authentik is the only identity source; there are no local passwords.
+        - name: CODER_DISABLE_PASSWORD_AUTH
+          value: "true"
+        - name: CODER_PROXY_TRUSTED_HEADERS
+          value: X-Forwarded-For
+        - name: CODER_PROMETHEUS_ENABLE
+          value: "true"
+        - name: CODER_PROMETHEUS_COLLECT_AGENT_STATS
+          value: "true"

--- a/kubernetes/apps/coder/coder/httproute.yaml
+++ b/kubernetes/apps/coder/coder/httproute.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "code.${ROOT_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: ${APP}
+          port: 80
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: local-user
+---
+# Per-workspace app subdomains (dashboard port forwarding, coder_apps). These
+# proxy websockets and stream non-200 responses, so they skip the error-pages
+# middleware that local-user adds; local-api keeps the internal-network guard.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}-apps
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "*.code.${ROOT_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: ${APP}
+          port: 80
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: local-api

--- a/kubernetes/apps/coder/coder/ks.yaml
+++ b/kubernetes/apps/coder/coder/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app coder
+  namespace: &namespace coder
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/coder/coder
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    # No failover/fast-node-eviction: it patches `defaultPodOptions`, which only
+    # the app-template chart reads. The equivalent tolerations are set natively
+    # under coder.tolerations in helmrelease.yaml.
+    - ../../../components/postgres
+    - ../../../components/tailscale
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      TAILSCALE_HOST: code

--- a/kubernetes/apps/coder/coder/kustomization.yaml
+++ b/kubernetes/apps/coder/coder/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./definition.yaml
+  - ./podmonitor.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/coder/coder/podmonitor.yaml
+++ b/kubernetes/apps/coder/coder/podmonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+# A PodMonitor rather than a Service + ServiceMonitor: the postgres/tailscale
+# components apply commonLabels that kustomize also injects into Service
+# selectors, which would not match the Helm-created coder pods.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${APP}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coder
+      app.kubernetes.io/instance: coder
+  podMetricsEndpoints:
+    # CODER_PROMETHEUS_ADDRESS defaults to 0.0.0.0:2112; the chart does not
+    # declare it as a named container port.
+    - targetPort: 2112
+      interval: 1m
+      path: /metrics

--- a/kubernetes/apps/coder/coder/prometheusrule.yaml
+++ b/kubernetes/apps/coder/coder/prometheusrule.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${APP}-rules
+spec:
+  groups:
+    - name: coder.rules
+      rules:
+        - alert: CoderAbsent
+          annotations:
+            description: Coder has disappeared from Prometheus target discovery.
+            summary: Coder is down.
+          expr: |
+            absent(up{job=~".*coder.*"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+        - alert: CoderWorkspaceBuildFailures
+          annotations:
+            description: >-
+              {{ humanize $value }} workspace builds failed in the last hour.
+            summary: Coder workspace builds are failing.
+          expr: |
+            increase(coderd_workspace_builds_total{status="failed"}[1h]) > 2
+          for: 0m
+          labels:
+            severity: warning
+        - alert: CoderAgentsUnhealthy
+          annotations:
+            description: >-
+              {{ humanize $value }} workspace agents are stuck in a failed
+              startup state.
+            summary: Coder workspace agents cannot start.
+          expr: |
+            sum(coderd_agents_connections{lifecycle_state=~"start_timeout|start_error"}) > 0
+          for: 15m
+          labels:
+            severity: warning

--- a/kubernetes/apps/coder/kustomization.yaml
+++ b/kubernetes/apps/coder/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: coder
+components:
+  - ../../components/alerts
+  - ../../components/common
+resources:
+  - ./coder/ks.yaml

--- a/kubernetes/apps/database/postgres/app/passwords.sops.yaml
+++ b/kubernetes/apps/database/postgres/app/passwords.sops.yaml
@@ -6,45 +6,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:vRxW8vd+qC0=,iv:XbSCVCsvTpHdfLRcblXUuAHckNvFNkY+I044/DYWEZ4=,tag:VjHeSU4fWvPMR6zuewZDdA==,type:str]
-  database: ENC[AES256_GCM,data:e8QeAHXIgQI=,iv:XN/8Yu3m628ktfrWeYdiWz4QkfScKAqofsaChlaif/A=,tag:FiTgKt+M/6lCD6MnwmrPNA==,type:str]
-  port: ENC[AES256_GCM,data:r7+obg==,iv:Jsg+j5dup+KM1ZtUByJ4fG2HiXoG3exoiu2R+f4qJn4=,tag:2I63vtnwFsdWiFAL3m2/Pg==,type:str]
-  hostname: ENC[AES256_GCM,data:pP+E7Gr+iNXaZJpbSz3pEtCl9lIfx2BdTSBr5xF5r9wo6lyMbFY=,iv:5EKNmgdurYypTJHzzWSxCQDZT0J2SnQ8v3Ir67Aa3AI=,tag:7BPvQhuEHTxIHpdp6hnttg==,type:str]
-  password: ENC[AES256_GCM,data:1iJ5N8hioymsjQ+2KB5cU1Q9avXvfb5ZxlRODYRR8HA=,iv:6b3hKjP3Z/8sJqmqO3vkOWw8d1rReWX1YFw1aokl2Q4=,tag:0y4dHe1wtFfFZB0ERaiYtg==,type:str]
+  username: ENC[AES256_GCM,data:/zWUxnbSR9Y=,iv:+aAja2/JACNjpZFjzDy1s9ZF0nQIG1l4jBIjEbXG+q0=,tag:B8QL3YzMTF2jWwaWrHMaDQ==,type:str]
+  database: ENC[AES256_GCM,data:LOUW9aOj0zc=,iv:SLED4WiAS0v30mEej5xOuEoy64P0mX1I8PPwbX1IRW8=,tag:Tin2U/p7V/6Xv+N7hfDsaw==,type:str]
+  port: ENC[AES256_GCM,data:Pf9bxA==,iv:NrsGvLG9rJk3Z/pD3AF5V3neXf8gC1qfNEAI8eq4D+g=,tag:1BQe+6LecJaAoY+yf0PvvQ==,type:str]
+  hostname: ENC[AES256_GCM,data:IuL6Zcv548t0F9ImaHaz9QjgcoXepEiDE127ERCs2kJ/nAfHItE=,iv:CqcjiQ0/krlhaxOsA3GMO5rVLVLSIPguiSHfqDvce8w=,tag:CRATe1abKbaLCSPBso8zVQ==,type:str]
+  password: ENC[AES256_GCM,data:6v0pWAcEv2XcU8ot9j9Fc+46rMq68ZsvZ1FbqaA0djM=,iv:OZFdcve7kK5wEIMG1SnWPw7rRc15aK4wSOwy5jb05gI=,tag:1T4BsQvajCp+rhCbf1B4RA==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -54,45 +54,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:IR4qe8cqxA==,iv:deiOpGdzPLbO4oT5U1qqY1IE0ihy/odi/QI/07ngf7U=,tag:YKPUk5KaIsQwMhFKlOTDVA==,type:str]
-  database: ENC[AES256_GCM,data:kYgAFIcMMQ==,iv:WedPigHLg2M39KubnRvV00ly4Hfm9/lCE0NRtIzdRCg=,tag:fSjkxAoYcEIAiD/zcQ4TUw==,type:str]
-  port: ENC[AES256_GCM,data:la7ojA==,iv:nLxtlEzabK7AhZtvElemadkUYwkcFCbWWAuQM8S0xfs=,tag:hMaD/+LarWUNHX7+IePjCA==,type:str]
-  hostname: ENC[AES256_GCM,data:Y/KUkQ27zDa5PkIVGWuA8n5JwoWauumo/3aWovOyIBwfuN5yrHw=,iv:w4KNQMxTAEA9iEOAXuqkDo7eahXt34U3+hh2uKFCh0k=,tag:2fJnIJvdZ+8zVRKdWSw01g==,type:str]
-  password: ENC[AES256_GCM,data:OJEnW9gTArH1kG6qaECF2bKaEDlypifBTXEhN2gKM5M=,iv:Xv+DB5YSMZgwDHwVV4uNBJKj4HkqtgzUjKeOgEZPKf4=,tag:gVsFR2R/x20BEGw8Fp2Wkg==,type:str]
+  username: ENC[AES256_GCM,data:9djgMZr6cg==,iv:g0/JHFV7C8L02TGM2juXy+OmG6Sszpp53yCqLJQruJE=,tag:aUxh2Ccm4og0I50XEDaOAg==,type:str]
+  database: ENC[AES256_GCM,data:BoK/IMjPwg==,iv:a/BYsdTxj+/ic1YfoDN2RJxqHOkCEegeXn3EHrEjJ3E=,tag:VokwCBDFqQZ2/PENcmI0zw==,type:str]
+  port: ENC[AES256_GCM,data:386n3w==,iv:wsvDahPgJXRtvfv6o0HegvN34Bh5r3DjEGx0fXCK5U4=,tag:ya2y+MMcDwwzxLFqk/FHpQ==,type:str]
+  hostname: ENC[AES256_GCM,data:HAUHMle10kPMlPVASQHmQRDFN5AjVherVNcF5V0Gnz/vmBIPbOc=,iv:nnZffSmBVGYcXcsJX+QHGPQqmGGpi+OvaAtMVT+A5Q4=,tag:uNzcxAbgDqCuH3eQPQK4OQ==,type:str]
+  password: ENC[AES256_GCM,data:yczL8DYzmHir+C4NHuUHr13nKkCmchLbVm2xuLZdRMU=,iv:HEdg1nZTcXL+8TSwDQE83arocs0TXat4A4Q/TT3i1sE=,tag:/gs1UVCt65trGvEVURPJ7w==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -102,45 +102,93 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:Zudq+bTaMA==,iv:adN+4xjpfoWTDOpG13DjN7gi8yhRZjnt2AkGat6hELM=,tag:5+CgcybmLZaZLJ36fj4CIQ==,type:str]
-  database: ENC[AES256_GCM,data:XCuNn81dzQ==,iv:mAvl31wAURR8ykShFu3I9XpUWgThPv4/9eLJYLSvtnY=,tag:jag9idlXOkE9fb+8EVAYjg==,type:str]
-  port: ENC[AES256_GCM,data:m8CR5w==,iv:8wH8UHqZuU1WwFN2IS2sGZ9B4wEJx466LQRBwSsB+uI=,tag:V1PEatBHi+irrin+o/8j1Q==,type:str]
-  hostname: ENC[AES256_GCM,data:RJQZlC3O6GXEY8+V640qjW3YiHt0NT3frbBRlKAakl+ZJ4DcjCE=,iv:k6slk1IUR31WY5de0qpY3WB3Avwi+n5jXUXn0nXhGqw=,tag:UlCMcLJGuVOEht1T9ANUAA==,type:str]
-  password: ENC[AES256_GCM,data:HPNCk8+X5i/4E/Kz7hkUPIKq3rrQ28NnNNVVWpdR+Pw=,iv:AaiJPBdXP3+HXeFXuyOfOxlhEKht75aKxOkpOZIjWgs=,tag:AN3WdjkzWNR/WNROUi4HrA==,type:str]
+  username: ENC[AES256_GCM,data:7+k/lGCj/Q==,iv:5oLFAwc118o704drcEhgOZ+AN2ENdsdtDaRSGN2Idv4=,tag:UXUzKNOaI46l6gn+lG/kKA==,type:str]
+  database: ENC[AES256_GCM,data:R85uRlp91w==,iv:mh/9Lkmo47kq8V4lvTg40/nDfTkP3IOaoKvWjzrQJhI=,tag:L3BRWMN6WjuNwFTi7drojA==,type:str]
+  port: ENC[AES256_GCM,data:r8QV2Q==,iv:CLIHmAaatdACA0UjciDz+i5HjymDElNPPw2eid+8vQI=,tag:Pv0Z3e2BAkmXJEWRHu9Lpw==,type:str]
+  hostname: ENC[AES256_GCM,data:Hpps+/luAbJxsEyNmZmWXEj/uXWB2z5Xk1plIW+bt8t3oYbJkBw=,iv:J26MIYmLVy8vSU85UW2TifEIvp1A7sD3O2vknTYaYBk=,tag:i1YazQwagadL42V6czGApQ==,type:str]
+  password: ENC[AES256_GCM,data:ckiHma2gav1HJScpB6jWwXSm2Iwq6LF4UhddICgrkao=,iv:dos7Emd96cu/U2Lc1U3qGk2+zmN30PsCvnkIWSIG0AE=,tag:dYWcqfF0BuniA8OLdLNcow==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coder-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:ju9ZsUI=,iv:Az2EZCIQqJ/nqVXpTjU8p6FFr7prbh+NJhxrlKLkRtg=,tag:1nzgi4nmoOqWHZP1gcIyMw==,type:str]
+  database: ENC[AES256_GCM,data:wbjxqn8=,iv:Xccp+t0auxPe+Mlums2Cnv2V0W5VY0XNzbfcRPCCP94=,tag:Y4J6wtdKSO24ZctTYyNJFw==,type:str]
+  port: ENC[AES256_GCM,data:zbkuCw==,iv:Ga9WYSQh99naaNRZcqFNVY/rdAaiSyqdsDzCRNcF3G0=,tag:/xFjZ5CYdXFMnOJdycAJow==,type:str]
+  hostname: ENC[AES256_GCM,data:jsp6DUFvdxBhXtGMScvaHywYZYHZJJ97XFnOH6WPpnMRwpXhKT0=,iv:WBTzh8UWinV4QN8t0qCRUAidQgReah28unj4F1hIzx0=,tag:80qr5CPlWFATcb/nU+ueHg==,type:str]
+  password: ENC[AES256_GCM,data:4jILkBRgQdtWZ3HO+5j3w59LLw14HeKnFB1NxvLYS2Q=,iv:eOvsAd+q576NakDr6eclGVefvBoLXh7CtduuMGUXDUU=,tag:71FXagQ2nBwMEUDYZrurPA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -150,45 +198,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:v2lRnmJ0pA==,iv:qWOWnsKMZviicHbRcG6dMKptGCT5OKjm5utpDhvDj8c=,tag:mLSwl6c0blHGAr02F3mtDw==,type:str]
-  database: ENC[AES256_GCM,data:6nYDVOe7SQ==,iv:uJ4St3hU/5z8VLy3Dn8Po8xERq2zuJ+IDW+CPqA7aIk=,tag:luBl4lE1lH9XEYX9TpPCUg==,type:str]
-  port: ENC[AES256_GCM,data:hhQB/g==,iv:3W3SFNuQ0bbtuxA6O+Z207JAljenWkZN/sLnPNM95Ek=,tag:KCOyTdrApM7oTSVnHnrNdg==,type:str]
-  hostname: ENC[AES256_GCM,data:Mv9k3P3wLGT6tsRM1L8Eff4WytQxYbeWE7SCgavte7GCLRS5WG8=,iv:pFQMt/6NWm7kvcb6XQgZGIa+JfKn/jT73529E+m8BwA=,tag:v3iOT2uZ4Z2+krmeY4GEYA==,type:str]
-  password: ENC[AES256_GCM,data:lMarmexHoBKAdeweXhPF9vip0xo81hLak/4ZrI18xl4=,iv:vHQay3iOwIE2x0WM6Wta0JdenNs0kCgOc2cbvcmnAoU=,tag:ahhu5UfnpRFt6Pz5cWeZHg==,type:str]
+  username: ENC[AES256_GCM,data:3TJBPLUf8g==,iv:COfYUhF8ZTc7WhgaiwvusF9nYxsYuiKlKXR5zr/1JOQ=,tag:RpxlZ4mngtEq8q0Bn6TI6g==,type:str]
+  database: ENC[AES256_GCM,data:1E6KMHwHNA==,iv:19rgVFP5wlowmOxCDFvXI9suiZmCwZkj9rZyzcBx+2w=,tag:CXL/9CKDwOqajbtZePe1dA==,type:str]
+  port: ENC[AES256_GCM,data:5uSbAg==,iv:+65KSG9kJYQXrSc85qryZr+8N5YEWCRLVact83N4ufE=,tag:YR31hBd4heMk3fED1/KXIg==,type:str]
+  hostname: ENC[AES256_GCM,data:96CBMDIEo9YaBMNR8E+xWkt6mwFIHroU7tXuzYcr2ZZqVPpbsxw=,iv:j5kP3oEF0hhAXNk4IEBjakAL/MPp+pL9DK1FTHodmQM=,tag:T9czeN7XYuVLS9K7Qr9O5A==,type:str]
+  password: ENC[AES256_GCM,data:Anhqr26rDM/g4//riJqL33Dyc6f3hg9ZPgwx5WHlmBg=,iv:QA+7+r+GslARoC4EZ5lpBsnJaohhZMQbaSN+iMGqBtI=,tag:5JcEhRGwT59GDJmFQ3/HWQ==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -198,45 +246,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:AEnRFMLU,iv:M+EFD5lnI/8+XF3aBqrLLtUHy38cQmxTRGSChlfjPrc=,tag:NAEzgFSoWOIbRGkncHRiig==,type:str]
-  database: ENC[AES256_GCM,data:L13vHm+K,iv:mSEDrvLzD2A+UudloJR0YuePWL5BJfObLvmLxLLk7ao=,tag:iUcQrZ2SVS4BaiX96O0v1A==,type:str]
-  port: ENC[AES256_GCM,data:NQ1zWw==,iv:zsgBVHyC5YvgUOXAKYAc5f7UqjVeYaKLb8Iq/rFIduk=,tag:2DztLZCqMgD0h+mn5dc1iQ==,type:str]
-  hostname: ENC[AES256_GCM,data:/iAiCiePyG977bgHLYjPP1KA8rXkDAsKEjcXsVM7r78qcNGI4jk=,iv:i/O1HMMvKTMHGW4FE1eQ58Pp8xwPAHXGolgXLnWecVs=,tag:TDQDjaX9IxJIm1dvbAgUZw==,type:str]
-  password: ENC[AES256_GCM,data:IRPxVeMxU+lD9vUYHXo8jLCPWOlftwZd5KuvQJc0xMQ=,iv:jXOZWDmdUqbgcC334PGFn2jJhqtFazuiyTyTGaGZpmY=,tag:t3fLIn7fmDpInlvdvsNRcw==,type:str]
+  username: ENC[AES256_GCM,data:DoEUGD1e,iv:iygKIROtQanFa0x0WE1a6lKJEtzZgJL+sWvwVM2liEg=,tag:4DkbjBRaAK6GAsGIhNKT9w==,type:str]
+  database: ENC[AES256_GCM,data:FpMdH/6d,iv:EBvjvgDCYisI4VajERnHlT2nJiIL9qavBebV7IOv9GM=,tag:QNiNw2mUXX9av8uMKSiE2g==,type:str]
+  port: ENC[AES256_GCM,data:eTUP9Q==,iv:Sb4q5nkIlWWoa1sFJi71Mu+WLBwdcGcC/6pWb9tYHtg=,tag:9GPmat3raKuoBDyvgP/hLQ==,type:str]
+  hostname: ENC[AES256_GCM,data:zBncKJYPvHZLe++z9UaI3yumX2exKQwI2UWolpjghyWWkb2r864=,iv:v+4xjanQ3qDqU4EquVT0HE/2zfE3KmAdp2SBUlTBhWY=,tag:CFkmifiOQZDoS9XQfKd/lQ==,type:str]
+  password: ENC[AES256_GCM,data:puCGzG0gR21BPB8EezwoKTJKTkqdoRT+Wjk5SybJ2ps=,iv:AWy8Gwr7cHY5A226KlmtXZM5vSWE5kJ1fTvUGNFaHGg=,tag:zliWx471Be43e2gzIXG7mg==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -246,45 +294,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:6A929JFsvSQ=,iv:7q54yiDNLtJLP/l8omp/v9X8Z6SKQLVmQObuKLQqjLc=,tag:EF+UqqWzhdfAXZqtJlo4cw==,type:str]
-  database: ENC[AES256_GCM,data:kXVNc0gDA1Q=,iv:XWPV8oU/jt7pOIWfw4u/db3H3+2MicxofuSJ+IXdZx0=,tag:0lzbwM+ZbubG5wJKD16Qdw==,type:str]
-  port: ENC[AES256_GCM,data:s0c1bA==,iv:PqtKkJtddaTMhUdR0fj6MUSnA/arf7MZ/CtuMWm5O7o=,tag:WahHhdwnJa2Nahmsv+lUqA==,type:str]
-  hostname: ENC[AES256_GCM,data:qYhsn/yiby51RyN/ZLyKUMDgRqnG+Pm0BO+59AY72a/uEvMOPaw=,iv:720FdTYf8L4VK3zuff5uKf5Cu4YOe0fz06UlIVBj014=,tag:8ztzuoW1iiaJvtrgmtybiQ==,type:str]
-  password: ENC[AES256_GCM,data:vydgh3ahqTocnzHU5nPtzqBq3l1PfzqIYL2InWPN+qo=,iv:6wtLy8ugZ5KylQNNh/ysgymxB5rFlFBMmnPR4B3r180=,tag:XSh1WU4+kmzIpdP4kjn81A==,type:str]
+  username: ENC[AES256_GCM,data:weMLlYcO+aI=,iv:ck/Xv2IzIoMotyRX+GztfwO4450qrvUSCN/h5y4ak5g=,tag:cjJnTmIJ6k4K+swBreXuyw==,type:str]
+  database: ENC[AES256_GCM,data:6A85Hc0V5kk=,iv:LhMlZE9EC4U3B4LRO82kKTZc9pt1tbyOAh08BCAONPo=,tag:cB4HIDhR+zOzvWntVQMElQ==,type:str]
+  port: ENC[AES256_GCM,data:4NxMpw==,iv:5IVrCvFyfjOZk/wyA0qu4HpzrmN4wt/kjajtla/Saf8=,tag:aQpx8pt6NPiXkhmIj17GGw==,type:str]
+  hostname: ENC[AES256_GCM,data:auZDWNinGV5BCDHG+17B6E8Tv+Fswq1BLnm2ODyEoi8cWln42Vo=,iv:R7N6GJXOzw6QBRhZmFOgSp0Eyw0mJJCMAgBmnWh7Q4M=,tag:2sHHTyS1GR6oUvh2nDGNow==,type:str]
+  password: ENC[AES256_GCM,data:gNLXhB/X1TU3Ue5/3Q/f8oJpfzT0KcVj2XSrLWJaYgE=,iv:Ynk/0/jLJEwhne8+I+//yvg1VE/G5j/PhNkzXtAu/Rs=,tag:3JSRGTGgOyU+CCw4d8H4rw==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -294,45 +342,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:wgD5Bj/C+24=,iv:0YUjoOykCkciYzURbtJOeLAM+mVpjfGhFU0TFozIFjY=,tag:Vvy47xnPilpbtzuIaMhoPQ==,type:str]
-  database: ENC[AES256_GCM,data:ctCw2QYY2Ww=,iv:LcIqIcGfCHsq3/YtJ4eBPlS+w6MwZLg4UuuaIaB81TE=,tag:g/l/TpWYnIyyeuuo/emddw==,type:str]
-  port: ENC[AES256_GCM,data:4komEg==,iv:t824D/hj0dqshiLs7zcAWhD261iPwUOMHIgUApI74+Q=,tag:dgMZCTmOMxmH4wd20TR+qQ==,type:str]
-  hostname: ENC[AES256_GCM,data:AB0BLXIQMQHz9pwE42j2zcKPAWG25dIUJjF7grNUiZhJo0W7Rn4=,iv:px7s9d7qvG3nHYxVjArwgCBiFzRR0JKEXuaX7v4I5zc=,tag:oqn90MhaDjCqWxb5DIvpBw==,type:str]
-  password: ENC[AES256_GCM,data:drh4ZG6fWK2KTSiqB+LOA5aV7CbNSkvmRGFRAQehCHs=,iv:2NjY8rRSJQYXnDL34DeFb12vhkBH2RN2SLqKt1F1d40=,tag:1h03mEpc0lZdon00aaaljg==,type:str]
+  username: ENC[AES256_GCM,data:UhLo8Cwyi94=,iv:AMwVEPCa0c3W3L/Lqnvs/yXiQKktjwZBN65yytuS320=,tag:rVPpqucJS18sonp6jA1tSg==,type:str]
+  database: ENC[AES256_GCM,data:MTexO9aCEMI=,iv:eoLbodwsVQmIov4DTdzdGeJcnCJRjWCJo3jOadeg+kE=,tag:BJqR8810ejCTqdVdERVN1Q==,type:str]
+  port: ENC[AES256_GCM,data:vK4x3Q==,iv:8pSeQEde+BvJ/MoyRTRVw4ikxeupwpYUmr/qdWVDo3w=,tag:2LKmbUnlBIgtqfVMfZ8/gQ==,type:str]
+  hostname: ENC[AES256_GCM,data:/PeG02ys9fqoI6b+AvbMLvNnojxCLHlnEXsOolqythTt8JRDJu0=,iv:/te/60WNco6ZXyVnxFFHBjhaKKz0BxtsvueOmUIXI9U=,tag:ubKaL2z04smgx0qKkpEUSg==,type:str]
+  password: ENC[AES256_GCM,data:xyqCasZOdaVA2CijKC81kdnHOQI4sVKXJp1pFlOM02k=,iv:ILgydb0TxTE4ljqh7qcGpsQbTL0DU3Lrn7yoABSt56E=,tag:9mVVLHiBaXXtM6o3LAvQUw==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -342,45 +390,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:pmez,iv:1U0kYPvfV5vI/Y/ROBk6f3p4tiVD8b5xDwLxhE11beE=,tag:cmbiyBVnmqKber/mD5Hf8A==,type:str]
-  database: ENC[AES256_GCM,data:fXQN,iv:QY8TjNHDHpkOG3CNpXt37CtG3JtQsx1geTdSo6CZays=,tag:sULX/NhzGGox+BNv15m4AQ==,type:str]
-  port: ENC[AES256_GCM,data:G/Ft8g==,iv:3JcOW/CAcckBYepBiseyEcXkoE1qJ8ocQqScFKbd4tU=,tag:hjqG+c2LXMR5jJW9Dw9Faw==,type:str]
-  hostname: ENC[AES256_GCM,data:iPoOsej4+Kdxp+5PLzMEhzyOq/livz+slMjd/xiigA6mli88WDs=,iv:MISqhIuqyITRDqF7V04s4s5wcR/LOdF90aWWr8MYyck=,tag:4wPpe1v3wjPTFPr3FacbJg==,type:str]
-  password: ENC[AES256_GCM,data:04y4MUJBsDC1pVCD7USq50oO3bvBJA0VRHFSHUNR0t4=,iv:49iezltCigQT3yq1T/jHhjf+0vC5Pi6JF1FrLaLDwcI=,tag:6MtkvCYmjfScQqo302BHBQ==,type:str]
+  username: ENC[AES256_GCM,data:kr+w,iv:D4craNKKQpOuEwQqYqZZXY52cF5ishjs/MpOB2F5mMM=,tag:O/E7b2dCSAiS3P1wf84Z6Q==,type:str]
+  database: ENC[AES256_GCM,data:MIaT,iv:bCE1/ojpmO8aZ6icTIT0wMj4JkoC0pVPFLwP3dS0k90=,tag:FZJoEwRRgxRZ7E8vJhy3rQ==,type:str]
+  port: ENC[AES256_GCM,data:1RPFvA==,iv:cSZkDBsxr3UEe1efuB9nTA+7O+oZxqXciHEemINncO8=,tag:5lwKhuszAe9m/gt+usV9og==,type:str]
+  hostname: ENC[AES256_GCM,data:FKfqkSiSvcdonrb/HWo8qKiECpLaFiVsEhWQa5Ml6UL6nKwiZvE=,iv:hG4zPwsT/bkrIIKPqMMWKJrqvYzT4ZZWfEgZxWonfDQ=,tag:0hwks8VFhE+ShRHB62mzYw==,type:str]
+  password: ENC[AES256_GCM,data:r/RnNdUYNRMo21NtlH3XCRN8dJsy7EzsFTXnIjvP8Lc=,iv:lacvsb1mKmfkQ6+vtF1khDx5TGl7soco6H1JDVj7/Vo=,tag:ofxDQumVEPSPkhh0dFzPcw==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -390,45 +438,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:4MuMGX1RkQ==,iv:0GybPe022eXyU1MemUlyOYmtBqyD8rkq/AY0eCxUQX4=,tag:xT69Z0VlVAfOouF4XrgImQ==,type:str]
-  database: ENC[AES256_GCM,data:UyvRtb/bWQ==,iv:t+s24loVSJVSVnby/RUMeZJdufoc28+nwJM1wstLU0g=,tag:Zya7+UyjfGzAg+W1iBxr0Q==,type:str]
-  port: ENC[AES256_GCM,data:XFoTvg==,iv:bYzg+s1EMzPrTy9UpmMp2I6WsgSOxQ8/BXJ1YJELvgM=,tag:GC4UwJkZRYvuLCYLIliGAQ==,type:str]
-  hostname: ENC[AES256_GCM,data:xSkJK2mljooVWrsZZjaxQkzTp7RKs8MqDP961p9Pzqv++ckal1M=,iv:+TBy3ejYRXn4k2SvgJg0FjYAnh5tBsIL7FgrUuevn6g=,tag:m/6zCfc1dKmk9Pk2EBynWg==,type:str]
-  password: ENC[AES256_GCM,data:kHvLKdmDBx3wHUFfifHKxhYxbpWHbZDdqd8vSpUPJOE=,iv:MPmahqLKWaif0VRQc+i7avm6mYp2Hdv8UD7gm74yxg4=,tag:AUnkNqeF4/g8MUscdGGLlg==,type:str]
+  username: ENC[AES256_GCM,data:ExrvnV15SA==,iv:Ep7uItfFL0anD7EMmBjAMUBhtfe0b0DU1B+M0PogHio=,tag:FCF1x1x/XY20l0uDqU4zXg==,type:str]
+  database: ENC[AES256_GCM,data:PnRRYchITg==,iv:IT6u1FNFn3jW+NXZqnNy7v0PXzkrxGB8REc4YhhTyVc=,tag:t8Uy8ieIivG6KFozBQ+KiA==,type:str]
+  port: ENC[AES256_GCM,data:zcZUQg==,iv:PCVc/xUPoNP38eP5Ush3wapgRbmFgyVSqMM9QRcVcLA=,tag:C+jNrXhaABiRioXcojXikw==,type:str]
+  hostname: ENC[AES256_GCM,data:xKmSjs1Q7awfC/95+JCoBsNYcyaCot8tjvGus3YHrj7J5xCI9Wg=,iv:9aanxf8W/0RPgYEXNbhE9zVDOXYcY/o1auSj3ihX34Y=,tag:KRsDXoukgNNgwYF9Ylg/NQ==,type:str]
+  password: ENC[AES256_GCM,data:7P+s/SxuaPQZSF9mnqB+UVsTxxNKMP/EqQXQPrmDKoU=,iv:wef3u2tZaAT1mgYsgzdVzgKaSXptiSseggE8mw6fSNo=,tag:4BNz9+DTt9w2grH5zJJHNQ==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -438,45 +486,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:dH1dN6gV/Q==,iv:xcKx0wDOd/NQZkp0cieSrLE7N09QRYXxlg9al+D8qac=,tag:TwhtFBfouuPbWkQOnrBjHg==,type:str]
-  database: ENC[AES256_GCM,data:FtPNlNP4Sw==,iv:w7W1D/r9OBNzXzc4mFud6n5LzlgK6ZrwsbMo0W/Bc9c=,tag:XxqCG/A9a/efEcqnVAZUuw==,type:str]
-  port: ENC[AES256_GCM,data:xjcwzg==,iv:rh5lXAl+hmMTDSw3iMBXtj2XUVRcV3ksL2s9S5THv80=,tag:/810595YQfVBkMjZMWuwrg==,type:str]
-  hostname: ENC[AES256_GCM,data:tevDrYzGttmWzlsPwjdQS8qaZgDHkQEZNvoipZqsVuRYIUvf264=,iv:XJKNOJtq3LCeCQ6OyEP6UdC9x0McoGjmYtwx5ciPpA4=,tag:meXSWrGZXo6abC42p0UEuQ==,type:str]
-  password: ENC[AES256_GCM,data:Fzu0Ff0ozfioePYFk6E2sI8j+2oMafFQU4YXI/azw9c=,iv:hwKLfrl7PaCrtebazOtHhbSQuFdFrCZo0/xSQBFust4=,tag:etGgFkO6ltT0PmQ9mB7JiA==,type:str]
+  username: ENC[AES256_GCM,data:Rm1l/lKt8g==,iv:9pF8KXEcI+sJCj3uYL1SZOJCRx+uBOYqwRVVO0lXTa4=,tag:Ts4T0LZgcR87i3kcB3TeNg==,type:str]
+  database: ENC[AES256_GCM,data:Mff/ID815A==,iv:coZhhRbbnKj8E6SMaPll6rxARLFbAEADYv52pzSatSE=,tag:Xf5R9/kCmnXq0fjBNW3N4Q==,type:str]
+  port: ENC[AES256_GCM,data:76lZtQ==,iv:IiaD+A7w9Y8BdQbda9B76UD1ZXFnqMYwifc37EZ2KTI=,tag:GogUP8X8fgTkpApIdghQng==,type:str]
+  hostname: ENC[AES256_GCM,data:ldf4OjgHG0Pxl5jzgURLUPZdMoNPhIuZoV90dsiDXo+cZ7W8aoA=,iv:YPrNjeFTtok9sp5VsxxcyHc/QkgIv2TAlIhXvi9m4wY=,tag:Q+esLUdNWloDIb4oLuCz6w==,type:str]
+  password: ENC[AES256_GCM,data:YDxCahNpN4xo/nZV5A3SCz4Z9QZWxkzWNOF+YRc5zR4=,iv:IKqdnmsCdVHtTRojZSMimfUpeMbFqYoyiOo2KXf20yA=,tag:3e9N7rtsRrq25NcqMFYOyA==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -486,45 +534,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:9d2YguCD,iv:vSq2cu95hnKp6wQktLjQIhUSKN24ygkfJNpIeqWDPxI=,tag:RCABcAyRliBC/tazOjCgbQ==,type:str]
-  database: ENC[AES256_GCM,data:X0lfWuPB,iv:1/zP5jJss9ly8nycHuEs1aOf/GiGPoRI3gf7fPWqioI=,tag:52TYO/CnUtGY+IGoNiT0QA==,type:str]
-  port: ENC[AES256_GCM,data:ro0ziA==,iv:FPWrWkq1ximmr1wOMtwH0rl66Z6QcRnPvu9K1dqt2SE=,tag:q2014Yiy7sn3OB1ln3L2hA==,type:str]
-  hostname: ENC[AES256_GCM,data:Fiq06Pt8aWpEJGVWLEEgVKT+sBUidQZZt5hyst2Wf7QZGvwvdBc=,iv:k+2EHrvEJoyQ5ONyK4VQKbV0oZ18VpW9DSoZ4NE/Fys=,tag:uDyOEXYcYdsP5np2reURKw==,type:str]
-  password: ENC[AES256_GCM,data:W3MiIPd0ixSH+YRROjjObJIybqmwwB8PnuTXuTFWMkE=,iv:0xSs55w5WSMU2RbfStPFCFMR2o0KjXX1gOB7LI3fn3Y=,tag:Q/3vAzpRz0F2XL5KDq3jKA==,type:str]
+  username: ENC[AES256_GCM,data:PWMJIOiO,iv:VjwfrtmErKWZyIanK5E8gZ1AMzDcaaVO1V5e7Z6yqds=,tag:yDGQE/ROL5hD5ZDgZnAS+g==,type:str]
+  database: ENC[AES256_GCM,data:iJONRP15,iv:ae0hw4C0OqmfYMbboCtwBCMVw8Ur6vsicaHXrzPVKlk=,tag:N5ul99OBfOoHz0TTj8/wUw==,type:str]
+  port: ENC[AES256_GCM,data:mglW9g==,iv:D908bnweC7C+3Eup7Ri6M3sAU/GOIJvEhTx+vb9iBxM=,tag:5GrNBy42IAQ88vbPJw7SSQ==,type:str]
+  hostname: ENC[AES256_GCM,data:KqAYfPj19ctbg25V2ay0GFhPNyr8bc+w5xG84yYUC4IWIG37MIo=,iv:eHw0pjP4HTpuNgE/aIm8xeFLM+e+J2/A0yxGJeGqZ9Q=,tag:1pSPgR3SUg9n6jc42flwrw==,type:str]
+  password: ENC[AES256_GCM,data:/zOtpwXQomPEyO5aogiyO+UqawEzcYLU040s5MShKD8=,iv:7rIGOnoEYOd4xO0KgsxXcFUHu/A6ONlXlIS0os6G9cA=,tag:n86JMlpG8+uFiI2C+RsWYA==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -534,45 +582,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:3eUc4/LqcVo=,iv:aPj/NfMlKJJZZED/zTwKowEeQrWG1LgQucLbp5BeUao=,tag:Of359DkvZywbtLrMlla9Og==,type:str]
-  database: ENC[AES256_GCM,data:pJYytg/U6lI=,iv:dXPGCNslR2WmJLisfNmgIGUQ8XiYX+ZMgKpP391pTeg=,tag:TmiwiGgtmPpFGcD6YSXGiA==,type:str]
-  port: ENC[AES256_GCM,data:cg+3hQ==,iv:vXTJB3V2NapWbAC4FI9Igz5ZlSUj9yqCGhqFnauIqsU=,tag:C+XvcJbmCQ9FOM88B4oT0g==,type:str]
-  hostname: ENC[AES256_GCM,data:BEih8Bjkk9IIxDz3dnAhHyQIY7vGysGTbmKNzO/jVzLA60k+nOs=,iv:qmurFAt7fvRkXoOYXfGY7s/URAWieCrOLrX58QyiPwg=,tag:OcRifjxibkkQYuQj7nfzIA==,type:str]
-  password: ENC[AES256_GCM,data:IjH6S73zmBhnqXs2yfhCuvk2PNwth2jr5YGzPdK0K0o=,iv:wGPTSyewX1j3xpJsHNVk2uVDYRhdg2eKIvLyYXwRv8Y=,tag:SphaJWq/SB29AZrgDy2lVA==,type:str]
+  username: ENC[AES256_GCM,data:IhBxlzMsnKo=,iv:vGqrijt7skPae1RS/hIcW+KQAgwo7mlFO715i+OkRDI=,tag:KipSkkQ+pajnFTCtsSVDkA==,type:str]
+  database: ENC[AES256_GCM,data:o0F/9Oh8icI=,iv:iEXJeQAcZZkHY9b8pW9OJtYahdfxb4iOrDKaNS18X0g=,tag:Zu2kLFWiu9bEqPKAnjIeig==,type:str]
+  port: ENC[AES256_GCM,data:LwEbfw==,iv:b9YNoFos8lkK5eqjc5yWZCWRarCrmB0TdJ+1i271dBk=,tag:4ztXUByAzFCh/AtXhjsoKg==,type:str]
+  hostname: ENC[AES256_GCM,data:DT2a6H3CRgZE6t+gYghAye/gNTR6x4GZRDoOjkb9hwER/rl9Ag8=,iv:0O7kjnsi1RzqilMMSjS0Ci5TLae/jKeF1dAmNLgf6vs=,tag:LfN6KDfiPdZamav4lgcx8Q==,type:str]
+  password: ENC[AES256_GCM,data:hQYZWPgwx5r24zdezFNXaEuYYrYwoWpILGj+akvDUTg=,iv:yHhztlDKBpPxLKmZRvVDRi9QFXn/it+REZaHcXII1rk=,tag:Lflv4lYjbA2SmnbQmXprEQ==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -582,45 +630,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:rtyJEg==,iv:Y0J9HyW7umcfjgbmVtG/UYrMdW5IuxHI4xWc6dYFmAE=,tag:KJ/N1jZIg2ZGYpy7wbAFfw==,type:str]
-  database: ENC[AES256_GCM,data:7kHpaQ==,iv:0qFLu55QFV7sE92v6CUJ00xT/5nVnqqIVKez2m2gC0E=,tag:jjsl1YW3J1vwqEveMURVyA==,type:str]
-  port: ENC[AES256_GCM,data:LRZNWw==,iv:2CVDe1xDGc5roUjIlcYI1NY2FYNQ+s8qjmQFPcEySa4=,tag:quDao8fnlt88OYAppsTFeQ==,type:str]
-  hostname: ENC[AES256_GCM,data:yof0aU8T9uYFhVZhR3WuX41X1zwVYx8LoNs5j7rlXvO7FRvpCUY=,iv:r9+7eqCBwzQxvmIujpNH/WY+MJ8iemCQMlaBVk3/c6o=,tag:ybhyyIZWzQHf2TOQTS9E3Q==,type:str]
-  password: ENC[AES256_GCM,data:tvr3txnqUGfn8fhcAJLZdGkjGqWyfnrJzkkFFBccR6Q=,iv:CuZLTOH8aiidn4YM/3zykk3Rpp8IirzVcBcWg5Th40k=,tag:d4gaXphbkgThlLOQofyQ9g==,type:str]
+  username: ENC[AES256_GCM,data:fXD9Ow==,iv:0jvxKt7J/QPCO5QHZP8DJz0E+OfcMAD3UvzeF8ulGbQ=,tag:0gdLS9g/vm0MR8fKE6eGKA==,type:str]
+  database: ENC[AES256_GCM,data:XDaQzg==,iv:eXVpZyaGUgJY9c50xb0n+pxFI4x8N2GftMuMCUV2hdY=,tag:OFGfp7LFORa3/G6R39vM6g==,type:str]
+  port: ENC[AES256_GCM,data:jFUUgw==,iv:wYDDO9qin/cYpX6bnEGHOkEfwkBKA6GMDi4P7F4pjDk=,tag:XEfPx0YzlqtckzlCMNVfqg==,type:str]
+  hostname: ENC[AES256_GCM,data:vh9gPV+xrc9iFg4atGivpg1VeW+gS3AkPeFToo+rQfvgQXxZ1mE=,iv:uSm14UU0V6UFl4FxFPsv6aLxp+57MXzH28qvrsku77o=,tag:VxXbXXYqbxIciEsCubNqJg==,type:str]
+  password: ENC[AES256_GCM,data:wFlaO8ZBtKBOe2Tl5cK5QDsYd2Zb24/EYtpZ4xr1AFA=,iv:5Zq5++pV+oo2O8Nv7V5myiIIUEn0AuOzAypCjsSGyuI=,tag:Devu6CZffUUN8XpIGLSrbQ==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -630,45 +678,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:lJqeJcqX0eo=,iv:xl3DiOPPlBeF8l/Ty2n+VF9Gnp3Z3E1iqA0sbEYtpEE=,tag:i8RO6yzjjJMPcnzj7wucgA==,type:str]
-  database: ENC[AES256_GCM,data:Vj3g02zSjJo=,iv:RhJFafngd+bnnlcrm0qAufVNNiBhgzosfpjjuABcD1E=,tag:fBYuvz5e6b9qaO7wh81I0Q==,type:str]
-  port: ENC[AES256_GCM,data:KsvArA==,iv:10FocBUw11Bi1nM9Hcc5aLbu8M0hr8GvVwiJQUTLYII=,tag:qynz57FxuMroOl043Rma8w==,type:str]
-  hostname: ENC[AES256_GCM,data:W/DI1hYtiVPosNLKcs77hpoNXd449MXXHeBnDeDEPC6+WlnaBTo=,iv:evsA0UvEfhCGsDaeDc6rON/O5zaCVTvBwheG3MVDTaU=,tag:xR+grmpgPmtQK4dD9IjgMQ==,type:str]
-  password: ENC[AES256_GCM,data:HVqACnpzU0O2InOCFMo3VImnh9c7VAQD/yPNRrc8Kbg=,iv:4dzutFTR5MiQetFqB6RxDEsj3Gd0YAHUziUymsN9ZLs=,tag:Jp4K/LrDljFyoeA2r4qTrQ==,type:str]
+  username: ENC[AES256_GCM,data:LUM3045OlLM=,iv:kMOjeXVt0s8kBpYgV5y6sIuMhINMguMKrhymqO8nd9U=,tag:XyfQHKkeWb3kFD7ZUDjhFA==,type:str]
+  database: ENC[AES256_GCM,data:HZM6TLF0/vU=,iv:B7/xy/d8XshjMJR6nH/7vNR6o8+9893iVDW73SW61/Y=,tag:7sZ+pl4KJIp11YlhQEhnBQ==,type:str]
+  port: ENC[AES256_GCM,data:d1fSgg==,iv:cNBtlrqXumv61+T3YekBD2PhBubEXw/0Rtt0GidjkVU=,tag:mxyXCanl6dA+qIW64v0mMw==,type:str]
+  hostname: ENC[AES256_GCM,data:+kNKjpGw9lLS1lCHB171lwIdc75UXncPBjPOTIulkq7OAE0NbjY=,iv:9yX76Kr0af6LIP9cuOwoYMTSa8vTaCvhQQ5F5mE0bO0=,tag:kKWqrz+hAL84B2XwyXKH+A==,type:str]
+  password: ENC[AES256_GCM,data:AiZFJrow+GKEU/icSPMeZKjHuJkfDIcdvmCF2U87BzY=,iv:91jfz4OZLcu4jZ7U762jYn52R9pEd26IzXrv2CnXVm4=,tag:rp1ndIilxLcMBSrpO3yCtA==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -678,45 +726,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:6ibkIXhJ1A==,iv:UcR8QrsQYPQ78RqcCJwhR1WJUdLsiTD7omYS3pu20yM=,tag:CU7T6z6YIzTPnL8t3/QenA==,type:str]
-  database: ENC[AES256_GCM,data:jlbOJfMU+Q==,iv:SU2nWor9aPcKskegd3L9QDV0kRXtGnsrnrs2HT/l+E8=,tag:yprR8BRDnuE/I4MPwgiKNA==,type:str]
-  port: ENC[AES256_GCM,data:+UAs5w==,iv:1cYzZ5k4k/X+hwjB9AazpClyls+eLDo1zT2DeHLJGJg=,tag:MOI9RPHM+WsMAPShHqXqkw==,type:str]
-  hostname: ENC[AES256_GCM,data:YNXOXnA+olbp3Jf5VCmPm7sgXXVsFKy9SaQbytg25ZYeItdO74g=,iv:Ee1tR4J+2u7EF442O5QXJhRFgITxb64syoCzceKwGIk=,tag:MRRStgv+zN/jztaq3Oj7NA==,type:str]
-  password: ENC[AES256_GCM,data:TvxEjpBcF7BtEN0m3ds66M7WrbkHYf1BGt9wjIuxPAM=,iv:rjn9jzk858c7BlCcE5zqzJSfocQlxFqv9qtqDR6mYTQ=,tag:qnx3AJdsG634EC1vWT1Iiw==,type:str]
+  username: ENC[AES256_GCM,data:bF5NlG+3Mw==,iv:MMY9t8WSG/GAD4dsX5+w8BQouIa5SQ/m0A0CZYcDVBs=,tag:PffgbYFx3Dz1Vp0ADNYVHA==,type:str]
+  database: ENC[AES256_GCM,data:0D6QT0RSqA==,iv:9qM3xmZlW+UtRS0XauLxO2KDn70cN+Lq4tKmhZcurAI=,tag:mLmwfrEGJqvVWXfJuoYDOQ==,type:str]
+  port: ENC[AES256_GCM,data:soNSHQ==,iv:vFQUZBIf2zubW6I4MFrGdetQXvZ8RXpt51swJbOwtrA=,tag:jqsN2OurtBpdCw0xP6W9LQ==,type:str]
+  hostname: ENC[AES256_GCM,data:TdLXDMnL3hnxdhlxQB0a8P+SB+LR2xRw5cJmJ8hsLn+w0dWDkbk=,iv:TA/0CRJnSQSAwuR4Jvzyi8N3U1nFLaglQ2hRuWJDrYg=,tag:bvAQmnsQ5WOAzEyzJA1GWg==,type:str]
+  password: ENC[AES256_GCM,data:CGyxvJ5eGjS7cSj1AGD0Xx4V9Q2AQhBkwEYkObcVumI=,iv:JCQ6QETgZX2kkysdaf02bno2y2B5PBoHgw9OP1jrZs4=,tag:o/Jja2AEeR2sE/dVu8vB/Q==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -726,45 +774,45 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:ZW3M8uZ5t4NjXB2Bh9zaPQ==,iv:cGAhQXYkaz8FXl+DHqulBBLfGe49nRp1RFBkl56BWX0=,tag:Dm5eZXFfpSl7aWH+MLgRLg==,type:str]
-  database: ENC[AES256_GCM,data:DE8XS56EZjg=,iv:MgAb/ikO6hf+B/Fmfr1vhceIqUPsnSOQrrWdDK64vME=,tag:BV5vPuDl30sPCxAUP0KR/A==,type:str]
-  port: ENC[AES256_GCM,data:l4T6sg==,iv:m1utRGbQd4qMsFXjlm98cQP068friWA/v4BpE/dJXM8=,tag:PN0H3kh6u/6NE+dV/L+l+A==,type:str]
-  hostname: ENC[AES256_GCM,data:/2MTl+qUOLiDgwYzOrQPHL0OJgf9dQFM4EtwWyVC9061Z/st+R0=,iv:YevXb1q2vySs2djQLVCnHhRUwqJpQeiMQP8cDp2YtHw=,tag:+A3p/6U3+Yh0hvUmLD3pJw==,type:str]
-  password: ENC[AES256_GCM,data:d+QT0mSmbUbfL6FLiXnACoMdFxIL5Nw7Nm0L+LElheU=,iv:ipkoYNBwnh/kbDtsxUbVSYCA9THBh3JDaxc+By2C9y0=,tag:FTKh5hOGtYhpZMR/G2zvqg==,type:str]
+  username: ENC[AES256_GCM,data:Acc4dpHJIgq2xhU+K1T/dw==,iv:57H514BCKEWwLCm3Ysb5FQ8zSlyqVPoqgFqbhNbcVXs=,tag:hF8xFOW3G/9Be2sSogn6kQ==,type:str]
+  database: ENC[AES256_GCM,data:B4kJprO3Kps=,iv:HoixxW8bbqMg3SfYv59wTot01zx8/4P44DhUaYT21cI=,tag:oe5V9sXs/NFxgbePZaMIoA==,type:str]
+  port: ENC[AES256_GCM,data:QOu4UQ==,iv:6zPeyrcE4WYr081QcOiMIsaEm8TkvFrvuK+H89IfCuY=,tag:TQpaket+o3TQ68NsV0dhvw==,type:str]
+  hostname: ENC[AES256_GCM,data:Qvbs8FnDY6ViPGZmq8fFLKAfdMIXYqbnSs4OtmLgAMXjYPr652Q=,iv:Ro2dVVkg7Goxwl8OIRiComFYA35s5x/ELPKGPP7Eze8=,tag:eaP88Npk4A3gjHbzPyTg5Q==,type:str]
+  password: ENC[AES256_GCM,data:31Zoqscdr74rcWnYeiUcxiQjxd2uMgEGxSCz1UT2cjI=,iv:+z7zMdrp6tAYkP2W/17RoWtQD2NUO8awXypSeKLALhA=,tag:8qcVfn8oVBOzNcSNCDfCKw==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
 apiVersion: v1
@@ -774,42 +822,42 @@ metadata:
   labels:
     cnpg.io/reload: "true"
 stringData:
-  username: ENC[AES256_GCM,data:dAxrALlLQA8s3zylBwDBU6gg,iv:EL6zeWPkCplgeT3DkAW4kIaf3eBs3JnI293/9wCwQTQ=,tag:Z+kAwci7F7uHFTqgmAwXZw==,type:str]
-  database: ENC[AES256_GCM,data:DgPD/3+Vlk4=,iv:D7rgqlLbr5fvhz8oy/GC3CAh2ScdpwydNoh8xBVgTK0=,tag:owFh2QDJ57JLqv0M0K4vSA==,type:str]
-  port: ENC[AES256_GCM,data:DouW/g==,iv:SjKGCUNXGWF5pfzfQxq3Nz6QWf8yFMmjrncVFGNBT+0=,tag:hSlEY1LwKRe+f7mNu332eA==,type:str]
-  hostname: ENC[AES256_GCM,data:5UbcQ86e+ia+wSGGegRuzcwZsHtaZ+Npg9FWF2ymqsNwvO9dO0A=,iv:Y5kTDvoPKvxBrKWKqh+6vKSc1Wd4jECpgABtAxjI8DA=,tag:DPRs9k+sNcw1GXYL98kKug==,type:str]
-  password: ENC[AES256_GCM,data:VFhK6BsHPAisju9XQ0a2kFKHRKNblN36HXCSvkM80U1ybN4G/J5ANYL3AX6eFksfPnCSXQDmyqWjnNDrJfdGSA==,iv:8kKoBaV/OQholy7Pp2BilMLjeMavjefzZ/w0DcedFI0=,tag:Tuiyrl8MSL5+2Zzk+a3RaA==,type:str]
+  username: ENC[AES256_GCM,data:g53SfKqed/83LXmTNQD+EPtR,iv:fRWivZ2C7XHTh6NRulFW9sMfVsSW+c6NwnYmdzKtjSs=,tag:Rj+Us+aLZ2g5zJCMQhzpeA==,type:str]
+  database: ENC[AES256_GCM,data:5ym6ZPbMxF8=,iv:oLJJTLGG5eUgm6x6MVnSylXju1zPUHvXOmOE3af5Htg=,tag:+mvJtpzg/8PBVvHTXUCEiw==,type:str]
+  port: ENC[AES256_GCM,data:/BYdng==,iv:kPcHRV0PQM1bO/wJtgRw4uRR4olrZAuLkh3JD39ibFg=,tag:pEdUDOi84125HYqNkYBx6w==,type:str]
+  hostname: ENC[AES256_GCM,data:G8gTI29Zw9aWro2waB/ek2Uk2raAercP2CQNSICbjLLrw+sJEd8=,iv:QqdO5P4cJ7bMzEJAIxwXaEtELTnZZgKn9+pYkzdMGBo=,tag:ckLuvCkihsIUaS20VM/XeA==,type:str]
+  password: ENC[AES256_GCM,data:UtDGty5O+ozIiN5bB7NnDSCUwlT/qiwTKQu6qeSJrkZmniAGWUwLsbhskjUE5TF+eTc1oBkF28fFeb0ockxcRA==,iv:Jyt0GzxpjXs7lf9FTHOLuhaE6NvrQ+yDKRrGKQmfPX0=,tag:fP6WCHyiXbYe5KEt4+cu5Q==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBOVdxQ01SY2szNTVNdjc0
-        N2Q0K3N2ZmR3dnl2ZnJwSGJVb2hpdlI3MDBjCkljWWF0MFo5NklLcnI5Qytnb0dz
-        OENlU2drbXQ1VWtPNG5Vd2JiZUhjZHcKLS0tIFVyOUlLQVpmQ3JjL1gvQUhHVjY2
-        MW1RT0greEFZakoxY1F5NlEwcEYyVEEK0BCHQNia0TxJNK6+U61/rrfO4tigwSih
-        DlMfKWRrqmTM1yMvhiid/5uaVqFqSrd88ZY3E3FOS8lSVMnjYOeWXw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVVlBYXRDV1UxcVZKVnZ3
+        WEQ4a2x3S1ZJSFhPZTVaUVJjbmovQ0xJb2lJCmhISjVzdExpRWRyTXZuamQrSFRj
+        MktpbWE0NXUvaEp2VzVwNk80QnYvY3cKLS0tIHVReW1MOHA4ZEd6K0VENW5tT2ov
+        ZDcxOThYL0svNG42QytlTENJeXhoakUKZH6scNgQ03d9ihBxspuKQFifZrg4bZMo
+        hNwKmXa8GRY77wr+W33w0KLibMYkG8sVkcDoyKynRdk6WwcQpu4yPg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvdTZlbThQbXVxK0szRzFp
-        NGxUS0ZxVG1ndy9qMEFUd0V4RHd3TW9xUmxrCk1YdGtLb3hnSDFJdytnSGt5TUp6
-        cDVwRXRtakR4SXVrZElrQjd2ZVRnNDgKLS0tIE1lMnZMbEhEYVBSU1ordEw2c2o1
-        OGpjSWhLa1ZDZG1TTDdQZXdLTlJVUTQKlfaRb7VvBCh/7CKrSsc32pId9HEFP7+V
-        xUn4XLnBF9yDRIzmf6gsjM+3Qv9QhWxD63zmHl/pSpgrnLjjJ0DTfw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzA2WWNoVXdEcGtvZldj
+        WUxpQ3cxLzNNOGxnck9vdlNkdlFjdml4bXlBCmtIR1hrNXltRzd0QjNnTDV1OVVP
+        OHM5c0hxY1FwMEYwYng3cjQ3TEMyRjgKLS0tIFdKSzRZMFVIekhZQTY5Q05YUWc1
+        MXlEaVd4M21GZXgzRUlUZWZ3azhJaTgKbznFEwoC/0wiAWDJdGuLakl/NcTzcCuZ
+        ucUVNF/YcsoZK3i3eqUu4MNwhRO2zz4qKDV1J2pjjATfxKFn/UX9Pg==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYXBYeUhTQ3AxUVNxaHda
-        TUx5a1RzSHhJY2VrRy95SXZ1UW8rV0kyWjBzCnhTSXhQaW50SWk0NUpleWVPOEkz
-        dytIRTJJK09hQkc0QjFneXJ6ZGxLMEEKLS0tIFp2NDh2VDdKVlQrZUNUa2MvUmt5
-        M1pkZXZxOHFmM1dVSGI4Mk8yeGw5Z0UKf7TubZBA0ELlOGn9cq+GPGkPlKEYE8Fc
-        aAD6uclNaESm4A4+n8qMdYjtkOuaft0yx3et9+8VPBf2CzRQOEX89g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTVRncEdWKytQeTZPZkVn
+        YTBpdzZoeUpYRWUwemR0bWJYVzZBT0dWNENVCksvY0tHcHgzdWlMMlFyelVMRUdx
+        TzZBSXA0bzgwNG9NUi9CWTR1OTJPSEUKLS0tIDMycDFLWVc1RmI5QjlEaklvSjdI
+        QjU0Y1plamlZVmUxRGVlRjc3ZndFcUkKkxNp1pYfqjPHlyobLnJwuopdOpDQeD4F
+        iUCKjA01/uYmHqCXJVTxd3eheuzcUr5rd/2Glzj77syW/3937UAIUw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-07T15:10:01Z"
-  mac: ENC[AES256_GCM,data:n2qb73zx6bXDNebS3ezRfECRf5SfQ16yQrwDmKglaDo/0yjSIKoXtJmfT4ibzUGO+YeIEjQs4ezHyMEuO+IYRjOzFh1jRUtDuJWc1O/AQbxEkL4YFafQhA7/rDAP2narbqimisF8HAVwbV7WVxZXpoVrXbDubKCQviVAT1My99o=,iv:DtUAULKPPGSdaWyk6H0xmAYpAM7Cxhp9M0szcAUIrKU=,tag:jNcyH6URY+IH5wYKf3SV5g==,type:str]
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.3
+  version: 3.13.2

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -91,6 +91,12 @@ cluster:
     superuser: false
     passwordSecret:
       name: openbao-postgres-password
+  - name: coder
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: coder-postgres-password
   - name: tandoor
     ensure: present
     login: true

--- a/kubernetes/apps/database/postgres/app/users.yaml
+++ b/kubernetes/apps/database/postgres/app/users.yaml
@@ -279,6 +279,98 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: &name coder-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "coder-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app coder
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: coder
+  owner: coder
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: coder
+    - ensure: present
+      name: coder
+      owner: coder
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: &name tandoor-postgres
   annotations:
     reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/database/postgres/postgres-push-secrets/push-secrets.yaml
+++ b/kubernetes/apps/database/postgres/postgres-push-secrets/push-secrets.yaml
@@ -459,6 +459,158 @@ spec:
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
+  name: coder-postgres-push-secret
+spec:
+  deletionPolicy: None
+  refreshInterval: 24h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-connect
+  selector:
+    secret:
+      name: coder-postgres
+  data:
+    - match:
+        secretKey: username
+        remoteRef:
+          remoteKey: &key ${CLUSTER_CNAME}-coder-postgres
+          property: username
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: *key
+          property: password
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: hostname
+        remoteRef:
+          remoteKey: *key
+          property: hostname
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-hostname
+        remoteRef:
+          remoteKey: *key
+          property: public-hostname
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: port
+        remoteRef:
+          remoteKey: *key
+          property: port
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: database
+        remoteRef:
+          remoteKey: *key
+          property: database
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: pgpass
+        remoteRef:
+          remoteKey: *key
+          property: pgpass
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: jdbc-uri
+        remoteRef:
+          remoteKey: *key
+          property: jdbc-uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: uri
+        remoteRef:
+          remoteKey: *key
+          property: uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: uriql
+        remoteRef:
+          remoteKey: *key
+          property: uriql
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-jdbc-uri
+        remoteRef:
+          remoteKey: *key
+          property: public-jdbc-uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-uri
+        remoteRef:
+          remoteKey: *key
+          property: public-uri
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-uriql
+        remoteRef:
+          remoteKey: *key
+          property: public-uriql
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: connection-string
+        remoteRef:
+          remoteKey: *key
+          property: connection-string
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+    - match:
+        secretKey: public-connection-string
+        remoteRef:
+          remoteKey: *key
+          property: public-connection-string
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec: {}
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
   name: tandoor-postgres-push-secret
 spec:
   deletionPolicy: None

--- a/kubernetes/apps/network/certificates/production.yaml
+++ b/kubernetes/apps/network/certificates/production.yaml
@@ -24,3 +24,6 @@ spec:
     # - "*.web.${CLUSTER_DOMAIN}"
     - "*.${INTERNAL_DOMAIN}"
     - "*.${EXTERNAL_DOMAIN}"
+    # Coder per-workspace app subdomains (code.${ROOT_DOMAIN} itself is already
+    # covered by the *.${ROOT_DOMAIN} wildcard above).
+    - "*.code.${ROOT_DOMAIN}"

--- a/kubernetes/apps/network/certificates/staging.yaml
+++ b/kubernetes/apps/network/certificates/staging.yaml
@@ -24,3 +24,6 @@ spec:
     # - "*.web.${CLUSTER_DOMAIN}"
     - "*.${INTERNAL_DOMAIN}"
     - "*.${EXTERNAL_DOMAIN}"
+    # Coder per-workspace app subdomains (code.${ROOT_DOMAIN} itself is already
+    # covered by the *.${ROOT_DOMAIN} wildcard above).
+    - "*.code.${ROOT_DOMAIN}"

--- a/kubernetes/apps/observability/grafana/dashboards/coder.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/coder.yaml
@@ -1,0 +1,1013 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: coder
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  title: "Coder"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: coder
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folder: "coder"
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  # Upstream https://github.com/coder/coder/blob/main/examples/monitoring/dashboards/grafana/dashboard.json
+  # with the filter_key/filter_value import constants pinned to this deployment.
+  json: |
+    {
+      "__elements": {},
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "9.5.3"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "CPU seconds"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "rate(process_cpu_seconds_total{$filter_key=\"$filter_value\"}[$__rate_interval])",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "coderd_api_active_users_duration_hour{$filter_key=\"$filter_value\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Active Users",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 16,
+            "y": 0
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "sum(coderd_agents_up{$filter_key=\"$filter_value\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Running agents",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 20,
+            "y": 0
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "avg(coderd_agents_connection_latencies_seconds{$filter_key=\"$filter_value\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Avg connection latency",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/coderd_provisionerd_num_daemons/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Running provisioners"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/coderd_provisionerd_jobs_current/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Running jobs"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "coderd_provisionerd_jobs_current{$filter_key=\"$filter_value\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "coderd_provisionerd_num_daemons{$filter_key=\"$filter_value\"}",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Concurrent jobs",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*coderd_db_query_latencies_seconds_count.*/"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "none"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Queries/s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*coderd_db_query_latencies_seconds_bucket.*/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "P95 query latency"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(coderd_db_query_latencies_seconds_bucket{$filter_key=\"$filter_value\"}[$__rate_interval])))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "sum(rate(coderd_db_query_latencies_seconds_count{$filter_key=\"$filter_value\"}[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Query latency and rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/go_memstats_alloc_bytes/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Allocated bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/go_goroutines/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Goroutines"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "go_memstats_alloc_bytes{$filter_key=\"$filter_value\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "go_goroutines{$filter_key=\"$filter_value\"}",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Heap and Goroutines",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/coderd_api_requests_processed_total{code=\"500\"}/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Error rate"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/coderd_api_requests_processed_total/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Request rate"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/coderd_api_request_latencies_seconds_bucket/"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "P95 request latency"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "sum(rate(coderd_api_requests_processed_total{$filter_key=\"$filter_value\"}[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "sum(rate(coderd_api_requests_processed_total{code=\"500\"}[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(coderd_api_request_latencies_seconds_bucket[$__rate_interval])))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "API Requests and Error Rate",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "description": "The key to use for filtering metrics",
+            "hide": 2,
+            "label": "Filter key",
+            "name": "filter_key",
+            "query": "namespace",
+            "skipUrlSync": false,
+            "type": "constant",
+            "current": {
+              "value": "namespace",
+              "text": "namespace",
+              "selected": false
+            },
+            "options": [
+              {
+                "value": "namespace",
+                "text": "namespace",
+                "selected": false
+              }
+            ]
+          },
+          {
+            "description": "The value to use for filtering metrics",
+            "hide": 2,
+            "label": "Filter value",
+            "name": "filter_value",
+            "query": "coder",
+            "skipUrlSync": false,
+            "type": "constant",
+            "current": {
+              "value": "coder",
+              "text": "coder",
+              "selected": false
+            },
+            "options": [
+              {
+                "value": "coder",
+                "text": "coder",
+                "selected": false
+              }
+            ]
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Coder Dashboard",
+      "uid": "cb63c6ac-e392-42a9-a966-ee642b9c997c",
+      "version": 10,
+      "weekStart": ""
+    }

--- a/kubernetes/apps/observability/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cadvisor.yaml
+  - ./coder.yaml
   - ./flux.yaml
   - ./gpu.yaml
   - ./kubernetes.yaml


### PR DESCRIPTION
Deploys [Coder](https://coder.com) (self-hosted cloud development environments) via the upstream `coder-v2` Helm chart.

## Layout

Its own `coder` namespace rather than `equestria/home` — the chart's ServiceAccount gets RBAC to create and manage pods, PVCs, and deployments in its release namespace, and workspaces spawn there as pods. That authority should not extend over the namespace every other app runs in.

## Identity

Authentik OIDC is the only way in; `CODER_DISABLE_PASSWORD_AUTH=true`. Coder OSS has no IdP role sync (that is a Premium feature), so the mapping is done the OSS way:

- **Who can sign in at all** — `access_policy.groups: [admins, family]` on the `ApplicationDefinition`, enforced Authentik-side.
- **Member** — automatic; every OIDC login lands as a regular member.
- **Owner/admin** — the first OIDC login receives the owner role (`coderd/userauth.go` grants `RoleOwner` when the user count is zero, and allows that signup regardless of settings). Any further admins are promoted in-app.

Break-glass if the owner is ever lost: `kubectl -n coder exec deploy/coder -- coder server create-admin-user`.

## Routing and TLS

`code.driscoll.tech` on the internal Traefik Gateway, plus the standard tailscale ingress component (`code.${TAILSCALE_DOMAIN}`). No external gateway.

A second HTTPRoute serves `*.code.driscoll.tech` for per-workspace apps and dashboard port forwarding. It uses `local-api` instead of `local-user` — those connections proxy websockets and stream non-200 responses that the `error-pages` middleware in `local-user` would mangle; the `internal-network` guard is kept. `*.code.${ROOT_DOMAIN}` is added to the shared Let's Encrypt certificates, since `*.driscoll.tech` is single-label and does not cover it.

## Observability

- **PodMonitor, not Service + ServiceMonitor.** The shared components apply `commonLabels` that kustomize also injects into Service selectors, adding `driscoll.dev/name` — a label the Helm-created coder pods do not carry, so a hand-written metrics Service would select nothing. A PodMonitor's `spec.selector.matchLabels` is left untouched by that transformer.
- Baseline `PrometheusRule`: coderd absent, repeated workspace build failures, agents stuck in a failed startup state.
- The upstream Coder Grafana dashboard, with its `filter_key`/`filter_value` import constants pinned to `namespace`/`coder`.
- Logs need nothing app-specific — Alloy already ships all pod output to Loki.

## Notes

- Postgres comes from the shared CNPG cluster via the postgres component; the generator output for the `coder` role is in this branch.
- `failover/fast-node-eviction` is deliberately skipped: it patches `defaultPodOptions`, which only the app-template chart reads. The equivalent tolerations are set natively under `coder.tolerations`.
- **After merge**, run the home-operations `stacks/applications` Pulumi stack so Authentik provisions `coder-oidc-credentials`. Until then the coder pod will crash-loop on the missing secret — expected ordering.

## Validation

- `flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets` — 332 passed, 2 skipped, no new warnings.
- `eso-values-lint` — 0 findings. `yamllint` — clean.
- Rendered output verified: env vars resolve to the right secret keys, both HTTPRoutes attach to the `internal` Gateway (listeners are hostname-less with `from: All`), the tailscale ingress targets the chart's `coder`/`http` service, and the decrypted postgres password diff adds only the `coder` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)