### PR TITLE
feat(volsync): move every restic repository credential onto OpenBao

### DIFF
--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -6,9 +6,18 @@ metadata:
   name: "${APP}-volsync"
 spec:
   refreshInterval: 4m
+  # Phase 6: one edit here moves 39 ExternalSecrets across 4 namespaces —
+  # every VolSync restic repository in the estate. Verified before the change:
+  # the template reads exactly one field (.credential; RESTIC_REPOSITORY is a
+  # literal), secrets/shared/volsync-password has it at 47 bytes, and all 39
+  # rendered RESTIC_PASSWORD values were byte-identical to it.
+  #
+  # There are no rewrite rules here, so the "empty is not missing" trap that
+  # broke kometa cannot apply — that needs a template reference to a field
+  # absent in OpenBao, and the one field referenced is present.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: "${APP}-volsync-secret"
     template:
@@ -23,4 +32,6 @@ spec:
         RESTIC_PASSWORD: "{{ .credential }}"
   dataFrom:
     - extract:
-        key: 'Volsync Password'
+        # was: 'Volsync Password'   (1Password item title in vault Eris)
+        # Path within the `secrets` mount; the store pins `path: secrets`.
+        key: shared/volsync-password


### PR DESCRIPTION
One edit to `kubernetes/components/volsync/externalsecret.yaml`, moving **39 ExternalSecrets across 4 namespaces** — every VolSync restic repository in the estate.

```diff
-    name: onepassword-connect
+    name: openbao
-        key: 'Volsync Password'
+        key: shared/volsync-password
```

| Namespace | Count |
|---|---|
| equestria | 35 |
| network | 2 |
| kube-system | 1 |
| tailscale-system | 1 |

## Parity established before the change

- the template reads **exactly one field** from the store — `.credential`; `RESTIC_REPOSITORY` is a literal built from `${APP}`
- `secrets/shared/volsync-password` has that field at **47 bytes**, `source_title: Volsync Password`
- **all 39 rendered `RESTIC_PASSWORD` values are byte-identical to it**

No `rewrite` rules are involved, so the *empty is not missing* trap that broke kometa can't apply — that needs a template reference to a field absent in OpenBao, and the single referenced field is present.

## Safety

`creationPolicy: Owner` and `deletionPolicy: Retain` are both already set on the component, so a failed sync leaves every existing Secret untouched and VolSync keeps running on the credentials it already has.

## Verifying after merge

Green `SecretSynced` is necessary but not sufficient — a rendered Secret proves ESO works, not that restic can still open the repository:

```bash
kubectl get externalsecret -A | grep volsync | grep -v SecretSynced   # expect empty
kubectl get replicationsource -A                                       # then watch a job complete
```

The value is byte-identical, so this should be a formality — but it's backup plumbing and worth not assuming.

Running total after this: **43 of 78** on OpenBao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
