### PR TITLE
fix(karakeep): authenticate to meilisearch with meilisearch's key

### DIFF
--- a/kubernetes/apps/equestria/home/karakeep/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -26,20 +26,26 @@ spec:
         TZ: "${TIMEZONE}"
         DATA_DIR: "/data"
         MEILI_ADDR: "http://meilisearch:7700"
-        MEILI_MASTER_KEY: "{{ .karakeep_password }}"
+        # The MASTER key of the meilisearch this points at, not karakeep's own
+        # secret. Meilisearch enforces auth now, so sending anything else is a
+        # 403 on every search. NEXTAUTH_SECRET below is karakeep's own and is
+        # correctly unrelated.
+        MEILI_MASTER_KEY: "{{ .meili_password }}"
         NEXTAUTH_URL: "https://${APP}.${ROOT_DOMAIN}"
         NEXTAUTH_SECRET: "{{ .karakeep_password }}"
         DISABLE_PASSWORD_AUTH: "true"
         DISABLE_SIGNUPS: "true"
         OAUTH_AUTO_REDIRECT: "true"
         OAUTH_PROVIDER_NAME: "${CLUSTER_TITLE}"
-        # Optional OIDC fields - provide via 1Password item named '${APP}-oidc-credentials'
+        # OIDC fields come from the cluster store below, populated by the
+        # applications Pulumi stack.
         OAUTH_WELLKNOWN_URL: "{{ .oidc_openid_configuration_url }}"
         OAUTH_CLIENT_ID: "{{ .oidc_client_id }}"
         OAUTH_CLIENT_SECRET: "{{ .oidc_client_secret }}"
   dataFrom:
     - extract:
-        key: 'Karakeep Secret Key'
+        # was: 'Karakeep Secret Key'
+        key: shared/karakeep-secret-key
       rewrite:
         - regexp:
             source: "[\\W]"
@@ -47,6 +53,17 @@ spec:
         - regexp:
             source: "(.*)"
             target: "karakeep_$1"
+    - extract:
+        # Meilisearch's master key, so karakeep authenticates with the same
+        # value the server was started with.
+        key: shared/meilisearch-secret-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "meili_$1"
     - extract:
         key: '${APP}-oidc-credentials'
       sourceRef:


### PR DESCRIPTION
`MEILI_MASTER_KEY` was set from `{{ .karakeep_password }}` — **karakeep's own secret, not the master key of the meilisearch it points at.** Two different 42-byte values:

```
karakeep  sha=f330a6fe41f11096
meili     sha=34c743d147d3c08c
```

## Why it didn't matter until now

Meilisearch ran **unauthenticated** — with `MEILI_MASTER_KEY` empty it accepted anything, including a wrong key. #3097 turns on production mode and enforcement, so karakeep would get a **403 on every search** the moment it's re-enabled.

A latent bug that only becomes real because of a change made elsewhere, in a component that isn't currently deployed. Worth fixing while it's a config edit rather than an outage.

## The fix

Adds an extract for `shared/meilisearch-secret-key` under a `meili_` prefix and points `MEILI_MASTER_KEY` at it.

`NEXTAUTH_SECRET` keeps using `karakeep_password` — that one *is* karakeep's own and correctly unrelated. Both being `{{ .karakeep_password }}` on adjacent lines is probably how they got conflated.

## Also migrates its own key

`Karakeep Secret Key` → `shared/karakeep-secret-key`. This manifest hadn't been through Phase 6 only because karakeep is undeployed, so it never appeared in the live inventory the batches worked from.

## ⚠️ Cannot be verified at runtime

karakeep is commented out of the equestria home kustomization and has no workloads.

What **is** verified is that every template reference resolves against the live server:

```
openbao-satisfiable refs: ['karakeep_password', 'meili_password']
unsatisfied (excluding oidc_ from cluster store): none
```

That's the check that would have caught the missing-key trap; it can't tell you whether karakeep's application logic is happy, only that ESO will render.

## Also

The stale comment offering the OIDC fields *"via 1Password item"* is corrected — they come from the `cluster` store, written by the applications Pulumi stack.

`flate test all` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
