### PR TITLE
fix(kometa): empty is not missing — index the absent omdb_apikey

### DIFF
--- a/kubernetes/apps/equestria/media/kometa/externalsecret.yaml
+++ b/kubernetes/apps/equestria/media/kometa/externalsecret.yaml
@@ -5,8 +5,19 @@ metadata:
   name: kometa
 spec:
   # Phase 6: reads from OpenBao. The key is a path within the `secrets` mount —
-  # ClusterSecretStore/openbao pins `path: secrets`. Field names are unchanged
-  # from the 1Password item, so the rewrite rules and template are untouched.
+  # ClusterSecretStore/openbao pins `path: secrets`.
+  #
+  # ⚠️ EMPTY IS NOT MISSING. 1Password carried an `omdb_apikey` field with an
+  # empty value, so `{{ .omdb_apikey }}` rendered "". Phase 4 did not migrate
+  # empty-valued fields, so in OpenBao the key is ABSENT — and ESO renders
+  # templates with missingkey=error, which fails the whole ExternalSecret:
+  #
+  #   executing "KOMETA_OMDB_APIKEY" at <.omdb_apikey>:
+  #     map has no entry for key "omdb_apikey"
+  #
+  # Hence `index` below: it returns the zero value for a missing key instead of
+  # erroring, so the rendered Secret is byte-identical to the 1Password era.
+  # Any template referencing a field that was empty in 1Password needs this.
   secretStoreRef:
     kind: ClusterSecretStore
     name: openbao
@@ -19,7 +30,8 @@ spec:
         KOMETA_PLEX_APIKEY: "{{ .plex_token }}"
         KOMETA_TAUTULLI_APIKEY: "{{ .tautulli_token }}"
         KOMETA_TMDB_APIKEY: "{{ .tmdb_apikey }}"
-        KOMETA_OMDB_APIKEY: "{{ .omdb_apikey }}"
+        # Deliberately `index`, not `.omdb_apikey` — see the note above.
+        KOMETA_OMDB_APIKEY: '{{ index . "omdb_apikey" | default "" }}'
         KOMETA_MDBLIST_APIKEY: "{{ .mdblist_apikey }}"
         KOMETA_RADARR_APIKEY: "{{ .radarr_apikey }}"
         KOMETA_SONARR_APIKEY: "{{ .sonarr_apikey }}"


### PR DESCRIPTION
`kometa` went `SecretSyncedError` immediately after moving to OpenBao in #3086:

```
unable to mutate secret kometa-secret: could not apply template:
executing "KOMETA_OMDB_APIKEY" at <.omdb_apikey>:
map has no entry for key "omdb_apikey"
```

## Empty is not missing

1Password carried an `omdb_apikey` field with an **empty value**, so `{{ .omdb_apikey }}` rendered `""` — `KOMETA_OMDB_APIKEY` has been 0 bytes for as long as it has existed.

Phase 4 **did not migrate empty-valued fields**, so in OpenBao the key is *absent* rather than empty. ESO renders templates with `missingkey=error`, which fails the **entire ExternalSecret**, not just that one entry.

`index . "omdb_apikey"` returns the zero value for a missing key instead of erroring, so the rendered Secret is byte-identical to the 1Password era.

## The app was never at risk

`deletionPolicy: Retain` meant `kometa-secret` survived intact with all 7 keys throughout — the failure was confined to the sync. That property is why it was worth migrating in small batches.

## This is a migration-wide class

Not a kometa quirk. **Any template referencing a field that happened to be empty in 1Password fails identically**, and there are ~74 ExternalSecrets left to move.

I wrote a scanner that diffs template references against live OpenBao fields, modelling the `rewrite` rules. Two notes on it:

- its first version produced false positives on `coder` and `playerr` because a `(.*)` source also matches the empty string at the end, duplicating the prefix — the live `SecretSynced` status is what exposed the bug
- corrected, it reports `kometa` as the only affected one of the four migrated so far

That check belongs in the loop before each future batch rather than discovering this per-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
