### PR TITLE
feat(alerts): move github-status-token onto OpenBao (17 namespaces)

### DIFF
--- a/kubernetes/components/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/alerts/github-status/externalsecret.yaml
@@ -7,7 +7,16 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    # Phase 6: one edit here moves 17 ExternalSecrets, one per namespace.
+    # Verified first — all three template fields exist in OpenBao under the
+    # same names (the [\W]->_ rewrite is a no-op, they are already snake_case),
+    # and all 17 rendered secrets matched OpenBao byte for byte across 51
+    # comparisons.
+    #
+    # NOTE: this component exists in home-operations too, and 16 equestria
+    # Kustomizations source from THAT copy. Both must change together or the
+    # apps fed from the other repo silently stay on 1Password.
+    name: openbao
   target:
     name: github-status-token-secret
     template:
@@ -17,7 +26,8 @@ spec:
         githubAppPrivateKey: "{{ .github_app_private_key }}"
   dataFrom:
     - extract:
-        key: Github Actions Runner (david-driscoll)
+        # was: Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
One edit to `kubernetes/components/alerts/github-status/externalsecret.yaml`, moving **17 ExternalSecrets** — one per namespace carrying the github-status alerting integration.

```diff
-    name: onepassword-connect
+    name: openbao
-        key: Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll
```

## Parity established before the change

All three template fields exist in OpenBao under exactly the same names, so the `[\W]->_` rewrite is a no-op (already snake_case):

```
github_app_id                len=6     sha=35ec2213
github_app_installation_id   len=8     sha=a1560cf0
github_app_private_key       len=1674  sha=7a05fc28

17 namespaces x 3 fields = 51 comparisons, 0 mismatches
```

The **1674-byte private key** is the one worth having checked — a truncated or re-wrapped PEM would still render, still look green, and only fail at use.

## Paired change in home-operations

That repo holds **its own copy** of this component, and 16 equestria Kustomizations source from it. Editing only one repo is exactly what left `dynacat` behind during the volsync step, so both ship together.

## Verifying

```bash
kubectl get externalsecret -A | grep github-status-token | grep -v SecretSynced   # expect empty
```

Low consequence if it does fail (alerting, not workload auth), which is why it's a reasonable place to take a 17-namespace fan-out in one go.

Running total after this and its twin: **60 of 78**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
