### PR TITLE
fix(external-dns): unifi cannot store wildcards, so exclude them by regex

### DIFF
--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -84,7 +84,41 @@ spec:
             port: http-webhook
           initialDelaySeconds: 10
           timeoutSeconds: 5
-    extraArgs: []
+    extraArgs:
+      # ---- WHY THIS PROVIDER FILTERS BY REGEX AND THE OTHERS DO NOT --------
+      #
+      # UniFi's static-DNS API cannot store a wildcard record. It answers
+      # `400 Invalid Hostname`, and not one of the 235 live entries is a
+      # wildcard. That would be a small problem except that external-dns
+      # applies a batch atomically: the webhook fails the WHOLE ApplyChanges
+      # call on the first rejected record and returns 500, so a single
+      # unstorable name stops every other write to this provider.
+      #
+      # That is not hypothetical. `*.code.${ROOT_DOMAIN}` (the coder-apps
+      # HTTPRoute, for per-workspace app subdomains) appeared at
+      # 2026-08-08T18:25:09Z and unifi-dns wrote NOTHING for the next two days
+      # — silently, because the failure looks like ordinary provider flakiness
+      # in the logs and nothing alerts on it.
+      #
+      # So the exclusion is stated as a property of the PROVIDER, not as a
+      # named exception for Coder: any name containing an asterisk is
+      # unstorable here, today and for whatever adds a wildcard route next.
+      # Cloudflare and Technitium both accept the record and keep it, so
+      # resolution is unaffected — only UniFi's copy omits it.
+      #
+      # `--regex-domain-filter` OVERRIDES `domainFilters`, which is why that
+      # value is gone from below rather than left in place looking load-bearing
+      # (external-dns/endpoint/domain_filter.go: Match() takes the regex path
+      # whenever either regex is set, and ignores Filters entirely).
+      #
+      # Anchors are `\A`/`\z`, not `^`/`$`: MatchString is unanchored so the
+      # anchors are required, and avoiding `$` keeps a regex metacharacter out
+      # of reach of Flux's postBuild envsubst. Single-quoted so YAML leaves the
+      # backslashes alone. The `.` inside ${ROOT_DOMAIN} expands unescaped and
+      # so matches any character — harmless here, and worth less than
+      # hardcoding the domain against the repo's convention.
+      - '--regex-domain-filter=(\A|\.)${ROOT_DOMAIN}\z'
+      - '--regex-domain-exclusion=\*'
     sources:
       - "traefik-proxy"
       - "crd"
@@ -97,9 +131,11 @@ spec:
       - gateway-udproute
     txtPrefix: "${CLUSTER_CNAME}."
     txtOwnerId: "${CLUSTER_CNAME}"
-    domainFilters:
-      - "${ROOT_DOMAIN}"
-      # - "${TAILSCALE_DOMAIN}"
+    # domainFilters is deliberately absent — --regex-domain-filter in extraArgs
+    # above replaces it and would silently override it if both were set. The
+    # regex covers the same ${ROOT_DOMAIN} scope. (${TAILSCALE_DOMAIN} was
+    # commented out here and remains excluded; add it as an alternation in the
+    # regex if it is ever wanted.)
     serviceMonitor:
       enabled: true
     podAnnotations:


### PR DESCRIPTION
unifi-dns has written **nothing for two days** and nothing noticed.

### What is actually wrong

UniFi’s static-DNS API rejects a wildcard with `400 Invalid Hostname` — not one of the 235 live entries is a wildcard. On its own that is a missing record. The reason it is an outage is that **external-dns applies a batch atomically**: the webhook fails the entire `ApplyChanges` call on the first rejected name and returns 500, so one unstorable record blocks every other write to this provider.

`*.code.driscoll.tech` (the `coder-apps` HTTPRoute, per-workspace app subdomains) was created at `2026-08-08T18:25:09Z`. The first `Invalid Hostname` is at `18:25:13Z` — four seconds later — and it has repeated every reconcile since.

Confirmed against Loki, and confirmed **not** to be the Phase 6 credential cutover that happened to restart this pod: the migrated API key returns **200** on the controller where an unauthenticated control returns **401**.

### Why a regex and not `--exclude-domains=*.code.driscoll.tech`

Both work. The named exception leaves the next wildcard route free to re-break the provider in exactly the same silent way. The constraint is a property of **UniFi**, not of Coder, so it is written that way: any name containing an asterisk is unstorable here.

Cloudflare and Technitium both accept the record and keep it, so **resolution is unaffected** — only UniFi’s copy omits it.

### The details that could have gone wrong

- `--regex-domain-filter` **overrides** `domainFilters`, so that value is removed rather than left looking load-bearing (`endpoint/domain_filter.go`: `Match()` takes the regex path whenever either regex is set and ignores `Filters` entirely).
- Anchors are `\A`/`\z`, not `^`/`$`. `MatchString` is unanchored so anchors are required, and avoiding `$` keeps a regex metacharacter out of reach of Flux’s `postBuild` envsubst — **verified** by rendering the built manifest through envsubst with the real `ROOT_DOMAIN`.
- Single-quoted so YAML leaves the backslashes alone.
- Exercised over the real name set: apex `code.driscoll.tech`, the `equestria.` TXT registry names and every existing record stay included; only the wildcard drops out.

### First run

`policy: sync`, so the first successful reconcile applies two days of backlog and **may delete as well as create**. A snapshot of all 235 records was taken before merge; I will diff it against the post-sync state and report.

<!-- crew:agent=claude -->