### PR TITLE
feat(external-secrets): ClusterSecretStore/openbao (Phase 6a)

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./onepassword-store.yaml
+  - ./openbao-store.yaml
   - ./kubernetes.yaml

--- a/kubernetes/apps/kube-system/external-secrets/stores/openbao-store.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/openbao-store.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: openbao
+spec:
+  provider:
+    vault:
+      # openbao-active, not openbao: the chart labels the leader pod and this
+      # Service selects only it. The general `openbao` Service also routes to
+      # standbys, which answer reads with a 307 redirect to the leader — extra
+      # hops for no benefit, and a source of confusing intermittent failures.
+      server: http://openbao-active.kube-system.svc.cluster.local:8200
+      # The kv-v2 mount holding real secrets. `docs/` and `meta/` are separate
+      # mounts and would each need their own store if anything ever consumes
+      # them from in-cluster (nothing does today — see PLAN.md §A).
+      path: secrets
+      version: v2
+      auth:
+        # Kubernetes auth rather than a stored token or AppRole: ESO presents
+        # its own ServiceAccount token and OpenBao validates it against the
+        # cluster's API. Nothing to rotate and nothing to leak, and it is why
+        # OpenBao lives in kube-system alongside ESO.
+        kubernetes:
+          mountPath: kubernetes
+          # Bound in OpenBao to this exact ServiceAccount + namespace, and
+          # carries the `eso-equestria` policy: read on secrets/shared/* and
+          # secrets/clusters/equestria/*. See vault:bootstrap/openbao/equestria-init.sh.
+          role: eso-equestria
+          serviceAccountRef:
+            name: external-secrets
+            namespace: kube-system


### PR DESCRIPTION
The store `PLAN.md` §B assumed existed and never did. Phase 3 enabled the `kubernetes` auth method on the server, but no store resource was ever created:

```console
$ kubectl get clustersecretstore
backup  cluster  database  network  onepassword-connect     # no openbao
```

Nothing can be cut over until this lands, so it gates all of Phases 6–7.

## Two choices worth the comments they carry

**`openbao-active`, not `openbao`.** The chart labels the leader pod and that Service selects only it. The general Service also routes to standbys, which answer reads with a 307 redirect to the leader — extra hops for no benefit, and a good source of confusing intermittent failures.

**`kubernetes` auth, not a stored token or AppRole.** ESO presents its own ServiceAccount token and OpenBao validates it against the cluster API. Nothing to rotate, nothing to leak — and it's the reason OpenBao was put in `kube-system` alongside ESO in the first place.

## Already verified

The `eso-equestria` role this binds to is created in vault#159, and was tested end to end before this was written — a real ServiceAccount token exchanged at `auth/kubernetes/login`:

```
policies: ["default","eso-equestria"]  ttl=3600s
secrets/data/shared/*                  -> 200
secrets/data/clusters/equestria/*      -> 200
sgc / meta / hosts                     -> 403
```

So this should report `Valid` on first reconcile rather than needing a second pass.

**No ExternalSecret references this store yet** — migrating the 93 refs and converting the 22 `OnePasswordItem` CRs is the rest of Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)