### PR TITLE
feat(github-actions): the runner GitHub App OnePasswordItem CRs become ExternalSecrets

### DIFF
--- a/kubernetes/apps/github-actions/runners/david-driscoll/secret.yaml
+++ b/kubernetes/apps/github-actions/runners/david-driscoll/secret.yaml
@@ -1,10 +1,29 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR.
+#
+# The ARC scale set reads this Secret through `githubConfigSecret`, which
+# requires the exact keys github_app_id / github_app_installation_id /
+# github_app_private_key. All seven of the operator's keys exist in OpenBao
+# under identical names, so no rewrite and no template are needed.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
   name: david-driscoll-github-app
-  annotations:
-    reloader.stakater.com/auto: "true"
 spec:
-  itemPath: vaults/Eris/items/Github Actions Runner (david-driscoll)
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: david-driscoll-github-app
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll

--- a/kubernetes/apps/github-actions/runners/littles-tech/secret.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech/secret.yaml
@@ -1,10 +1,26 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. Same shape as the
+# ./david-driscoll runner set; all seven keys exist in OpenBao under identical
+# names. Also read by the ../littles-tech-release overlay.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
   name: littles-tech-github-app
-  annotations:
-    reloader.stakater.com/auto: "true"
 spec:
-  itemPath: vaults/Eris/items/Github Actions Runner (littles-tech)
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: littles-tech-github-app
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Github Actions Runner (littles-tech)
+        key: shared/github-actions-runner-littles-tech

--- a/kubernetes/apps/github-actions/runners/vault/secret.yaml
+++ b/kubernetes/apps/github-actions/runners/vault/secret.yaml
@@ -1,17 +1,32 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR.
+#
+# Same GitHub App as the ./david-driscoll scale set — a dedicated resource
+# (rather than reusing that overlay's Secret) keeps this overlay
+# self-contained, so pruning one runner set cannot break the other.
+#
+# The app installation MUST include david-driscoll/vault with
+# `Administration: read & write` (or Self-hosted runners), or the listener
+# will 404 on the runner registration-token call.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
   name: vault-github-app
-  annotations:
-    reloader.stakater.com/auto: "true"
 spec:
-  # Same GitHub App as the ./david-driscoll scale set — a dedicated
-  # OnePasswordItem (rather than reusing that overlay's Secret) keeps this
-  # overlay self-contained, so pruning one runner set cannot break the other.
-  #
-  # The app installation MUST include david-driscoll/vault with
-  # `Administration: read & write` (or Self-hosted runners), or the listener
-  # will 404 on the runner registration-token call.
-  itemPath: vaults/Eris/items/Github Actions Runner (david-driscoll)
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: vault-github-app
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll


### PR DESCRIPTION
Phase 6, the OnePasswordItem half — **step 2 of 5**, after #3099.

The three ARC scale-set credentials. The scale sets read these Secrets through `githubConfigSecret`, which needs the exact keys `github_app_id` / `github_app_installation_id` / `github_app_private_key`.

| Secret | OpenBao path | keys |
|---|---|---|
| `github-actions/david-driscoll-github-app` | `secrets/shared/github-actions-runner-david-driscoll` | identical (7) |
| `github-actions/littles-tech-github-app` | `secrets/shared/github-actions-runner-littles-tech` | identical (7) |
| `github-actions/vault-github-app` | `secrets/shared/github-actions-runner-david-driscoll` | identical (7) |

All seven keys exist in OpenBao under identical names and none is empty, so no rewrite and no template are needed — verified against the live server, not against `mapping.yaml`.

`vault-github-app` intentionally stays a separate resource pointing at the same underlying item as `david-driscoll-github-app`, so pruning one runner set cannot break the other. That comment survives the conversion.

Self-contained: nothing outside `github-actions` reads these, so a bad merge costs CI runners and nothing else.

**Verify after merge:** `kubectl get externalsecret -n github-actions` all `SecretSynced`, and a runner picks up a job.

<!-- crew:agent=claude -->