### PR TITLE
feat(eso): the remaining app ExternalSecrets onto OpenBao

### DIFF
--- a/kubernetes/apps/equestria/games/questarr/externalsecret.yaml
+++ b/kubernetes/apps/equestria/games/questarr/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -34,7 +34,8 @@ spec:
         PROWLARR_URL: "http://prowlarr.equestria.svc.cluster.local:9696"
   dataFrom:
     - extract:
-        key: 'Twitch Developer'
+        # was: Twitch Developer
+        key: shared/twitch-developer
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -43,7 +44,8 @@ spec:
             source: "(.*)"
             target: "twitch_$1"
     - extract:
-        key: 'questarr JWT Secret'
+        # was: questarr JWT Secret
+        key: shared/questarr-jwt-secret
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/games/romm/externalsecret.yaml
+++ b/kubernetes/apps/equestria/games/romm/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -63,7 +63,8 @@ spec:
 
   dataFrom:
     - extract:
-        key: 'Twitch Developer'
+        # was: Twitch Developer
+        key: shared/twitch-developer
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -72,7 +73,8 @@ spec:
             source: "(.*)"
             target: "twitch_$1"
     - extract:
-        key: 'SteamGridDB'
+        # was: SteamGridDB
+        key: shared/steamgriddb
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -81,7 +83,8 @@ spec:
             source: "(.*)"
             target: "sgdb_$1"
     - extract:
-        key: 'Retro Achievements Api Key'
+        # was: Retro Achievements Api Key
+        key: shared/retro-achievements-api-key
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -90,7 +93,8 @@ spec:
             source: "(.*)"
             target: "retroachievements_$1"
     - extract:
-        key: 'Romm Secret Key'
+        # was: Romm Secret Key
+        key: shared/romm-secret-key
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/home/freshrss/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -47,7 +47,8 @@ spec:
         OIDC_CLIENT_CRYPTO_KEY: "{{ .crypto_password }}"
   dataFrom:
     - extract:
-        key: 'FreshRSS Crypto Key'
+        # was: FreshRSS Crypto Key
+        key: shared/freshrss-crypto-key
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/home/n8n/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/n8n/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -33,7 +33,8 @@ spec:
         N8N_LICENSE_ACTIVATION_KEY: "{{ .n8n_license_key }}"
   dataFrom:
     - extract:
-        key: 'N8N'
+        # was: N8N
+        key: shared/n8n
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/home/searxng/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/searxng/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -27,7 +27,8 @@ spec:
         SEARXNG_SECRET: "{{ .searxng_password }}"
   dataFrom:
     - extract:
-        key: 'SearXNG Secret Key'
+        # was: SearXNG Secret Key
+        key: shared/searxng-secret-key
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/home/tandoor/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -46,7 +46,8 @@ spec:
         REMOTE_USER_AUTH: "1"
   dataFrom:
     - extract:
-        key: 'Tandoor Secret Key'
+        # was: Tandoor Secret Key
+        key: shared/tandoor-secret-key
       rewrite:
         - regexp:
             source: "(.*)"

--- a/kubernetes/apps/equestria/home/tududi/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/tududi/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -30,7 +30,8 @@ spec:
         OIDC_ISSUER_URL: "{{ .oidc_openid_configuration_url }}"
   dataFrom:
     - extract:
-        key: 'Tududi'
+        # was: Tududi
+        key: shared/tududi
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/media/pinepods/externalsecret.yaml
+++ b/kubernetes/apps/equestria/media/pinepods/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -31,7 +31,8 @@ spec:
             templateAs: Values
   dataFrom:
     - extract:
-        key: 'PinePods Admin'
+        # was: PinePods Admin
+        key: shared/pinepods-admin
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/media/pulsarr/externalsecret.yaml
+++ b/kubernetes/apps/equestria/media/pulsarr/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -51,7 +51,8 @@ spec:
             source: "(.*)"
             target: "postgres_$1"
     - extract:
