### PR TITLE
fix(grafana): escape DS_PROMETHEUS in the coder and gpu dashboards

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/coder.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/coder.yaml
@@ -78,7 +78,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -172,7 +172,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "rate(process_cpu_seconds_total{$filter_key=\"$filter_value\"}[$__rate_interval])",
@@ -187,7 +187,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -237,7 +237,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "coderd_api_active_users_duration_hour{$filter_key=\"$filter_value\"}",
@@ -252,7 +252,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -302,7 +302,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "sum(coderd_agents_up{$filter_key=\"$filter_value\"})",
@@ -317,7 +317,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -368,7 +368,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "avg(coderd_agents_connection_latencies_seconds{$filter_key=\"$filter_value\"})",
@@ -383,7 +383,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -485,7 +485,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "coderd_provisionerd_jobs_current{$filter_key=\"$filter_value\"}",
@@ -496,7 +496,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "coderd_provisionerd_num_daemons{$filter_key=\"$filter_value\"}",
@@ -512,7 +512,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -620,7 +620,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "histogram_quantile(0.95, sum by(le) (rate(coderd_db_query_latencies_seconds_bucket{$filter_key=\"$filter_value\"}[$__rate_interval])))",
@@ -632,7 +632,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "sum(rate(coderd_db_query_latencies_seconds_count{$filter_key=\"$filter_value\"}[$__rate_interval]))",
@@ -648,7 +648,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -758,7 +758,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "go_memstats_alloc_bytes{$filter_key=\"$filter_value\"}",
@@ -769,7 +769,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "exemplar": false,
@@ -786,7 +786,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -912,7 +912,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "sum(rate(coderd_api_requests_processed_total{$filter_key=\"$filter_value\"}[$__rate_interval]))",
@@ -924,7 +924,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "sum(rate(coderd_api_requests_processed_total{code=\"500\"}[$__rate_interval]))",
@@ -936,7 +936,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "histogram_quantile(0.95, sum by(le) (rate(coderd_api_request_latencies_seconds_bucket[$__rate_interval])))",

--- a/kubernetes/apps/observability/grafana/dashboards/gpu.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/gpu.yaml
@@ -9,7 +9,7 @@
 # the metric names stay pinned to the exporter versions actually deployed.
 # The Intel one is adapted from the exporter's own grafana-operator export
 # (assets/dashboard/dashboards.yaml, v0.7.1): datasource swapped to the
-# estate's ${DS_PROMETHEUS} input, a `cluster` variable added so it renders
+# estate's $${DS_PROMETHEUS} input, a `cluster` variable added so it renders
 # equestria and sgc together through Thanos, and the aggregations changed to
 # keep `node` so selecting multiple nodes stops averaging five different GPUs
 # into a single line.
@@ -23,7 +23,7 @@
 # runs in strict mode and aborts the whole observability/grafana Kustomization
 # on any `${...}` it cannot resolve. The doubled `$$` collapses to a single
 # `$` during substitution, so grafana-operator still receives the
-# `${DS_PROMETHEUS}` it maps via the `datasources:` inputName below.
+# `$${DS_PROMETHEUS}` it maps via the `datasources:` inputName below.
 # Grafana's own template variables ($cluster, $node, $__all) use the bare-`$`
 # form, which Flux does not touch, so they are deliberately left unescaped.
 apiVersion: grafana.integreatly.org/v1beta1


### PR DESCRIPTION
The `grafana` Kustomization has been failing to build **since 2026-08-08**, stuck applying revision `263ae6f8` while reporting `Ready=True` on its last good apply:

```
post build failed for GrafanaDashboard/coder: envsubst error:
variable substitution failed: variable not set (strict mode): "DS_PROMETHEUS"
```

## Cause

`DS_PROMETHEUS` is a **Grafana datasource placeholder** belonging to the dashboard JSON, not a Flux variable. Every other dashboard in the directory escapes it — **97 occurrences of `$${DS_PROMETHEUS}` across nine files** — but `coder.yaml` and `gpu.yaml` wrote it bare, so Flux `postBuild` tried to resolve it and failed the whole Kustomization in strict mode.

## Both, not just coder

`coder.yaml` fails first, so escaping only it would have moved the error to `gpu.yaml` on the next reconciliation rather than clearing it. 21 occurrences in coder, plus gpu's. Verified afterwards that **no dashboard has an unescaped substitution left**.

## This was blocking more than dashboards

`grafana-secret` and `grafana-admin-secret` were migrated to OpenBao in #3094, but the Kustomization couldn't apply them — so both were still reading from 1Password. **Two of the three remaining 1Password ExternalSecrets were waiting on a broken dashboard**, which is not a connection the ExternalSecret status would ever have shown you.

Same envsubst class as `bf159f1fb` and the comment fix in #3092 — third instance this session, so it's a recurring trap in this repo rather than a one-off.

`flate test all` unchanged at `330 passed · 2 skipped · 2 blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
