### PR TITLE
feat(openbao): TEMPORARY generate-root window for the policy + approle work

### DIFF
--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -85,6 +85,32 @@ spec:
             // TLS terminates at the internal gateway and this listener is only
             // reachable in-cluster, matching the other kube-system services.
             tls_disable = true
+
+            // ██ TEMPORARY BOOTSTRAP TOGGLE — REVERT AS SOON AS THE WINDOW CLOSES ██
+            //
+            // OpenBao >= 2.5.3 disables the unauthenticated sys/generate-root/*
+            // endpoints by default — they 403 even from localhost inside the
+            // pod, so the recovery shares alone cannot mint a root token (see
+            // vault:docs/openbao-migration/STATUS.md, "Facts established the
+            // hard way").
+            //
+            // Second time this has been opened. It is needed for work that only
+            // an `admin` token can do, and nothing automated holds that policy:
+            //   - vault#155: re-write the `pulumi` policy so it can reach
+            //     sys/mounts/auth/oidc, without which the OIDC AuthBackend
+            //     update 403s and the admin/family roles never get created
+            //   - vault:bootstrap/openbao/restore-test.sh init: mint the
+            //     restore-test policy/AppRole for the Phase 5 monthly restore
+            //     test, which currently ships PROVISION-ME placeholders
+            //
+            // Both are done in ONE window on purpose — each open/close cycle
+            // costs two pod rolls and leaves generate-root reachable
+            // unauthenticated in between.
+            //
+            // REVERT THIS LINE in a follow-up commit the moment both complete.
+            // The pods must roll for the revert to take effect, same as for
+            // this commit (reloader + RollingUpdate now make that automatic).
+            disable_unauthed_generate_root_endpoints = false
           }
 
           storage "postgresql" {


### PR DESCRIPTION
## What

Re-opens `disable_unauthed_generate_root_endpoints = false` on the openbao tcp listener, undoing #3070 for as long as the work below takes.

## Why it has to be open again

Two pieces of outstanding work need an `admin` token, and **nothing automated holds the `admin` policy** — the recovery shares plus this toggle are the only way to get one. OpenBao >= 2.5.3 403s the unauthenticated `sys/generate-root/*` endpoints even from localhost inside the pod, so recovery shares alone are not enough.

1. **vault#155** — re-write the `pulumi` policy so it can reach `sys/mounts/auth/oidc`. `sys/auth/oidc` and `sys/mounts/auth/oidc` are separate ACL paths; the policy only had the first, so the OIDC `AuthBackend` update 403s:

   ```
   URL: GET https://bao.equestria.driscoll.tech/v1/sys/mounts/auth/oidc
   Code: 403. Errors: * permission denied
   ```

   That failure blocks the `admin` and `family` roles, which depend on the backend — the remaining reason OIDC login does not work.

2. **`restore-test.sh init`** — mint the restore-test policy/AppRole for the Phase 5 monthly restore test. The equestria `openbao-replica` secret currently ships `PROVISION-ME-run-vault-bootstrap-openbao-restore-test.sh` placeholders and fails at approle login by design.

## Batched on purpose

Each open/close cycle costs two pod rolls and leaves generate-root reachable unauthenticated in between. Doing these separately would double the exposure for no benefit.

## Closing it

The revert PR follows immediately once both are confirmed. Reloader + `RollingUpdate` (#3072, #3075) mean the revert actually reaches the pods now, which was not true the first time this was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
