### PR TITLE
feat(network): the network and cert-manager OnePasswordItem CRs become ExternalSecrets

### DIFF
--- a/kubernetes/apps/cert-manager/cert-issuers/secret.yaml
+++ b/kubernetes/apps/cert-manager/cert-issuers/secret.yaml
@@ -1,10 +1,35 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. The Cloudflare API token both
+# ClusterIssuers solve DNS-01 with; if this is wrong, certificate issuance stops.
+#
+# THE KEY IS NO LONGER A SUBSTITUTION. It used to be `CLOUDFLARE_SECRET`,
+# which resolved to `vaults/Eris/items/7ntcze3fqqzun7huc7vyoirco4` out of
+# shared-secrets.sops.yaml. Carrying a variable across would have hidden whether
+# the value was a 1Password item path or an OpenBao path — exactly the shape
+# that broke dynacat (vault:docs/openbao-migration/STATUS.md, lesson 4). The
+# path is spelled out so it is visibly inside the `secrets` mount.
+#
+# An identical copy lives at kubernetes/apps/network/secrets/cloudflare-default-domain.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-default-domain
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-default-domain
 spec:
-    itemPath: "${CLOUDFLARE_SECRET}"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-default-domain
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/7ntcze3fqqzun7huc7vyoirco4
+        #      ("Cloudflare (driscoll.tech)")
+        key: shared/cloudflare-driscoll-tech

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -33,8 +33,10 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-    - apiVersion: onepassword.com/v1
-      kind: OnePasswordItem
+    # Phase 6: the tunnel token is an ExternalSecret against
+    # ClusterSecretStore/openbao now, not a OnePasswordItem CR.
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
       name: cloudflare-tunnel
       namespace: *namespace
   postBuild:

--- a/kubernetes/apps/network/cloudflare-tunnel/secret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/secret.yaml
@@ -1,10 +1,34 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. This is the tunnel token; if
+# it is wrong, every externally-published hostname goes dark.
+#
+# THE KEY IS NO LONGER A SUBSTITUTION. It was `CLOUDFLARE_TUNNEL_SECRET`,
+# resolving to `vaults/Eris/items/mgksuktp4tea6hbh5kctzdmbiu` out of
+# cluster-secrets.sops.yaml. That variable is per-cluster (SGC has its own
+# tunnel), but so is this file, so the indirection bought nothing and hid
+# whether the key was a 1Password item path or an OpenBao path.
+#
+# ./ks.yaml healthChecks this resource by kind — that reference changed too.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-tunnel
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-tunnel
 spec:
-    itemPath: "${CLOUDFLARE_TUNNEL_SECRET}"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-tunnel
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mgksuktp4tea6hbh5kctzdmbiu
+        #      ("Equestria Cloudflare Tunnel")
+        key: shared/equestria-cloudflare-tunnel

--- a/kubernetes/apps/network/external-dns/technitium/secret.yaml
+++ b/kubernetes/apps/network/external-dns/technitium/secret.yaml
@@ -1,10 +1,26 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. external-dns reads `username`
+# and `credential` out of this Secret by name; both exist in OpenBao unchanged.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: technitium-tsig-key
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: technitium-tsig-key
 spec:
-    itemPath: vaults/Eris/items/g32sc45j6dj2qkjqtgikjmaude
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: technitium-tsig-key
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/g32sc45j6dj2qkjqtgikjmaude
+        #      ("Technitium TSIG Key")
+        key: shared/technitium-tsig-key

--- a/kubernetes/apps/network/external-dns/unifi/secret.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/secret.yaml
@@ -1,10 +1,35 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. external-dns reads `credential`
+# (the UniFi API key) out of this Secret by name.
+#
+# The rewrite is required: the item has a field literally named "valid from",
+# and a space is not a legal Kubernetes Secret key, so without it the API server
+# rejects the whole Secret. The 1Password Operator sanitised the same way — the
+# live Secret already reads `valid-from`.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: unifi-dns-secret
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: unifi-dns-secret
 spec:
-    itemPath: "vaults/Eris/items/nxhctyryy6b7hauxfysmzev6uu"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: unifi-dns-secret
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/nxhctyryy6b7hauxfysmzev6uu
+        #      ("Unifi Api Key Eris Cluster")
+        key: shared/unifi-api-key-eris-cluster
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/network/secrets/cloudflare-default-domain.yaml
+++ b/kubernetes/apps/network/secrets/cloudflare-default-domain.yaml
@@ -1,10 +1,30 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. Read by external-dns/cloudflare
+# in this namespace; the cert-manager copy of the same credential is at
+# kubernetes/apps/cert-manager/cert-issuers/secret.yaml and must change with it.
+#
+# The key was `CLOUDFLARE_SECRET` and is now a literal OpenBao path — see the
+# cert-manager copy for why the substitution was not carried across.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-default-domain
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-default-domain
 spec:
