### PR TITLE
feat(eso): the three cases a store flip could not handle

### DIFF
--- a/kubernetes/apps/database/postgres/app/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/app/externalsecret.yaml
@@ -39,8 +39,18 @@ spec:
         - regexp:
             source: "(.*)"
             target: "backblaze_$1"
+    # Split source on purpose: the Minio credential has migrated to OpenBao but
+    # the ${BACKBLAZE_DATABASE} extract above has NOT (B2 is excluded from the
+    # migration, estate decision 2026-08-07). So secretStoreRef stays on
+    # onepassword-connect and only this reference is redirected — flipping the
+    # store would silently take the Backblaze extract with it.
     - extract:
-        key: 'Spike Minio Access Token'
+        # was: 'Spike Minio Access Token'
+        key: shared/spike-minio-access-token
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: openbao
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -97,8 +107,18 @@ spec:
         - regexp:
             source: "(.*)"
             target: "backblaze_$1"
+    # Split source on purpose: the Minio credential has migrated to OpenBao but
+    # the ${BACKBLAZE_DATABASE} extract above has NOT (B2 is excluded from the
+    # migration, estate decision 2026-08-07). So secretStoreRef stays on
+    # onepassword-connect and only this reference is redirected — flipping the
+    # store would silently take the Backblaze extract with it.
     - extract:
-        key: 'Spike Minio Access Token'
+        # was: 'Spike Minio Access Token'
+        key: shared/spike-minio-access-token
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: openbao
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/downloads/autobrr/externalsecret.yaml
+++ b/kubernetes/apps/equestria/downloads/autobrr/externalsecret.yaml
@@ -7,9 +7,14 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
+  # Every dataFrom below carries an explicit sourceRef, so this default store
+  # was never consulted — it named onepassword-connect purely by inheritance
+  # from the template it was copied from. Pointing it at the store actually in
+  # use removes a phantom 1Password dependency that Phase 11 would otherwise
+  # have to chase down.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: cluster
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:

--- a/kubernetes/apps/equestria/home/immich/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/immich/externalsecret.yaml
@@ -7,9 +7,14 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
+  # Every dataFrom below carries an explicit sourceRef, so this default store
+  # was never consulted — it named onepassword-connect purely by inheritance
+  # from the template it was copied from. Pointing it at the store actually in
+  # use removes a phantom 1Password dependency that Phase 11 would otherwise
+  # have to chase down.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: cluster
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -54,9 +59,14 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
+  # Every dataFrom below carries an explicit sourceRef, so this default store
+  # was never consulted — it named onepassword-connect purely by inheritance
+  # from the template it was copied from. Pointing it at the store actually in
+  # use removes a phantom 1Password dependency that Phase 11 would otherwise
+  # have to chase down.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: database
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:

--- a/kubernetes/apps/observability/grafana/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -38,7 +38,11 @@ spec:
         GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'admins') && 'GrafanaAdmin' || contains(groups[*], 'media-managers') && 'Editor' || 'Viewer'"
   dataFrom:
     - extract:
-        key: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        # was: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        # The substitution variables carry straight over — Phase 8a writes this
+        # family to clusters/<cluster>/apps/<app>/oidc, so the path is derivable
+        # from the same two vars rather than needing to be spelled out.
+        key: 'clusters/${CLUSTER_CNAME}/apps/${APP}/oidc'
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -68,7 +72,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -81,7 +85,8 @@ spec:
         admin-password: "{{ .grafana_password }}"
   dataFrom:
     - extract:
-        key: Grafana Credentials
+        # was: Grafana Credentials
+        key: shared/grafana-credentials
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/tailscale-system/resources/externalsecret.yaml
+++ b/kubernetes/apps/tailscale-system/resources/externalsecret.yaml
@@ -23,8 +23,19 @@ spec:
         AWS_ACCESS_KEY_ID: "{{ .backblaze_username }}"
         AWS_SECRET_ACCESS_KEY: "{{ .backblaze_credential }}"
   dataFrom:
+    # Split source on purpose. The restic password has migrated to OpenBao, but
+    # the Backblaze credential below has NOT — B2 is excluded from the migration
+    # (estate decision 2026-08-07) — so this ExternalSecret keeps
+    # onepassword-connect as its default store and only this reference is
+    # redirected. Flipping secretStoreRef instead would silently take the
+    # Backblaze extract with it and break the repository URL.
     - extract:
-        key: 'Volsync Password'
+        # was: 'Volsync Password'
+        key: shared/volsync-password
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: openbao
       rewrite:
         - regexp:
             source: "(.*)"


### PR DESCRIPTION
The scripted rewrite in #3090 refused these on purpose. Each needs something other than swapping `secretStoreRef`.

## 1. Split references — `postgres/app` (×2), `tailscale-system/resources`

Each pulls **one key that has migrated and one that never will**: `${BACKBLAZE_DATABASE}` and `${BACKBLAZE_S3}`, excluded by the 2026-08-07 estate decision.

Flipping `secretStoreRef` would have taken the Backblaze extract to OpenBao with it — where the path doesn't exist — **breaking the restic repository URL and the backup credentials**. Instead the default store stays on `onepassword-connect` and only the migrated reference carries an explicit `sourceRef`:

```
${APP}-values          top=onepassword-connect
    ${BACKBLAZE_DATABASE}            -> onepassword-connect
    shared/spike-minio-access-token  -> openbao
```

## 2. Substituted key — `observability/grafana`

The key is `'${CLUSTER_CNAME}-${APP}-oidc-credentials'`, which no static keymap can resolve. It doesn't need one — Phase 8a writes that family to `clusters/<cluster>/apps/<app>/oidc`, so **the same two variables build the path**:

```yaml
key: 'clusters/${CLUSTER_CNAME}/apps/${APP}/oidc'
```

The `${APP}-postgres` reference in the same file already had its own `sourceRef` and is untouched.

## 3. Vestigial stores — `autobrr`, `immich` (×2)

These named `onepassword-connect` while **every** `dataFrom` carried an explicit `sourceRef` elsewhere — so the default was never consulted. Inherited from whatever template they were copied from.

They now name the store actually in use, removing three phantom 1Password dependencies that Phase 11 would otherwise have had to chase down.

```
OK  ${APP}-oidc      top=cluster    refs=['cluster']
OK  ${APP}-config    top=cluster    refs=['cluster']
OK  ${APP}-env       top=database   refs=['database']
```

## Validation

`flate test all` → `330 passed · 2 skipped · 2 blocked`, unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