-        key: 'Media Management Secrets'
+        # was: Media Management Secrets
+        key: shared/media-management-secrets
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/equestria/pvr/xcproxy/externalsecret.yaml
+++ b/kubernetes/apps/equestria/pvr/xcproxy/externalsecret.yaml
@@ -9,7 +9,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: ${APP}-env
     creationPolicy: Owner
@@ -30,7 +30,8 @@ spec:
 
   dataFrom:
     - extract:
-        key: "XCProxy"
+        # was: XCProxy
+        key: shared/xcproxy
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -39,7 +40,8 @@ spec:
             source: "(.*)"
             target: "xcproxy_$1"
     - extract:
-        key: "TMDB API Key"
+        # was: TMDB API Key
+        key: shared/tmdb-api-key
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -27,7 +27,8 @@ spec:
         OIDC_SCOPES: "openid profile email"
   dataFrom:
     - extract:
-        key: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        # was: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        key: 'clusters/${CLUSTER_CNAME}/apps/${APP}/oidc'
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/secrets/docker-hub-auth/docker-hub-auth.yaml
+++ b/kubernetes/apps/kube-system/secrets/docker-hub-auth/docker-hub-auth.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -37,7 +37,8 @@ spec:
           }
   dataFrom:
     - extract:
-        key: 'Docker Hub'
+        # was: Docker Hub
+        key: shared/docker-hub
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/observability/alertmanager/alertmanager-secret.yaml
+++ b/kubernetes/apps/observability/alertmanager/alertmanager-secret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -26,7 +26,10 @@ spec:
         pushover_api_token: "{{ .pushover_credential }}"
   dataFrom:
     - extract:
-        key: ${CLUSTER_TITLE} Pushover Key
+        # was: '${CLUSTER_TITLE} Pushover Key' — CLUSTER_TITLE is the
+        # display-cased name; the OpenBao slug uses the lowercase
+        # CLUSTER_CNAME, so the substitution changes variable here.
+        key: 'shared/${CLUSTER_CNAME}-pushover-key'
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
Thirteen manifests — the rest of the equestria app group plus `headlamp`, `docker-hub-auth` and `alertmanager`. Field names unchanged throughout, so every template and `rewrite` rule survives untouched.

## Ten went through the scripted rewrite

`freshrss`, `n8n`, `pinepods`, `pulsarr`, `questarr`, `romm`, `searxng`, `tandoor`, `tududi`, `xcproxy` — plus `docker-hub-auth`.

## Three needed hand-holding

Their keys are built from Flux substitutions, which no static keymap can resolve:

| | |
|---|---|
| **headlamp** | `'${CLUSTER_CNAME}-${APP}-oidc-credentials'` → `'clusters/${CLUSTER_CNAME}/apps/${APP}/oidc'` — the same two variables build the Phase 8a path, so the substitution carries straight over |
| **alertmanager** | `'${CLUSTER_TITLE} Pushover Key'` → `'shared/${CLUSTER_CNAME}-pushover-key'` — **this one changes variable** |

That second case is the one worth reading twice. `CLUSTER_TITLE` is the *display-cased* name (`Equestria`) because it addressed a 1Password item **title**. The OpenBao slug is lowercase, which is `CLUSTER_CNAME` (`equestria`). Carrying `CLUSTER_TITLE` across unchanged would have produced `shared/Equestria-pushover-key` and a 404 — and since alertmanager only fails when it tries to *page* someone, that's a failure you'd discover during an incident.

## Deliberately excluded

`meilisearch-env` stays on 1Password. Its OpenBao path still has no fields, and migrating before the master key is written would turn a silent empty value into a hard `SecretSyncedError`.

## Validation

- `eso-values-lint` → **0 findings**
- `flate test all` → `330 passed · 2 skipped · 2 blocked`, unchanged

Running total: **87 of 88** migratable ExternalSecrets, with only `meilisearch-env` outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
