### PR TITLE
feat(obsidian-sync): Phase 6 pilot — first ExternalSecret onto OpenBao

### DIFF
--- a/kubernetes/apps/equestria/home/obsidian-sync/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/externalsecret.yaml
@@ -6,9 +6,19 @@ metadata:
   name: ${APP}
 spec:
   refreshInterval: 1h
+  # PHASE 6 PILOT — first ExternalSecret moved from 1Password to OpenBao.
+  #
+  # Chosen deliberately: one standalone app, one key, nothing else depends on
+  # this Secret, and a failure shows up as CouchDB rejecting auth rather than as
+  # anything cluster-wide.
+  #
+  # The `key` below is now a path INSIDE the `secrets` mount — the store pins
+  # `path: secrets`, so it is not repeated here. Field names are unchanged
+  # (`username`, `password`), which is why the template needs no edit: Phase 4
+  # migrated the item field-for-field.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: obsidian-sync-secret
     creationPolicy: Owner
@@ -19,4 +29,5 @@ spec:
         couchdb-password: "{{ .password }}"
   dataFrom:
     - extract:
-        key: Obsidian Sync
+        # was: Obsidian Sync   (1Password item title in vault Eris)
+        key: shared/obsidian-sync


### PR DESCRIPTION
The first of **78** ExternalSecrets to move off `onepassword-connect`.

## Why this one

Chosen for blast radius, not convenience:

- one standalone app, one key
- **nothing else consumes `obsidian-sync-secret`**
- pure 1Password source (no `sourceRef` override — 15 of the 93 have one, and I nearly picked one of those by mistake)
- failure surfaces as CouchDB rejecting auth, not as anything cluster-wide
- not storage, not cluster infrastructure

## Verified before writing it

```
secrets/shared/obsidian-sync   fields: passphrase, password, username
                               custom_metadata.source_title: Obsidian Sync
```

The template interpolates `.username` and `.password` — both present — so it needs **no edit**. Phase 4 migrated the item field-for-field. The extra `passphrase` field is harmless; `dataFrom.extract` supplies what the template asks for.

## The change

```diff
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   dataFrom:
     - extract:
-        key: Obsidian Sync
+        key: shared/obsidian-sync
```

The key becomes a path *within* the `secrets` mount — `ClusterSecretStore/openbao` pins `path: secrets` rather than repeating it per reference.

## Verifying after merge

`refreshInterval` is **1h**, so the old Secret keeps serving until the next refresh — **"it still works" proves nothing here.** Check the object, and force a refresh rather than waiting:

```bash
kubectl -n equestria annotate externalsecret obsidian-sync force-sync="$(date +%s)" --overwrite
kubectl -n equestria get externalsecret obsidian-sync -o jsonpath='{.status.conditions[-1].reason}'
```

Expect `SecretSynced`. Then confirm `obsidian-sync-secret` still carries `couchdb-user`/`couchdb-password` and that the app can still reach CouchDB.

`deletionPolicy: Retain` means a failed sync leaves the existing Secret in place, so the app keeps working while we debug — the reason this is a safe first move.

Plan and inventory: vault#161, corrected in vault#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)