-    itemPath: "${CLOUDFLARE_SECRET}"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-default-domain
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/7ntcze3fqqzun7huc7vyoirco4
+        #      ("Cloudflare (driscoll.tech)")
+        key: shared/cloudflare-driscoll-tech

--- a/kubernetes/apps/network/secrets/home-assistant.yaml
+++ b/kubernetes/apps/network/secrets/home-assistant.yaml
@@ -1,10 +1,31 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. Identical copy at
+# kubernetes/apps/equestria/shared/secrets/home-assistant.yaml; both must change
+# together. The rewrite is required — see that file for why.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: home-assistant-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: home-assistant-credentials
 spec:
-    itemPath: "vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: home-assistant-credentials
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+        #      ("Eris Home Assistant Credentials")
+        key: shared/eris-home-assistant-credentials
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/network/secrets/ks.yaml
+++ b/kubernetes/apps/network/secrets/ks.yaml
@@ -15,7 +15,11 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   dependsOn:
-    - name: onepassword-connect
+    # Phase 6: this path holds ExternalSecrets against ClusterSecretStore/openbao
+    # now, not OnePasswordItem CRs, so the gate is the store rather than Connect.
+    # external-secrets-stores itself still dependsOn onepassword-connect until
+    # Phase 11, so nothing is ordered any earlier than before.
+    - name: external-secrets-stores
       namespace: kube-system
     - name: external-secrets
       namespace: kube-system

--- a/kubernetes/apps/network/traefik/crowdsec-secret.yaml
+++ b/kubernetes/apps/network/traefik/crowdsec-secret.yaml
@@ -1,9 +1,32 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR.
+#
+# Traefik mounts this Secret as a VOLUME, so every key becomes a file and the
+# key NAMES are the interface (see traefik/middleware/crowdsec.yaml). Both keys
+# — apikey_bouncer and credential — exist in OpenBao under exactly those names,
+# so the file list is unchanged.
+#
+# Distinct from the `crowdsec-secrets` ExternalSecret in ../crowdsec/, which
+# feeds the LAPI. Same credential family, two consumers, two Secrets.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: crowdsec-secret
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: crowdsec-secret
 spec:
-    itemPath: vaults/Eris/items/Crowdsec ApiKey
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: crowdsec-secret
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Crowdsec ApiKey
+        key: shared/crowdsec-apikey


### PR DESCRIPTION
Phase 6, the OnePasswordItem half — **step 3 of 5**, after #3099 and the runners PR. This is the batch that breaks loudest: certificate issuance, the tunnel, both external-dns providers, and the CrowdSec bouncer key.

| Secret | OpenBao path | notes |
|---|---|---|
| `cert-manager/cloudflare-default-domain` | `secrets/shared/cloudflare-driscoll-tech` | keys identical |
| `network/cloudflare-default-domain` | `secrets/shared/cloudflare-driscoll-tech` | keys identical |
| `network/cloudflare-tunnel` | `secrets/shared/equestria-cloudflare-tunnel` | keys identical |
| `network/crowdsec-secret` | `secrets/shared/crowdsec-apikey` | keys identical; Traefik mounts it as a **volume**, so key names are the interface |
| `network/technitium-tsig-key` | `secrets/shared/technitium-tsig-key` | keys identical |
| `network/unifi-dns-secret` | `secrets/shared/unifi-api-key-eris-cluster` | needs the rewrite |
| `network/home-assistant-credentials` | `secrets/shared/eris-home-assistant-credentials` | needs the rewrite; twin of the `equestria` copy in #3099 |

Every key the live Secret carries exists in OpenBao under the same name, none is empty. The `[^-._a-zA-Z0-9] -> -` rewrite is required where a field is literally named `valid from` / `one-time password` — a space is not a legal Secret key, so the API server would reject the entire Secret. It reproduces the 1Password Operator’s own sanitisation exactly.

### The two substitutions are gone on purpose

`${CLOUDFLARE_SECRET}` and `${CLOUDFLARE_TUNNEL_SECRET}` resolved to `vaults/Eris/items/<uuid>` out of the sops files. Carrying a variable across would have hidden whether the value was a 1Password item path or an OpenBao path — the exact shape that broke dynacat. The paths are spelled out so they are visibly inside the `secrets` mount.

Both variables are now unreferenced outside their sops definitions. Removing them is deliberate follow-up work, not part of this PR.

### Also

- `cloudflare-tunnel/ks.yaml` healthChecked the CR by kind; that reference moves to `ExternalSecret` with it.
- `network/secrets/ks.yaml` gates on `external-secrets-stores` instead of `onepassword-connect` — that store still `dependsOn` Connect until Phase 11, so nothing is ordered any earlier.

**Verify after merge, in this order:** every `externalsecret` in `network`/`cert-manager` `SecretSynced`; `kubectl get clusterissuer` still Ready; the tunnel pods stay up; an external hostname still resolves and serves.

<!-- crew:agent=claude -->