### PR TITLE
feat(eso): move kometa and playerr onto OpenBao (Phase 6 batch 2)

### DIFF
--- a/kubernetes/apps/equestria/games/playerr/externalsecret.yaml
+++ b/kubernetes/apps/equestria/games/playerr/externalsecret.yaml
@@ -7,9 +7,12 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
+  # Phase 6: reads from OpenBao. The key is a path within the `secrets` mount —
+  # ClusterSecretStore/openbao pins `path: secrets`. Field names are unchanged
+  # from the 1Password item, so the rewrite rules and template are untouched.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -28,7 +31,8 @@ spec:
         PROWLARR_URL: "prowlarr.equestria.svc.cluster.local:9696"
   dataFrom:
     - extract:
-        key: 'Twitch Developer'
+        # was: Twitch Developer
+        key: shared/twitch-developer
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/media/kometa/externalsecret.yaml
+++ b/kubernetes/apps/equestria/media/kometa/externalsecret.yaml
@@ -4,9 +4,12 @@ kind: ExternalSecret
 metadata:
   name: kometa
 spec:
+  # Phase 6: reads from OpenBao. The key is a path within the `secrets` mount —
+  # ClusterSecretStore/openbao pins `path: secrets`. Field names are unchanged
+  # from the 1Password item, so the rewrite rules and template are untouched.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: kometa-secret
     creationPolicy: Owner
@@ -22,7 +25,8 @@ spec:
         KOMETA_SONARR_APIKEY: "{{ .sonarr_apikey }}"
   dataFrom:
     - extract:
-        key: Media Management Secrets
+        # was: Media Management Secrets
+        key: shared/media-management-secrets
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
Third and fourth ExternalSecrets off `onepassword-connect`, after the `obsidian-sync` pilot and the `coder` fix.

## `meilisearch-env` was in this batch and I pulled it

Its OpenBao entry `secrets/shared/meilisearch-secret-key` has **zero fields** — `mapping.yaml` recorded `fields: []` at migration time, so there was nothing to migrate.

1Password renders `MEILI_MASTER_KEY` as **0 bytes** today, so the master key is already empty. But an empty KV entry may make ESO error outright rather than render empty, turning a quiet problem into `SecretSyncedError`. Not worth finding that out on an app whose key is already broken.

## Parity checked per field, against the live server

| | Result |
|---|---|
| **kometa** | template wants `mdblist_apikey plex_token radarr_apikey sonarr_apikey tautulli_token tmdb_apikey omdb_apikey`. OpenBao has all but `omdb_apikey` — and **1Password doesn't have it either** (`mapping.yaml` lists 18 fields, no omdb), so `KOMETA_OMDB_APIKEY` already renders 0b. Migrating is neutral for that field. |
| **playerr** | template wants `twitch_credential twitch_username`; OpenBao has `credential` and `username`, and the existing `rewrite` prepends `twitch_`. |

That second row is worth flagging as a method note: **my first parity check reported a false mismatch on playerr because it didn't model the `rewrite` rules.** Any bulk-migration tooling has to apply rewrites before comparing field names, or it will reject perfectly good migrations.

## Pre-existing bugs surfaced, not caused here

Both are 0 bytes *today*, from 1Password, and deserve a separate fix:

- `KOMETA_OMDB_APIKEY` — field absent from the 1Password item entirely
- `MEILI_MASTER_KEY` — Meilisearch running with an empty master key

## Verifying

```bash
kubectl -n equestria annotate externalsecret kometa force-sync="$(date +%s)" --overwrite
kubectl -n equestria annotate externalsecret playerr-env force-sync="$(date +%s)" --overwrite
kubectl -n equestria get externalsecret kometa playerr-env
```

Both are `deletionPolicy: Retain`, so a failed sync leaves the current Secret in place.

Running total: 4 of 78 on OpenBao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
