### PR TITLE
fix(coder): OIDC login has been broken for two days — repoint at OpenBao

### DIFF
--- a/kubernetes/apps/coder/coder/externalsecret.yaml
+++ b/kubernetes/apps/coder/coder/externalsecret.yaml
@@ -47,9 +47,19 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
+  # ClusterSecretStore/cluster reads Secrets out of the `equestria` namespace
+  # (remoteNamespace: equestria). Coder lives in its own `coder` namespace, so
+  # its coder-oidc-credentials Secret was never visible to that store and this
+  # ExternalSecret has been SecretSyncedError since 2026-08-08T18:25Z —
+  # "could not get secret data from provider" — leaving OIDC login broken.
+  #
+  # OpenBao is the fix rather than a workaround: Phase 8a writes this exact
+  # credential to secrets/clusters/equestria/apps/coder/oidc, with field names
+  # identical to the in-cluster Secret, and it is namespace-independent by
+  # construction.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: cluster
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -65,12 +75,14 @@ spec:
         client_id: "{{ .oidc_client_id }}"
         client_secret: "{{ .oidc_client_secret }}"
   dataFrom:
+    # Path within the `secrets` mount; the store pins `path: secrets`.
+    # was: '${APP}-oidc-credentials' out of ClusterSecretStore/cluster
     - extract:
-        key: '${APP}-oidc-credentials'
+        key: clusters/equestria/apps/${APP}/oidc
       sourceRef:
         storeRef:
           kind: ClusterSecretStore
-          name: cluster
+          name: openbao
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
`coder-oidc-secret` has been `SecretSyncedError` since **2026-08-08T18:25Z** — *"could not get secret data from provider"* — so **Coder's OIDC login is broken right now**. Found while verifying the Phase 6 pilot; unrelated to it.

## Cause

`ClusterSecretStore/cluster` reads Secrets out of the **`equestria`** namespace:

```json
{"kubernetes":{"remoteNamespace":"equestria", ...}}
```

Coder was deployed into its own **`coder`** namespace. Its `coder-oidc-credentials` Secret exists, with all 9 fields — but in `coder`, where that store cannot see it.

That store's `remoteNamespace` is a cluster-wide assumption, so **any app deployed outside `equestria` breaks this way silently.** Coder is just the first.

## Why OpenBao is the fix, not a workaround

Phase 8a already writes this exact credential to `secrets/clusters/equestria/apps/coder/oidc`, and the field names are identical to the in-cluster Secret:

```
authorization_url, client_id, client_secret, end_session_url, issuer,
jwks_url, openid_configuration_url, token_url, userinfo_url
```

Both sides verified live before writing this. The `rewrite` rules and the `template` are unchanged.

It's also **namespace-independent by construction**, which the `cluster` store is not — so this class of break cannot recur for Coder, and the same move fixes any future out-of-namespace app.

## Alternatives considered

- *Move the Secret into `equestria`* — puts one app's credential in another app's namespace to satisfy a store's assumption
- *Add a second store with `remoteNamespace: coder`* — one store per namespace, forever

## Phase 6 status

Second ExternalSecret onto OpenBao. Unlike the pilot (`obsidian-sync`, verified green — values hash-match OpenBao, app returns 200), **this one is currently failing**, so success is unambiguous:

```bash
kubectl -n coder get externalsecret coder-oidc-secret -o jsonpath='{.status.conditions[-1].reason}'
# expect SecretSynced, currently SecretSyncedError
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)