### PR TITLE
feat(eso): move the infrastructure ExternalSecrets onto OpenBao

### DIFF
--- a/kubernetes/apps/database/postgres/backups/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/backups/externalsecret.yaml
@@ -9,7 +9,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: postgres-backups
     creationPolicy: Owner
@@ -25,7 +25,8 @@ spec:
         CONNECT_TOKEN: "{{ .credential }}"
   dataFrom:
     - extract:
-        key: "Eris 1Password Connect Access Token"
+        # was: Eris 1Password Connect Access Token
+        key: shared/eris-1password-connect-access-token
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/dns/technitium/externalsecret.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -23,17 +23,21 @@ spec:
   data:
     - secretKey: DNS_SERVER_ADMIN_PASSWORD
       remoteRef:
-        key: "Technitium Password"
+        # was: Technitium Password
+        key: shared/technitium-password
         property: password
     - secretKey: DNS_SERVER_SSO_AUTHORITY
       remoteRef:
-        key: "equestria-technitium-oidc-credentials"
+        # was: equestria-technitium-oidc-credentials
+        key: clusters/equestria/apps/technitium/oidc
         property: issuer
     - secretKey: DNS_SERVER_SSO_CLIENT_ID
       remoteRef:
-        key: "equestria-technitium-oidc-credentials"
+        # was: equestria-technitium-oidc-credentials
+        key: clusters/equestria/apps/technitium/oidc
         property: client_id
     - secretKey: DNS_SERVER_SSO_CLIENT_SECRET
       remoteRef:
-        key: "equestria-technitium-oidc-credentials"
+        # was: equestria-technitium-oidc-credentials
+        key: clusters/equestria/apps/technitium/oidc
         property: client_secret

--- a/kubernetes/apps/flux-system/repositories/vault.yaml
+++ b/kubernetes/apps/flux-system/repositories/vault.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 1m
   target:
@@ -38,7 +38,8 @@ spec:
         known_hosts: "{{ .known_hosts }}"
   dataFrom:
     - extract:
-        key: "GitHub david-driscoll/vault Deploy Key"
+        # was: GitHub david-driscoll/vault Deploy Key
+        key: shared/github-david-driscoll-vault-deploy-key
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/etcd/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/etcd/externalsecret.yaml
@@ -7,12 +7,13 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: talos-etcd-restic-keys
     creationPolicy: Owner
   data:
     - secretKey: RESTIC_PASSWORD
       remoteRef:
-        key: Volsync Password
+        # was: Volsync Password
+        key: shared/volsync-password
         property: credential

--- a/kubernetes/apps/kube-system/openbao-replica/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/externalsecret.yaml
@@ -56,7 +56,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 1h
   target:
@@ -74,7 +74,8 @@ spec:
           {{ .private_key }}
   dataFrom:
     - extract:
-        key: "Rclone SFTP Key"
+        # was: Rclone SFTP Key
+        key: shared/rclone-sftp-key
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/registry/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/registry/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 1m
   target:
@@ -33,7 +33,8 @@ spec:
             templateAs: Values
   dataFrom:
     - extract:
-        key: 'Docker Hub'
+        # was: Docker Hub
+        key: shared/docker-hub
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/network/crowdsec-ui/externalsecret.yaml
+++ b/kubernetes/apps/network/crowdsec-ui/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -84,7 +84,8 @@ spec:
     # Verified against Go's regexp: step 1 leaves `password` alone (no
     # non-word characters), step 2 turns it into `webui_password`.
     - extract:
-        key: 'Crowdsec UI'
+        # was: Crowdsec UI
+        key: shared/crowdsec-ui
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/network/crowdsec/externalsecret.yaml
+++ b/kubernetes/apps/network/crowdsec/externalsecret.yaml
@@ -49,7 +49,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -104,7 +104,8 @@ spec:
     # '.data | keys'` gives username/password/database/hostname/port, which the
     # rewrite turns into the postgres_* names values.yaml asks for.
     - extract:
-        key: 'Crowdsec ApiKey'
+        # was: Crowdsec ApiKey
+        key: shared/crowdsec-apikey
     - extract:
         key: '${APP}-postgres'
       sourceRef:

--- a/kubernetes/apps/observability/thanos/externalsecret.yaml
+++ b/kubernetes/apps/observability/thanos/externalsecret.yaml
@@ -10,7 +10,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: *name
     creationPolicy: Owner
@@ -27,7 +27,8 @@ spec:
             insecure: true
   dataFrom:
     - extract:
-        key: "Thanos S3 Storage"
+        # was: Thanos S3 Storage
+        key: shared/thanos-s3-storage
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/observability/unpoller/externalsecret.yaml
+++ b/kubernetes/apps/observability/unpoller/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: *app
     template:
@@ -19,7 +19,8 @@ spec:
 
   dataFrom:
     - extract:
-        key: unifipoller
+        # was: unifipoller
+        key: shared/unifipoller
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -28,7 +29,8 @@ spec:
             source: "(.*)"
             target: "unifi_$1"
     - extract:
-        key: Unifi Api Key Eris Cluster
+        # was: Unifi Api Key Eris Cluster
+        key: shared/unifi-api-key-eris-cluster
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
Ten manifests across `kube-system`, `database`, `observability`, `network`, `flux-system` and `equestria/dns`.

| 1Password key | OpenBao path |
|---|---|
| `Volsync Password` | `shared/volsync-password` |
| `Eris 1Password Connect Access Token` | `shared/eris-1password-connect-access-token` |
| `Rclone SFTP Key` | `shared/rclone-sftp-key` |
| `Docker Hub` | `shared/docker-hub` |
| `Thanos S3 Storage` | `shared/thanos-s3-storage` |
| `Unifi Api Key Eris Cluster` / `unifipoller` | `shared/unifi-api-key-eris-cluster`, `shared/unifipoller` |
| `GitHub david-driscoll/vault Deploy Key` | `shared/github-david-driscoll-vault-deploy-key` |
| `Crowdsec ApiKey` / `Crowdsec UI` | `shared/crowdsec-apikey`, `shared/crowdsec-ui` |
| `Technitium Password` | `shared/technitium-password` |
| `equestria-technitium-oidc-credentials` | `clusters/equestria/apps/technitium/oidc` |

Field names are unchanged, so every `template:` block survives untouched.

## Paths came from the server, not from mapping.yaml

`mapping.yaml` predates the Phase 8a generated families and reports paths as missing when they exist — it undercounted readiness by 16. Every path here was resolved by asking the live OpenBao.

## The rewrite refuses rather than guesses

It's scripted, but it bails on any file where an ExternalSecret would still need `onepassword-connect` afterwards, then re-parses its own output and asserts no 1Password reference survives.

**Three files were correctly left alone by that guard:**

- `observability/grafana` keys off `${CLUSTER_CNAME}-${APP}-oidc-credentials` — a Flux substitution that can't be resolved statically
- `database/postgres/app` and `tailscale-system/resources` each mix a migratable key with a `${BACKBLAZE_*}` one that's deliberately excluded from the migration

Those need per-reference `sourceRef` surgery instead of a store flip, and follow separately.

## Validation

`flate test all` → **330 passed · 2 skipped · 2 blocked**, byte-identical to the baseline — I re-ran it with the changes stashed to confirm. Both blocked entries are pre-existing (`GitRepository` secrets flate can't resolve statically).

Running total: **70 of 78**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
