### PR TITLE
feat(openbao-replica): real restore-test AppRole credentials

### DIFF
--- a/kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml
@@ -20,8 +20,8 @@ metadata:
   name: openbao-replica-restore
 type: Opaque
 stringData:
-  role-id: ENC[AES256_GCM,data:zXcCBzVTQgXXt56vU1OD2jdfHixpu9OIBoz13dm+3ITmP9jHWisFNQS3yjbasx0s35EjsMZXejU=,iv:akVoVDWtN1/31dCvbs0Ityha3DRd6tlDq2XWQ0DcRxo=,tag:OZbClq/8v8Eby/xEXpe2iw==,type:str]
-  secret-id: ENC[AES256_GCM,data:phod3WakLg88JBh4rnrMzKP1i4XKB3FYEHJMRQ9q2yfoWStd0jV0zULx8JITbRX8EIXqArSRdWo=,iv:Tvt8HxRyf1uzNskfHA9U/cQyU83DxTrOyXCYJ5HsXYU=,tag:G3e0NZVMmxwzf2N0MpMang==,type:str]
+  role-id: ENC[AES256_GCM,data:3g2jMtnhlIBIHo+jOXIZxh2LwCznX5gCoIFMOCgMW05Tf2YW,iv:0jwJb4XqVZnjoR7kitfHqL425lfNMrbDgpoVXuB04CM=,tag:GrvwW+UYYoCeDJGWmfsQ6g==,type:str]
+  secret-id: ENC[AES256_GCM,data:fJD2ji7J2pP/RkSEGZHUz1GHV9kLB4GC9R1qPxnhb6GYnwET,iv:hbGh5lql8Q/E9eKw68/s4Zeag1ayBBogYHpr7++ik6g=,tag:HCCF0xAtEwKrRzHzenuj9A==,type:str]
 sops:
   age:
     - enc: |
@@ -52,7 +52,7 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-08T15:38:28Z"
-  mac: ENC[AES256_GCM,data:f1+5jgM9sBDjPjgA1Hv27Gckc5J2vWsAoP9dU1MARKLhyTbbNPuc6fRx1J+EnHM5/3spJi9UQodZCTjc3DRR7kpubLsmtwgJgOkmqvuw4SucYwpsiZOXrbpy53DqzU/E0Q3z85EzOMgpRQPpsFG9G0tqW6sD954dzgC6yrlZToc=,iv:IaGGhYf+nG5JTFYU0z4Ci7PRlJiVH8Ev0smlFr3YJzI=,tag:jyijli91qVXwX33uu0BWsg==,type:str]
+  lastmodified: "2026-08-08T19:40:26Z"
+  mac: ENC[AES256_GCM,data:Z7Wm/8Ek0ipPq2OAzHmsZTn47dFZ4Sx7+kNK+Si8zxE7eDkaVdIp+UJdsLpZ9hNz4+gkwJP9/6LQfbLWx+rF14jt8Nr+JAgV9sJ3OCP/JSNIOabPuKWGiA2SFIRUNthOnPVz1F0dvOAvbNn8NOqeXxYb7nt2egMvo8VWCwxQ94U=,iv:iTzyl7PtCk4kZHZO/rvt126va9Fgorvtba2ijOHQQjc=,tag:t2uTUBpO59fpw4N9IXWkiw==,type:str]
   mac_only_encrypted: true
   version: 3.13.2


### PR DESCRIPTION
Replaces the `PROVISION-ME-run-vault-bootstrap-openbao-restore-test.sh` placeholders with the credentials minted during the #3078 admin window.

Until now the monthly restore-test CronJob (05:00 on the 1st) would have failed at approle login — the designed failure mode, but it means **the Phase 5 break-glass path has never been proven end to end**. The next run is the first real test of it.

Values moved between two sops processes in memory; the round trip was verified after writing and no placeholder survives in either field.

Minted by `vault:bootstrap/openbao/restore-test.sh init` — see vault#156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)