### PR TITLE
feat(equestria): the equestria-namespace OnePasswordItem CRs become ExternalSecrets

### DIFF
--- a/kubernetes/apps/equestria/pvr/dispatcharr/secret.yaml
+++ b/kubernetes/apps/equestria/pvr/dispatcharr/secret.yaml
@@ -1,10 +1,30 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. The app reads `username` and
+# `password` from this Secret through `secretKeyRef`; both exist in OpenBao
+# under identical names.
+#
+# ONE KEY IS DROPPED: `website`. The 1Password Operator synthesised it from the
+# item's URL field, which is not a field and so was never migrated. Nothing
+# reads it — checked against every workload in the cluster before removing it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: ${APP}
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: ${APP}
 spec:
-    itemPath: "vaults/Eris/items/Dispatcharr"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: ${APP}
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Dispatcharr
+        key: shared/dispatcharr

--- a/kubernetes/apps/equestria/shared/secrets/home-assistant.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/home-assistant.yaml
@@ -1,9 +1,38 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. An identical copy lives at
+# kubernetes/apps/network/secrets/home-assistant.yaml; both must change together.
+#
+# THE REWRITE IS LOAD-BEARING. One 1Password field is literally named
+# "one-time password", with a space, and OpenBao stores field names verbatim.
+# A space is not a legal Kubernetes Secret key, so without the rewrite the API
+# server rejects the whole Secret. The 1Password Operator did the same
+# sanitisation itself, which is why the live Secret already reads
+# `one-time-password` — this reproduces it exactly rather than approximating it
+# with the repo's usual [\W] -> _ rule.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: home-assistant-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: home-assistant-credentials
 spec:
-    itemPath: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: home-assistant-credentials
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+        #      ("Eris Home Assistant Credentials")
+        key: shared/eris-home-assistant-credentials
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/equestria/shared/secrets/ks.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/ks.yaml
@@ -15,7 +15,11 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   dependsOn:
-    - name: onepassword-connect
+    # Phase 6: these are ExternalSecrets against ClusterSecretStore/openbao now,
+    # not OnePasswordItem CRs, so the gate is the store rather than Connect.
+    # (external-secrets-stores itself still dependsOn onepassword-connect until
+    # Phase 11, so nothing is ordered any earlier than before.)
+    - name: external-secrets-stores
       namespace: kube-system
   path: ./kubernetes/apps/equestria/shared/secrets
   prune: true

--- a/kubernetes/apps/equestria/shared/secrets/media-management.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/media-management.yaml
@@ -1,9 +1,32 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. This is the widest-reach one
+# of the set: prowlarr, radarr, sonarr, lidarr and kometa all read keys out of
+# this Secret through `secretKeyRef`.
+#
+# All 18 keys the operator produced exist in OpenBao under the same names.
+# OpenBao carries ONE MORE — `omdb_apikey`, written during the kometa fix
+# (equestria-cluster#3087) because 1Password held it with an empty value and
+# Phase 4 does not migrate empty fields. So this Secret gains a key; it loses
+# none. Nothing keys off the field list, so the extra entry is inert.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: spike-management-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: spike-management-credentials
 spec:
-    itemPath: vaults/Eris/items/Media Management Secrets
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: spike-management-credentials
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Media Management Secrets
+        key: shared/media-management-secrets

