### PR TITLE
feat(meilisearch): production mode, now that a real master key exists

### DIFF
--- a/kubernetes/apps/equestria/home/meilisearch/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/helmrelease.yaml
@@ -46,11 +46,18 @@ spec:
       MEILI_NO_ANALYTICS: "true"
       # One-way on-startup DB migration 1.47.0 -> 1.51.0. See vault#102.
       MEILI_UPGRADE_DB: "true"
-      # Left at the chart default rather than "production": production mode
-      # requires a >=16 byte MEILI_MASTER_KEY, and meilisearch-env currently
-      # resolves MEILI_MASTER_KEY to an empty string, so production would
-      # refuse to boot. Tracked separately — see vault#102.
-      MEILI_ENV: "development"
+      # Production now that meilisearch-env resolves a real MEILI_MASTER_KEY
+      # (42 bytes, from secrets/shared/meilisearch-secret-key in OpenBao).
+      # It was pinned to "development" only because that key rendered empty and
+      # production refuses to boot without >=16 bytes.
+      #
+      # This is the change that makes Meilisearch ENFORCE auth. Until now it has
+      # been answering /keys with no credentials at all, because the pod has
+      # been running since before the key existed — the StatefulSet carries no
+      # reloader annotation, so the Secret gaining a value never restarted it.
+      # Editing this map changes the chart's checksum/config annotation, which
+      # rolls the pod and picks up the key and this setting together.
+      MEILI_ENV: "production"
 
     persistence:
       enabled: true


### PR DESCRIPTION
`MEILI_ENV` was pinned to `development` for exactly one reason, recorded in the comment it replaces: **production refuses to boot without a ≥16 byte `MEILI_MASTER_KEY`**, and `meilisearch-env` resolved that to an empty string.

It now resolves to **42 bytes** from `secrets/shared/meilisearch-secret-key`, so the reason is gone.

## What this actually changes

Meilisearch starts **enforcing auth**. It has been answering `/keys` with no credentials at all — verified from inside the pod:

```console
$ kubectl exec meilisearch-0 -- sh -c 'echo ${#MEILI_MASTER_KEY}'
0
$ wget -qO- http://127.0.0.1:7700/keys      # no credentials
{"results":[{"name":"Default Search API Key","key":"630f650e96d886f8...
```

The running instance predates the key existing. **The StatefulSet carries no reloader annotation**, so `meilisearch-env` gaining a value never restarted it — the container is 5 days old with an empty key.

## Why the ordering is safe

Editing this map changes the chart's `checksum/config` pod-template annotation, and the StatefulSet is `RollingUpdate`, so the pod rolls and picks up **the key and this setting together**.

That matters: production *without* the key would crash-loop. Landing them in one restart is the only ordering that can't go wrong, which is why this is a separate PR from the key itself rather than the same one.

## Two consequences to expect, not discover

- **The default API key value changes.** Meilisearch derives its default keys from the master key. Nothing consumes it — no live workload references `meilisearch:7700`, karakeep isn't deployed.
- **`MEILI_UPGRADE_DB` is still `true`**, so the restart re-runs the on-startup migration gate. The DB migrated 5 days ago and it should be a no-op — but that flag is what stranded this pod before (vault#102), so the restart is worth watching rather than assuming.

## Unaffected, still outstanding

The master key **does not match** the one karakeep is hardcoded to send (`f330a6fe…` vs `34c743d1…`). karakeep will be rejected when re-enabled until the two are reconciled.

`flate test all` unchanged at `330 passed · 2 skipped · 2 blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
