### PR TITLE
feat(tailscale-system): the operator OAuth OnePasswordItem CR becomes an ExternalSecret

### DIFF
--- a/kubernetes/apps/tailscale-system/operator/tailscale.yaml
+++ b/kubernetes/apps/tailscale-system/operator/tailscale.yaml
@@ -1,10 +1,37 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. This one breaks loudly: the
+# operator HelmRelease resolves `oauth.clientId` from key `username` and
+# `oauth.clientSecret` from key `credential` via `valuesFrom`, so a wrong or
+# missing Secret fails the release, not just a pod. Both keys exist in OpenBao
+# under exactly those names.
+#
+# The rewrite is required for a key nothing reads: the item also carries a field
+# literally named "valid from", and a space is not a legal Kubernetes Secret
+# key, so the API server would reject the entire Secret without it. The
+# 1Password Operator sanitised the same way — the live Secret reads `valid-from`.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: tailscale-oauth
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: tailscale-oauth
 spec:
-    itemPath: "vaults/Eris/items/Eris Tailscale OAuth Operator"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: tailscale-oauth
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Eris Tailscale OAuth Operator
+        key: shared/eris-tailscale-oauth-operator
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"


### PR DESCRIPTION
Phase 6, the OnePasswordItem half — **step 4 of 5**. Its own PR because it fails differently from the rest.

The operator resolves `oauth.clientId` from key `username` and `oauth.clientSecret` from key `credential` through `valuesFrom`. A wrong Secret means **no HelmRelease at all**, not a crash-looping pod — and the tailnet operator is how the cluster reaches every off-cluster host, including `bao-transit`. So this one is worth being able to revert on its own.

`secrets/shared/eris-tailscale-oauth-operator` carries `username` and `credential` under exactly those names, neither empty — verified against the live server.

The rewrite is there for a key nothing reads: the item also carries a field literally named `valid from`, and a space is not a legal Secret key, so the API server would reject the entire Secret without it. `[^-._a-zA-Z0-9] -> -` reproduces the 1Password Operator’s own sanitisation (`valid-from`).

**Verify after merge:** `flux get hr -n tailscale-system tailscale-operator` Ready, the operator pod restarts cleanly, and an existing tailnet-exposed Service is still reachable.

<!-- crew:agent=claude -->