--- a/kubernetes/apps/equestria/shared/secrets/pushover.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/pushover.yaml
@@ -1,9 +1,33 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — was a OnePasswordItem CR (the 1Password Operator, a mechanism with
+# no OpenBao equivalent), so this is a conversion rather than a repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field, so a bare
+# `extract` reproduces it. Verified against the live Secret before the change —
+# both sides carry exactly credential / email / username.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: pushover-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: pushover-credentials
 spec:
-    itemPath: vaults/Eris/items/44ynzawpyyaiiahgpjeaz4fjsu
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: pushover-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it
+      # onto the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/44ynzawpyyaiiahgpjeaz4fjsu  ("Pushover")
+        # Path within the `secrets` mount; the store pins `path: secrets`.
+        key: shared/pushover

--- a/kubernetes/apps/equestria/shared/secrets/tailscale.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/tailscale.yaml
@@ -1,12 +1,36 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# NOTE: this whole file is commented out of ./kustomization.yaml and has no
+# live counterpart in the cluster — the equestria-namespace `tailscale-oauth`
+# Secret does not exist. Converted with the rest of Phase 6 only so that no
+# OnePasswordItem manifest is left behind to be re-adopted later.
+#
+# The live copy of this credential is
+# kubernetes/apps/tailscale-system/operator/tailscale.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: tailscale-oauth
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: tailscale-oauth
 spec:
-    itemPath: vaults/Eris/items/Eris Tailscale OAuth Operator
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: tailscale-oauth
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Eris Tailscale OAuth Operator
+        key: shared/eris-tailscale-oauth-operator
+      # "valid from" carries a space, which is not a legal Secret key.
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kubernetes/apps/equestria/shared/secrets/truenas.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/truenas.yaml
@@ -1,9 +1,26 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. Keys verified identical on
+# both sides: credential / domain / hostname / username.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: truenas-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: truenas-credentials
 spec:
-    itemPath: vaults/Eris/items/nvvnzwmhywhgjf7uywkkyq7jxy
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: truenas-credentials
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/nvvnzwmhywhgjf7uywkkyq7jxy
+        #      ("Eris Truenas Credentials")
+        key: shared/eris-truenas-credentials

--- a/kubernetes/apps/equestria/shared/secrets/unifi.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/unifi.yaml
@@ -1,9 +1,32 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR.
+#
+# The UUID this used to address resolves to the 1Password item titled
+# "Unifi Discord", not to anything named after this Secret. That mismatch is
+# pre-existing; the path below is the same item, so behaviour is unchanged.
+#
+# ONE KEY IS DROPPED: `website`. The 1Password Operator synthesised it from the
+# item's URL field, which is not a field and so was never migrated. Nothing in
+# either cluster repo, and no live pod, reads it — checked before removing it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: unifi-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: unifi-credentials
 spec:
-    itemPath: vaults/Eris/items/dk2j2cscqjmfp3jlibkc5tx6hq
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: unifi-credentials
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/dk2j2cscqjmfp3jlibkc5tx6hq  ("Unifi Discord")
+        key: shared/unifi-discord


### PR DESCRIPTION
Phase 6, the OnePasswordItem half — **step 1 of 5**. Merge order: this → gha-runners → network → tailscale-operator → home-operations#pulumi-secrets.

These CRs are served by the 1Password Operator, a mechanism with no OpenBao equivalent, so each is a *conversion*, not a `secretStoreRef` repoint.

### What was verified before writing a line

Per path, against the live server rather than against `mapping.yaml`:

| Secret | OpenBao path | keys |
|---|---|---|
| `equestria/pushover-credentials` | `secrets/shared/pushover` | identical |
| `equestria/truenas-credentials` | `secrets/shared/eris-truenas-credentials` | identical |
| `equestria/unifi-credentials` | `secrets/shared/unifi-discord` | `website` dropped |
| `equestria/home-assistant-credentials` | `secrets/shared/eris-home-assistant-credentials` | identical, needs rewrite |
| `equestria/spike-management-credentials` | `secrets/shared/media-management-secrets` | `omdb_apikey` gained |
| `equestria/dispatcharr` | `secrets/shared/dispatcharr` | `website` dropped |

No field is empty on the OpenBao side, so the kometa trap cannot apply.

### The three deviations, all checked against every workload in the cluster

- **`website` dropped** (`unifi-credentials`, `dispatcharr`) — the operator synthesised it from the item URL, which is not a field and so was never migrated. No pod, no `valuesFrom`, no manifest in any repo reads it.
- **`omdb_apikey` gained** (`spike-management-credentials`) — written into OpenBao during the kometa fix (#3087) because 1Password held it empty. Nothing keys off the field list.
- **`home-assistant-credentials` rewrite** — one field is literally named `one-time password`, and a space is not a legal Secret key, so the API server would reject the whole Secret. `[^-._a-zA-Z0-9] -> -` reproduces the operator’s own sanitisation exactly (`one-time-password`), rather than approximating it with the repo’s usual `[\W] -> _`.

`shared/secrets/tailscale.yaml` is commented out of its kustomization and has no live counterpart — converted anyway so no OnePasswordItem manifest is left to be re-adopted.

### Ordering

`shared/secrets/ks.yaml` now gates on `external-secrets-stores` instead of `onepassword-connect`. That store still `dependsOn` Connect until Phase 11, so nothing is ordered any earlier than before.

### Expected behaviour on apply

Flux applies the ExternalSecret, then prunes the CR; the operator-owned Secret is garbage-collected with it and ESO recreates it. Expect a few seconds where the Secret is absent and one transient `SecretSyncedError`. Env-var consumers do not notice; the volume-mounted ones re-project on the next kubelet sync.

**Verify after merge:** `kubectl get externalsecret -n equestria` all `SecretSynced`, and `kubectl get onepassworditem -A` no longer lists these.

<!-- crew:agent=claude -->