### PR TITLE
feat(meilisearch): the last ExternalSecret onto OpenBao, plus a dead Secret

### DIFF
--- a/kubernetes/apps/database/backblaze.yaml
+++ b/kubernetes/apps/database/backblaze.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
-apiVersion: v1
-kind: Secret
-metadata:
-  name: backblaze-db-access-key
-  annotations:
-    reflector.v1.k8s.emberstack.com/reflects: "backup/backblaze-db-access-key"
-    reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -8,7 +8,6 @@ components:
   - ../../components/common
   - ../../components/repos/app-template
 resources:
-  - ./backblaze.yaml
   - ./postgres
   - ./valkey/ks.yaml
   # - ./neo4j/ks.yaml

--- a/kubernetes/apps/equestria/home/meilisearch/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -26,7 +26,8 @@ spec:
         MEILI_MASTER_KEY: "{{ .meili_password }}"
   dataFrom:
     - extract:
-        key: 'MeiliSearch Secret Key'
+        # was: MeiliSearch Secret Key
+        key: shared/meilisearch-secret-key
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
Two commits: the final ExternalSecret migration, and the `backblaze-db-access-key` cleanup that came out of #3092.

**This takes the estate to 90 of 90 — nothing left on `onepassword-connect`.**

---

## 1. meilisearch onto OpenBao

`secrets/shared/meilisearch-secret-key` now carries a 42-byte password, so the one ExternalSecret held back from the Phase 6 batches can move.

It was held back because migrating an ExternalSecret whose OpenBao path has *no fields* turns a quiet problem into a loud one: `MEILI_MASTER_KEY` has rendered as **0 bytes** for as long as it has existed, and ESO would have failed the whole ExternalSecret rather than continue rendering empty.

### ⚠️ This flips Meilisearch from open to authenticated

It currently runs with `MEILI_MASTER_KEY` empty, so `/keys` answers **without credentials**:

```console
$ wget -qO- http://127.0.0.1:7700/keys      # no credentials
{"results":[{"name":"Default Search API Key","key":"630f650e96d886f8...
```

Once a real key renders, reloader restarts the pod, auth starts being enforced, and Meilisearch **re-derives its default API keys** — so that `630f650e…` value changes.

Nothing consumes it (no live workload references `meilisearch:7700`, karakeep isn't deployed), so there's nothing to break now — and **doing it before karakeep returns is the cheap moment.**

### ⚠️ The key does not match karakeep's

```
karakeep  sha=f330a6fe41f11096  len=42
meili     sha=34c743d147d3c08c  len=42
```

karakeep's ExternalSecret sets `MEILI_MASTER_KEY` from the `Karakeep Secret Key` item and points `MEILI_ADDR` at this service. When karakeep is re-enabled it will send a **different** value and be rejected. Either make them match, or repoint karakeep at `shared/meilisearch-secret-key`.

Flagged because the failure would surface as karakeep search being broken, a long way from this change.

---

## 2. Delete the empty `backblaze-db-access-key` Secret

Dead three times over, each checked before deleting:

- **0 data keys** — the manifest declares metadata and annotations and no `stringData` at all, so the live Secret has been empty for its whole **153 days**
- **its reflector source doesn't exist** — the annotation mirrors `backup/backblaze-db-access-key`, and there is no `backup` namespace in this cluster
- **nothing consumes it** — no pod volume, no `envFrom`, no reference in either repo outside its own manifest

An empty Secret mirroring a namespace that doesn't exist reads as load-bearing to whoever finds it next, which is the argument for removing it rather than leaving it.

The live object stays until deleted by hand — dropping it from the kustomization stops Flux managing it but doesn't prune it.

---

## Follow-up

`MEILI_ENV` is still pinned to `development` with a comment saying production needs a ≥16-byte master key. **That reason no longer holds.**

`eso-values-lint` 0 findings; `flate test all` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
