### PR TITLE
chore(secrets): drop the CLOUDFLARE_SECRET and CLOUDFLARE_TUNNEL_SECRET substitutions

### DIFF
--- a/kubernetes/components/common/cluster-secrets.sops.yaml
+++ b/kubernetes/components/common/cluster-secrets.sops.yaml
@@ -1,86 +1,85 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: cluster-secrets
-    annotations:
-        reloader.stakater.com/auto: "true"
-        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+  name: cluster-secrets
+  annotations:
+    reloader.stakater.com/auto: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
 stringData:
-    CLUSTER_CNAME: ENC[AES256_GCM,data:iTWIXLYcIkvm,iv:GsmJ9PrjOUVyhi56NTniArRiXwEb7/iUF8rS5OVVubo=,tag:BEe3mA/fRXKPB5YCLcwqdA==,type:str]
-    CLUSTER_KEY: ENC[AES256_GCM,data:IW4XYVAcVSrR,iv:5mM5PY3yp5Gqd72ffTc5Ag2tixsPQiQWsXa4+vRo1VI=,tag:KxXiiAa6N2zl/2Uruj2BGw==,type:str]
-    CLUSTER_TITLE: ENC[AES256_GCM,data:mmiKPhyDCloy,iv:5nUpt3kCiz0x5a7jpmijGiGuGJBjXk7tQyGK5bkR1Ww=,tag:MX+J16GD9MpJxq5BDLYZ1Q==,type:str]
-    CLUSTER_DOMAIN: ENC[AES256_GCM,data:8Wh2NCoRQml2aBEAtbhhLPWxPAjNXZQ=,iv:KBW1Pr12I/6AiZGhtFa3BfdxlPhHVyVHqBWDMYQhByg=,tag:NC0krZDvk8W4ByJ3N0117Q==,type:str]
-    CLUSTER_IP: ENC[AES256_GCM,data:SrQ/3EZkUXrlAcM=,iv:qRxAVeuBGnC8qjTzPJ86y78rqjtZ5KgQjpNWvJyR1xg=,tag:9D54eVyHh6i3lUjb1xsRqg==,type:str]
-    CLUSTER_API_IP: ENC[AES256_GCM,data:NdYN7v9r9MzcVPT4Hg==,iv:Rg2LOr50ioyCY6pXuRlnMnjRbNP7ytLlxaBTQyIKwDk=,tag:dh+HbSxjlbj0SIi4ZrHdmw==,type:str]
-    LOCATION: ENC[AES256_GCM,data:D3jXjw==,iv:pdjgfvi7VoWIDwUraYHZxEZdyQK3TDxVod6WQhLZ1PU=,tag:1XHde/55pTjgWfqNKLnonA==,type:str]
-    ACME_EMAIL: ENC[AES256_GCM,data:+lUQv0E0rmzOOAi1cogD3psC/7VyjMRF1uxNCLuRQWjItlXzdJrIJUAY,iv:i+sW0ZwC/3FDVWb329mrOv6tQxsBCCiqtX4fm5zdhlc=,tag:Wsa7JHQErVcwpja/FYJYew==,type:str]
-    CLUSTER_TAILSCALE_DOMAIN: ENC[AES256_GCM,data:RXNT/Uph+AxrgE4gmshIUd9GU9PlRdiVTJLL,iv:LgspLTIAOsVZPOB5GkhFjV2mo7/L7PpiiMke4kL7aDs=,tag:ltQNaAfgUTFXJBKwUflKzA==,type:str]
-    INTERNAL_CLUSTER_DOMAIN: ENC[AES256_GCM,data:a3X7V4FN3h1dUVo97Q==,iv:cqPfpcRxX6YvZ0wX84GpRLslbnenlJE71ICv3cQV0tM=,tag:JNVQTbOjk+Pp1NVzXBDDfw==,type:str]
-    INTERNAL_CLUSTER_SERVICE: ENC[AES256_GCM,data:p3McXCTOt9iJv/Nqrvf49qt2fu80n8IhwYnT,iv:5POPmhE89cn4vTTRM1rlrJdv/TyKXt39BgZy0HmFgTc=,tag:rEJiMmB5eNtwNPsTNsS8mg==,type:str]
-    INTERNAL_CNAME: ENC[AES256_GCM,data:xHS6Di2FYjMy,iv:TgViXL8pqmqrAi8Qg4qE+saqWGTJEUQD8641K6ys3cY=,tag:FyFQlVLFotIoBsLRFHYHNQ==,type:str]
-    INTERNAL_DOMAIN: ENC[AES256_GCM,data:0sqwmyzuYKiTcnwupqjgqNp/2C4LC40=,iv:+LdvcyLJS2vEfoUPUT+1N4F1bqxvQtnCJxIupvXhA3s=,tag:DOa5AoaRsSyKdoJV9/8rFA==,type:str]
-    INTERNAL_IP: ENC[AES256_GCM,data:3qWy6Q6HlsnnITqsnQ==,iv:BcE7gIwJI64LgtDLCcbXL+B3WgADaRzLGdZCQHBbM3o=,tag:zQeImnAZQe9YOCngPOvL/A==,type:str]
-    INTERNAL_TAILSCALE_VIP: ENC[AES256_GCM,data:HsgLiwVUAIvGRKoEgLj0,iv:Q0VrbDH22d1z7WlL23Lcl2g9hnfkFafSbiz+K7/TPiQ=,tag:hY464Zn4HRFp+bpvckR+Ew==,type:str]
-    EXTERNAL_CNAME: ENC[AES256_GCM,data:pbqZdxnjYXt6t3/Z4bEDr+iJf14=,iv:r6rdZhBx9fHG4YENy8M9Kd+yIaMnUHfWIVTXQkE2nRo=,tag:sU4yjJOoRsSw1HDptRpm8g==,type:str]
-    EXTERNAL_DOMAIN: ENC[AES256_GCM,data:qyAx2N2iCj+XJj3nJtstUadPh3idE23iTI4t25Hw2sTZ1A==,iv:17DStSW9mredsg6uqfZnDjECrf5eVqYRseyumiega+8=,tag:ko0K+jNLlnIg/qWIcbDRKQ==,type:str]
-    EXTERNAL_IP: ENC[AES256_GCM,data:HAr2G1+jTikjYkfN6A==,iv:IeVawRPfOxEWcdIeAUby9mPGJP3xFVN/nwoje3FA/CY=,tag:QklES2FDQrD+xwP7MCMbgw==,type:str]
-    EXTERNAL_TAILSCALE_VIP: ENC[AES256_GCM,data:HIgsdANALrW0aG4Rjtw3,iv:hjgagqOmDhYv7tTjp0dI5ua2Fo+YKbFRQQma4kkY0+M=,tag:DUYdSIFh8BxLNj9DE+jBUw==,type:str]
-    RUSTDESK_IP: ENC[AES256_GCM,data:cToGQfWmjrAjqU+PGQ==,iv:DB4eTdS4rxNOetq09AfvD+QJha7s/NcWWyS51TIPEUo=,tag:V0/+FYBDr15OeIJpSLJlUg==,type:str]
-    K8S_GATEWAY_IP: ENC[AES256_GCM,data:7bMFpUeJymVoPPGDXg==,iv:UI08WFCo4OI7G6FdapRU4QgaoG16Zc7HEgIkeNCuTE4=,tag:DBM9kHhPrbGNwHJolDjELQ==,type:str]
-    LOADBALANCER_RANGE: ENC[AES256_GCM,data:P+JcZMXgvwfh,iv:+2DkJpYVdqHzolxkKbeobMERQoE5vTl8330aH6aQigA=,tag:EXS9eusuab3sMrJHHecXRQ==,type:str]
-    TECHNITIUM_VIP: ENC[AES256_GCM,data:JaXFMLZGPdDzwBMxTg==,iv:CV058DpYzO3ShcleUCW+LyV0rjrDSIDAY2hnUF7jvKM=,tag:IrIgvBmgGUCPCt7/l8ZJBQ==,type:str]
-    TECHNITIUM_TAILSCALE_VIP: ENC[AES256_GCM,data:D8RaYhvYVY9AZG+lYw9d,iv:SxJ6/kk6sCzWvQHUvSk3T47bAXUOJfQxjCDQAQKcWbM=,tag:W/fO0c4aY/tTyu9EhAyEzg==,type:str]
-    TUNNEL_DOMAIN: ENC[AES256_GCM,data:Br5We3y2mk6zThUP/X6pZpFWcmzPAol2gf71xiHHUH2p0BZNzMRZm9wvaq0azkEacW2T2qY=,iv:Rn6c99bckCg5iBWD3ngwe+ihDoaOmvZ4SPda1XcuI5c=,tag:RWUHg4dVAi25HgjzlX9PFg==,type:str]
-    CLOUDFLARE_TUNNEL_SECRET: ENC[AES256_GCM,data:dbAfKJO5sunSkOHfukgW/hZfO6Tf8icbWZO+s4kLk+R54ucIr7OpjY224ns=,iv:eR2J1XhUMVdlbeTXtOahg5Ji/NqtJ5iluauIRXXH3Ew=,tag:yFGotbtnr4EsvLIEu09h9Q==,type:str]
-    CLUSTER_NETWORK: ENC[AES256_GCM,data:gc1FSRgHJj3RvNBLVw==,iv:o6lU2TBQHHCQAZ/PTF6jHbfxhfZkoCC9cZfBQXrMDmE=,tag:WmKpAXFrS4GTPE/ym974Nw==,type:str]
-    SERVICE_NETWORK: ENC[AES256_GCM,data:OYYyaJQSiYhMSzp5dA==,iv:5n0EEeJZ9NWpb9JbU2LQiNmClq710KfdhHWouzdmfDI=,tag:ECme/GkPxWDo5MR4oC2zIw==,type:str]
-    TAILSCALE_NAMESERVER_IP: ENC[AES256_GCM,data:N+XeWtXCRW3qrQTo8w==,iv:CmOlkUBkPFTqYaAvKBlMBIr7ZsxZaL5YLqVbCABJjfQ=,tag:wTvfivpy12Ge+/3UWdolNA==,type:str]
-    OIDC_ISSUER: ENC[AES256_GCM,data:d71MoVhQmW+6RAhz43iFt0KUrexMRNc=,iv:iQTZ1+fODilvlNacqslUWPHvRt/647Yqpphv68oHvJU=,tag:D+KXDsTtQVzzxiO4ID59cg==,type:str]
-    S3_VOLUME_CAPACITY: ENC[AES256_GCM,data:kpM=,iv:Js0tqJr7ytpz9WwhuluQi4PSh5qF4PM0Q8LQFoGbo5c=,tag:cvJjUkXh7n/URTWOUOe6pA==,type:str]
-    BACKBLAZE_S3: ENC[AES256_GCM,data:Y2caBS4WjXRlQqtJeTD/j5nKnTMmeA==,iv:qROO7WqJojF3e802WCsPNKIfGXX/+0MYkvy/j2hhAZs=,tag:o/xfU24YTIwBShcC4Zp1tg==,type:str]
-    BACKBLAZE_DATABASE: ENC[AES256_GCM,data:Q+3ycfKBH1Twq9ADWjaeDXomsbPuQ3D9LNMeKaOkEw==,iv:AaNcxvq5Saud2q1TnuLDOT8m3ZGM1t/7GivYaEB+0AU=,tag:UI+AUEBkhMDfiSSGIG6iwQ==,type:str]
-    BACKBLAZE_BUCKET: ENC[AES256_GCM,data:xj2NGQgyCHhN,iv:qe1iOlbdsasSI7u71Dvds7Z0fNiDVmQAg6+8XnY6Rq4=,tag:HM9ukw/C9QOym6Po6Aa8TQ==,type:str]
-    BACKBLAZE_DB_BUCKET: ENC[AES256_GCM,data:jrEXnY4ahbUHnKVu,iv:7nkKLDDYm1EJB55oMkiqwRK0IL0jYZ3EoJIAC7QKSL8=,tag:xGMcDr42Oepl667x59DODg==,type:str]
-    POSTGRES_REQUESTS_CPU: ENC[AES256_GCM,data:lLXi3pM=,iv:TIMCJ9PRe8+GSEn/Ccb1I0pZxn7CQ2gNhw+RPpRmBVg=,tag:XqY4DcrLTdO+Ajrb70pWuw==,type:str]
-    POSTGRES_REQUESTS_MEMORY: ENC[AES256_GCM,data:qvl6,iv:YsazdCpopiNV+AE9GSw3Xw09HeFj1BwRgI/RrqCWjfk=,tag:8ktflpplA6/anIHyo+PaUA==,type:str]
-    POSTGRES_LIMITS_CPU: ENC[AES256_GCM,data:hgHY008=,iv:rdiFUAWY/6VFrB8TVZGgpTCk/wYXwMXYU8mpbJMIWTo=,tag:oVIBOgy50C4UWXxz0ppuNw==,type:str]
-    POSTGRES_LIMITS_MEMORY: ENC[AES256_GCM,data:nQiU,iv:QkKwGty0j3b54HrR8TmjF9lbue5HAaEbRIbTQX9QQ/c=,tag:KVv77gcZurngTW760yMxfg==,type:str]
-    POSTGRES_SHARED_BUFFERS: ENC[AES256_GCM,data:3QaaA25u,iv:FtSkfiZ276FdIQhPJDcDyWgB/OaXxe0ISQEJA3qdax4=,tag:PvPpqrznBM11eJ3iQRWdXQ==,type:str]
-    GITHUB_REPOSITORY: ENC[AES256_GCM,data:7sp8QPuuBqaaQfmd+zRTXqGHn+meSbmHycGRzSNxXpsMtf2FOnajfD5FgXj42f1ItvZn,iv:P1MDbcrKicHU2XSn3uFU6x4KB2uoonsXbKYsDb9Eous=,tag:UAg3m2dgJFu0u/ZksLKKwA==,type:str]
-    GITHUB_REPOSITORY_OWNER: ENC[AES256_GCM,data:2Up1wzZQPU59gSRviWoDXLaGBuo2udlvB3nRRmDjTuo=,iv:QxyvJcUCxlatbOAyPFV91238e3HNE/xF4w03C6yPlKc=,tag:5/aJb4HlYx56p6Lgr05jow==,type:str]
-    QBITTORRENT_IP: ENC[AES256_GCM,data:80uKuzx65aHgSWvnCA==,iv:CFem/Cwu0aZqSylAw0a0sZB0ZOo6HzCxbEyCkvCgMWk=,tag:Vs8USb74JjAKOc7JVbIqKg==,type:str]
+  CLUSTER_CNAME: ENC[AES256_GCM,data:iTWIXLYcIkvm,iv:GsmJ9PrjOUVyhi56NTniArRiXwEb7/iUF8rS5OVVubo=,tag:BEe3mA/fRXKPB5YCLcwqdA==,type:str]
+  CLUSTER_KEY: ENC[AES256_GCM,data:IW4XYVAcVSrR,iv:5mM5PY3yp5Gqd72ffTc5Ag2tixsPQiQWsXa4+vRo1VI=,tag:KxXiiAa6N2zl/2Uruj2BGw==,type:str]
+  CLUSTER_TITLE: ENC[AES256_GCM,data:mmiKPhyDCloy,iv:5nUpt3kCiz0x5a7jpmijGiGuGJBjXk7tQyGK5bkR1Ww=,tag:MX+J16GD9MpJxq5BDLYZ1Q==,type:str]
+  CLUSTER_DOMAIN: ENC[AES256_GCM,data:8Wh2NCoRQml2aBEAtbhhLPWxPAjNXZQ=,iv:KBW1Pr12I/6AiZGhtFa3BfdxlPhHVyVHqBWDMYQhByg=,tag:NC0krZDvk8W4ByJ3N0117Q==,type:str]
+  CLUSTER_IP: ENC[AES256_GCM,data:SrQ/3EZkUXrlAcM=,iv:qRxAVeuBGnC8qjTzPJ86y78rqjtZ5KgQjpNWvJyR1xg=,tag:9D54eVyHh6i3lUjb1xsRqg==,type:str]
+  CLUSTER_API_IP: ENC[AES256_GCM,data:NdYN7v9r9MzcVPT4Hg==,iv:Rg2LOr50ioyCY6pXuRlnMnjRbNP7ytLlxaBTQyIKwDk=,tag:dh+HbSxjlbj0SIi4ZrHdmw==,type:str]
+  LOCATION: ENC[AES256_GCM,data:D3jXjw==,iv:pdjgfvi7VoWIDwUraYHZxEZdyQK3TDxVod6WQhLZ1PU=,tag:1XHde/55pTjgWfqNKLnonA==,type:str]
+  ACME_EMAIL: ENC[AES256_GCM,data:+lUQv0E0rmzOOAi1cogD3psC/7VyjMRF1uxNCLuRQWjItlXzdJrIJUAY,iv:i+sW0ZwC/3FDVWb329mrOv6tQxsBCCiqtX4fm5zdhlc=,tag:Wsa7JHQErVcwpja/FYJYew==,type:str]
+  CLUSTER_TAILSCALE_DOMAIN: ENC[AES256_GCM,data:RXNT/Uph+AxrgE4gmshIUd9GU9PlRdiVTJLL,iv:LgspLTIAOsVZPOB5GkhFjV2mo7/L7PpiiMke4kL7aDs=,tag:ltQNaAfgUTFXJBKwUflKzA==,type:str]
+  INTERNAL_CLUSTER_DOMAIN: ENC[AES256_GCM,data:a3X7V4FN3h1dUVo97Q==,iv:cqPfpcRxX6YvZ0wX84GpRLslbnenlJE71ICv3cQV0tM=,tag:JNVQTbOjk+Pp1NVzXBDDfw==,type:str]
+  INTERNAL_CLUSTER_SERVICE: ENC[AES256_GCM,data:p3McXCTOt9iJv/Nqrvf49qt2fu80n8IhwYnT,iv:5POPmhE89cn4vTTRM1rlrJdv/TyKXt39BgZy0HmFgTc=,tag:rEJiMmB5eNtwNPsTNsS8mg==,type:str]
+  INTERNAL_CNAME: ENC[AES256_GCM,data:xHS6Di2FYjMy,iv:TgViXL8pqmqrAi8Qg4qE+saqWGTJEUQD8641K6ys3cY=,tag:FyFQlVLFotIoBsLRFHYHNQ==,type:str]
+  INTERNAL_DOMAIN: ENC[AES256_GCM,data:0sqwmyzuYKiTcnwupqjgqNp/2C4LC40=,iv:+LdvcyLJS2vEfoUPUT+1N4F1bqxvQtnCJxIupvXhA3s=,tag:DOa5AoaRsSyKdoJV9/8rFA==,type:str]
+  INTERNAL_IP: ENC[AES256_GCM,data:3qWy6Q6HlsnnITqsnQ==,iv:BcE7gIwJI64LgtDLCcbXL+B3WgADaRzLGdZCQHBbM3o=,tag:zQeImnAZQe9YOCngPOvL/A==,type:str]
+  INTERNAL_TAILSCALE_VIP: ENC[AES256_GCM,data:HsgLiwVUAIvGRKoEgLj0,iv:Q0VrbDH22d1z7WlL23Lcl2g9hnfkFafSbiz+K7/TPiQ=,tag:hY464Zn4HRFp+bpvckR+Ew==,type:str]
+  EXTERNAL_CNAME: ENC[AES256_GCM,data:pbqZdxnjYXt6t3/Z4bEDr+iJf14=,iv:r6rdZhBx9fHG4YENy8M9Kd+yIaMnUHfWIVTXQkE2nRo=,tag:sU4yjJOoRsSw1HDptRpm8g==,type:str]
+  EXTERNAL_DOMAIN: ENC[AES256_GCM,data:qyAx2N2iCj+XJj3nJtstUadPh3idE23iTI4t25Hw2sTZ1A==,iv:17DStSW9mredsg6uqfZnDjECrf5eVqYRseyumiega+8=,tag:ko0K+jNLlnIg/qWIcbDRKQ==,type:str]
+  EXTERNAL_IP: ENC[AES256_GCM,data:HAr2G1+jTikjYkfN6A==,iv:IeVawRPfOxEWcdIeAUby9mPGJP3xFVN/nwoje3FA/CY=,tag:QklES2FDQrD+xwP7MCMbgw==,type:str]
+  EXTERNAL_TAILSCALE_VIP: ENC[AES256_GCM,data:HIgsdANALrW0aG4Rjtw3,iv:hjgagqOmDhYv7tTjp0dI5ua2Fo+YKbFRQQma4kkY0+M=,tag:DUYdSIFh8BxLNj9DE+jBUw==,type:str]
+  RUSTDESK_IP: ENC[AES256_GCM,data:cToGQfWmjrAjqU+PGQ==,iv:DB4eTdS4rxNOetq09AfvD+QJha7s/NcWWyS51TIPEUo=,tag:V0/+FYBDr15OeIJpSLJlUg==,type:str]
+  K8S_GATEWAY_IP: ENC[AES256_GCM,data:7bMFpUeJymVoPPGDXg==,iv:UI08WFCo4OI7G6FdapRU4QgaoG16Zc7HEgIkeNCuTE4=,tag:DBM9kHhPrbGNwHJolDjELQ==,type:str]
+  LOADBALANCER_RANGE: ENC[AES256_GCM,data:P+JcZMXgvwfh,iv:+2DkJpYVdqHzolxkKbeobMERQoE5vTl8330aH6aQigA=,tag:EXS9eusuab3sMrJHHecXRQ==,type:str]
+  TECHNITIUM_VIP: ENC[AES256_GCM,data:JaXFMLZGPdDzwBMxTg==,iv:CV058DpYzO3ShcleUCW+LyV0rjrDSIDAY2hnUF7jvKM=,tag:IrIgvBmgGUCPCt7/l8ZJBQ==,type:str]
+  TECHNITIUM_TAILSCALE_VIP: ENC[AES256_GCM,data:D8RaYhvYVY9AZG+lYw9d,iv:SxJ6/kk6sCzWvQHUvSk3T47bAXUOJfQxjCDQAQKcWbM=,tag:W/fO0c4aY/tTyu9EhAyEzg==,type:str]
+  TUNNEL_DOMAIN: ENC[AES256_GCM,data:Br5We3y2mk6zThUP/X6pZpFWcmzPAol2gf71xiHHUH2p0BZNzMRZm9wvaq0azkEacW2T2qY=,iv:Rn6c99bckCg5iBWD3ngwe+ihDoaOmvZ4SPda1XcuI5c=,tag:RWUHg4dVAi25HgjzlX9PFg==,type:str]
+  CLUSTER_NETWORK: ENC[AES256_GCM,data:gc1FSRgHJj3RvNBLVw==,iv:o6lU2TBQHHCQAZ/PTF6jHbfxhfZkoCC9cZfBQXrMDmE=,tag:WmKpAXFrS4GTPE/ym974Nw==,type:str]
+  SERVICE_NETWORK: ENC[AES256_GCM,data:OYYyaJQSiYhMSzp5dA==,iv:5n0EEeJZ9NWpb9JbU2LQiNmClq710KfdhHWouzdmfDI=,tag:ECme/GkPxWDo5MR4oC2zIw==,type:str]
+  TAILSCALE_NAMESERVER_IP: ENC[AES256_GCM,data:N+XeWtXCRW3qrQTo8w==,iv:CmOlkUBkPFTqYaAvKBlMBIr7ZsxZaL5YLqVbCABJjfQ=,tag:wTvfivpy12Ge+/3UWdolNA==,type:str]
+  OIDC_ISSUER: ENC[AES256_GCM,data:d71MoVhQmW+6RAhz43iFt0KUrexMRNc=,iv:iQTZ1+fODilvlNacqslUWPHvRt/647Yqpphv68oHvJU=,tag:D+KXDsTtQVzzxiO4ID59cg==,type:str]
+  S3_VOLUME_CAPACITY: ENC[AES256_GCM,data:kpM=,iv:Js0tqJr7ytpz9WwhuluQi4PSh5qF4PM0Q8LQFoGbo5c=,tag:cvJjUkXh7n/URTWOUOe6pA==,type:str]
+  BACKBLAZE_S3: ENC[AES256_GCM,data:Y2caBS4WjXRlQqtJeTD/j5nKnTMmeA==,iv:qROO7WqJojF3e802WCsPNKIfGXX/+0MYkvy/j2hhAZs=,tag:o/xfU24YTIwBShcC4Zp1tg==,type:str]
+  BACKBLAZE_DATABASE: ENC[AES256_GCM,data:Q+3ycfKBH1Twq9ADWjaeDXomsbPuQ3D9LNMeKaOkEw==,iv:AaNcxvq5Saud2q1TnuLDOT8m3ZGM1t/7GivYaEB+0AU=,tag:UI+AUEBkhMDfiSSGIG6iwQ==,type:str]
+  BACKBLAZE_BUCKET: ENC[AES256_GCM,data:xj2NGQgyCHhN,iv:qe1iOlbdsasSI7u71Dvds7Z0fNiDVmQAg6+8XnY6Rq4=,tag:HM9ukw/C9QOym6Po6Aa8TQ==,type:str]
+  BACKBLAZE_DB_BUCKET: ENC[AES256_GCM,data:jrEXnY4ahbUHnKVu,iv:7nkKLDDYm1EJB55oMkiqwRK0IL0jYZ3EoJIAC7QKSL8=,tag:xGMcDr42Oepl667x59DODg==,type:str]
+  POSTGRES_REQUESTS_CPU: ENC[AES256_GCM,data:lLXi3pM=,iv:TIMCJ9PRe8+GSEn/Ccb1I0pZxn7CQ2gNhw+RPpRmBVg=,tag:XqY4DcrLTdO+Ajrb70pWuw==,type:str]
+  POSTGRES_REQUESTS_MEMORY: ENC[AES256_GCM,data:qvl6,iv:YsazdCpopiNV+AE9GSw3Xw09HeFj1BwRgI/RrqCWjfk=,tag:8ktflpplA6/anIHyo+PaUA==,type:str]
+  POSTGRES_LIMITS_CPU: ENC[AES256_GCM,data:hgHY008=,iv:rdiFUAWY/6VFrB8TVZGgpTCk/wYXwMXYU8mpbJMIWTo=,tag:oVIBOgy50C4UWXxz0ppuNw==,type:str]
+  POSTGRES_LIMITS_MEMORY: ENC[AES256_GCM,data:nQiU,iv:QkKwGty0j3b54HrR8TmjF9lbue5HAaEbRIbTQX9QQ/c=,tag:KVv77gcZurngTW760yMxfg==,type:str]
+  POSTGRES_SHARED_BUFFERS: ENC[AES256_GCM,data:3QaaA25u,iv:FtSkfiZ276FdIQhPJDcDyWgB/OaXxe0ISQEJA3qdax4=,tag:PvPpqrznBM11eJ3iQRWdXQ==,type:str]
+  GITHUB_REPOSITORY: ENC[AES256_GCM,data:7sp8QPuuBqaaQfmd+zRTXqGHn+meSbmHycGRzSNxXpsMtf2FOnajfD5FgXj42f1ItvZn,iv:P1MDbcrKicHU2XSn3uFU6x4KB2uoonsXbKYsDb9Eous=,tag:UAg3m2dgJFu0u/ZksLKKwA==,type:str]
+  GITHUB_REPOSITORY_OWNER: ENC[AES256_GCM,data:2Up1wzZQPU59gSRviWoDXLaGBuo2udlvB3nRRmDjTuo=,iv:QxyvJcUCxlatbOAyPFV91238e3HNE/xF4w03C6yPlKc=,tag:5/aJb4HlYx56p6Lgr05jow==,type:str]
+  QBITTORRENT_IP: ENC[AES256_GCM,data:80uKuzx65aHgSWvnCA==,iv:CFem/Cwu0aZqSylAw0a0sZB0ZOo6HzCxbEyCkvCgMWk=,tag:Vs8USb74JjAKOc7JVbIqKg==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2dVpxTWxvWGd3cmlXNkM0
-            RzMxTWh5eXdlSERTbklMUGVuYVF2V1hIMlhnCjMzcDRlNVZtQ2hzYndoV3ZkT1Rn
-            cGlnZGhnT2NtZjY5Ty9TY0NtN2lrSWMKLS0tIEkrMzdJR0wvbXRaM1VHOTBzU29Y
-            NlZuUitMSTBidUlNTlJtN3B3Qk54cW8Kgb/NKRdoI+lktDCLuGY8cR8CjW9jgKOp
-            9lk1TPxVl2k64KY2XD4QcvTV8hmhavJZKJaOuSC1dwhH71q9gSV95A==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEK3g5djdlZmlIY3AzWnlV
-            NEFYSmlZNllJSm02dTBMRHcwUTNWOVNRTkYwCjYycHlxVGQ1UC9ENWxDM3dLVDAy
-            NkdIT3VTN05OUUpOckYyUkE5RFovcGMKLS0tIDBIY2h2S0FBUmVkcTBicnYycENa
-            bGJtK3RYeWdiSzVQVXZ6WlBwM3Qxa2cKP2DRvOsLLNvwL4yts7E4qDldEm3xbggs
-            vwlOjHZMLGpJ6its9oansHk3/VttFW+NjX3TqexaHdURBmumqByGdA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFcHd1ZE4vUC95YlpVV3ZU
-            aGhyWG5yTDRyU0RjT1FaMkp3Vkk4QjJTeVdZCjdjM2xIcUx5MjVSVWdPSGNrNmRO
-            NUV3ZjltODJ6ZEt4bFNFKzFjcEowcE0KLS0tIFNpLzc5WjN6dko4ZHVaZnl3OGhz
-            Q25mOWZKT2Q5bHM5SWRoYlBTUVNtZUUKwuHCXkdMvtjaZg8ki2H07Djb8YmFc02t
-            D/V352D5bZD2GBUOMjGbcrix2uj2wt36rAUH1nuOahVSDh6SN9CZ/g==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-11T00:08:48Z"
-    mac: ENC[AES256_GCM,data:h1ZT1ZoXcDbvtJ0XZ/+w/uiGT9TyeoWZnjL5Q77FyfPJ7EM6Kt45GyAYBLWzE2qBa4IR3W28DnrxWVKriXySF5HR7/HFk2po7bKbIRpFRg8j0K5hHgSiIZWn3jKqtGZ2exWb/W5LxoWapGq8dtiY4RrgI1p/wwTIplb29KhBpfc=,iv:bZqO34BtDXKsaGPzUlObWWowSJSAcw/GdUKP73D6oOs=,tag:2Cn7rdyD1T4ONSZNoa645A==,type:str]
-    mac_only_encrypted: true
-    version: 3.13.0
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2dVpxTWxvWGd3cmlXNkM0
+        RzMxTWh5eXdlSERTbklMUGVuYVF2V1hIMlhnCjMzcDRlNVZtQ2hzYndoV3ZkT1Rn
+        cGlnZGhnT2NtZjY5Ty9TY0NtN2lrSWMKLS0tIEkrMzdJR0wvbXRaM1VHOTBzU29Y
+        NlZuUitMSTBidUlNTlJtN3B3Qk54cW8Kgb/NKRdoI+lktDCLuGY8cR8CjW9jgKOp
+        9lk1TPxVl2k64KY2XD4QcvTV8hmhavJZKJaOuSC1dwhH71q9gSV95A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEK3g5djdlZmlIY3AzWnlV
+        NEFYSmlZNllJSm02dTBMRHcwUTNWOVNRTkYwCjYycHlxVGQ1UC9ENWxDM3dLVDAy
+        NkdIT3VTN05OUUpOckYyUkE5RFovcGMKLS0tIDBIY2h2S0FBUmVkcTBicnYycENa
+        bGJtK3RYeWdiSzVQVXZ6WlBwM3Qxa2cKP2DRvOsLLNvwL4yts7E4qDldEm3xbggs
+        vwlOjHZMLGpJ6its9oansHk3/VttFW+NjX3TqexaHdURBmumqByGdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFcHd1ZE4vUC95YlpVV3ZU
+        aGhyWG5yTDRyU0RjT1FaMkp3Vkk4QjJTeVdZCjdjM2xIcUx5MjVSVWdPSGNrNmRO
+        NUV3ZjltODJ6ZEt4bFNFKzFjcEowcE0KLS0tIFNpLzc5WjN6dko4ZHVaZnl3OGhz
+        Q25mOWZKT2Q5bHM5SWRoYlBTUVNtZUUKwuHCXkdMvtjaZg8ki2H07Djb8YmFc02t
+        D/V352D5bZD2GBUOMjGbcrix2uj2wt36rAUH1nuOahVSDh6SN9CZ/g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-10T14:36:11Z"
+  mac: ENC[AES256_GCM,data:830CLW1POymlOIErYTEUEq5HZWmYFc4fE4L2oCUkVCo4h8wjCqO9TNo9nDL4v3FcpZGz/MnLvF9HGAgCBXjygQpyvrxF5ZQ9ARc7e5ASfkjg42auGBT0EeNqas0KSgycPOSZP41hoJl7wYPUKE6GeYbeTGREgjYhbt4mVIlA4fE=,iv:cDMe99x/Br6vbPqKEp4Ilb5kcX3hcO9+MewNhorjEDY=,tag:2j8wZ4PQotArSzzdsS2JGA==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.0

--- a/kubernetes/components/common/shared-secrets.sops.yaml
+++ b/kubernetes/components/common/shared-secrets.sops.yaml
@@ -7,74 +7,73 @@ metadata:
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
 stringData:
-    PUID: ENC[AES256_GCM,data:7e5n,iv:gmVNLAG0nGGL+ZV2yWOyY7lMOuYu+4wlZmlns5FnKDY=,tag:7vjYQnNEcsJuH1Yx6HrxCw==,type:str]
-    PGID: ENC[AES256_GCM,data:czDu,iv:w0W7X/zHjHMZOinL8R7FC/x856D8sa2j0Mob9dDaFyg=,tag:1BoZlnJhltuG/clcuzxWwg==,type:str]
-    #
-    TIMEZONE: ENC[AES256_GCM,data:ar7/tKtZnwGTcqK4DV4hbg==,iv:Yo89U5qRklHGTqOrNn9z4XBoukx0ygAxT7wMQbczx2Y=,tag:46pfEaQF4EAUSJhFzpjcGA==,type:str]
-    ROOT_DOMAIN: ENC[AES256_GCM,data:iJZw/0KAPUSxG5O+eQ==,iv:/v1wZKfNMuLJUc4i3mJDvV1Oltr1rEd5v/GdOXb36OM=,tag:SIUu0SETlL4RhNbllcdySA==,type:str]
-    TAILSCALE_DOMAIN: ENC[AES256_GCM,data:qbl4Q9RgXdnVhXdpwB8PaL8=,iv:EpEAY61bEXmTX7jsGeToXkx625fvkUesjUJQasnleHQ=,tag:HG8FBuDXqADy0pBLODoptA==,type:str]
-    BACKBLAZE_DOMAIN: ENC[AES256_GCM,data:wfTork9TjQ4hWfD0NgHB32GTh3iQ/K9KNSwmqbRC,iv:dEFVEKpFJVKNAjp6iWRPRJYhBgNoGKQtlUYQxpIV7g4=,tag:RJJ+01Wu/2FKjnRacRZETg==,type:str]
-    BACKBLAZE_KEY: ENC[AES256_GCM,data:JRAuLELvxkFWlhRi0Ey5maW/4rQGAeWggWwK20C+u4E=,iv:bmt9m7B8xMZTjXL3EyJ3uD+JcabrlekQM5V8UBmmcPs=,tag:T/HYsOAadWNx6/0vjsqsdg==,type:str]
-    CLOUDFLARE_SECRET: ENC[AES256_GCM,data:wCl22iO6etOCl48b1kKGxWpcj3CphMAVWj4pNL3UJFAfpKR1j6O42vm9g6I=,iv:PgN4tDV4bH+Namg2ncgotjIBDOB8x060eGkycj3FaF0=,tag:1z2UGb/ypeDPHXYDlpZxPA==,type:str]
-    INTERNAL_NETWORK: ENC[AES256_GCM,data:OsqU2nTtEZik7tGP,iv:KZqC/XzuJS3g8a8GK0iFcl5WYTElZvm113GAHW3XhQU=,tag:bxY8SwQ0pte34Zaq8NYwkQ==,type:str]
-    #ENC[AES256_GCM,data:2PPfRSDpkCG8wBI=,iv:0Ffl5NhRchr4y9iEXNCygB3c/Cr4oo8IEyO23DhZKUw=,tag:f14zGBmjEMi8xFwCWYO35A==,type:comment]
-    ALPHA_SITE_IP: ENC[AES256_GCM,data:EkfQUffpvdnQ2iLg,iv:tk0AmV15MHpSP33BnBcfs2/PR+3PX6Uq6z6fl+vrHk8=,tag:/08JPEKReUpLWsLBfoB6SA==,type:str]
-    ALPHA_SITE_TAILSCALE_IP: ENC[AES256_GCM,data:CauWMjIPDKAPQLqEr3g=,iv:aJuwG+KTN6W1FmUnXz1ikEn3D39vHkgV7YvVGVKmB6M=,tag:wnC45lfafAzRXiaXpPkxiQ==,type:str]
-    DOCKGE_DOMAIN: ENC[AES256_GCM,data:jkkPPQ3JIDgZQf6H0RuWQPzEA0vFK9Jj,iv:RQTc3aOsWQr/SCnEcfLxx3VF2pNwRRdcCH66NjgIuG0=,tag:/ikjOrEenC5jTnJc1gwLrQ==,type:str]
-    DOCKGE_IP: ENC[AES256_GCM,data:zyclP0EZFnLKuQ==,iv:c98VYPq5pZE8dE6nYiZ8kFy1JiV9QpJe6h0xT7mvrxs=,tag:ZS+NPWk/Gc19wRVK0pt+Rg==,type:str]
-    DOCKGE_TAILSCALE_IP: ENC[AES256_GCM,data:Du8tDijp/z+1Oh2E,iv:+ejS2FWwTMBNMQsjx+HYLZPvVArZsuUKbrrA9luz1KU=,tag:BEvmWBG+5kbqxyJxM0CihQ==,type:str]
-    #ENC[AES256_GCM,data:ovrXO02H,iv:vV+aOrloPZBA/TgClfO0ofgghH8ROh1t4PytHmNQDbI=,tag:k/03tGaQxO2UBtPG3xEQEw==,type:comment]
-    DISCORD_DOMAIN: ENC[AES256_GCM,data:1pV8Pf0LFaBJw3xPnxisGxyaZjKS,iv:mlBSYS4W2CwTS3kHyKJ2lUXswpRxbhYCutdbO5FTaQU=,tag:ydnhlscW5ch/mRVDiFPhmA==,type:str]
-    DISCORD_IP: ENC[AES256_GCM,data:2Hn0jJ3jf7ZH,iv:BhUFFDr2w/NIfRqCuT19potCgZhpO+1lcVMaDznDfmk=,tag:baAJVU/GkoILECpaHb7vpw==,type:str]
-    DISCORD_TAILSCALE_IP: ENC[AES256_GCM,data:KMdjKGgB8pbWH6Q=,iv:ghbrrxRKERSZhYaDx0EwrvEZXxnY+VkGDhePgBHVH30=,tag:BW8bsejNlLNKv6CMfTTSNw==,type:str]
-    #ENC[AES256_GCM,data:+XDaaj3y+QE=,iv:Mnb2f3Fo4T+2iYr3gbfD3Ozz7Gq5SERx6bUe9NyTJQY=,tag:75bmxqegu9ATYGQ5GZfHHw==,type:comment]
-    SPIKE_DOMAIN: ENC[AES256_GCM,data:Xwu5b4gEhQQLnk9mbtdKkMuwQw==,iv:cMROuA/3h/XCuqS8DiV/0XPNdWvrwOFP5m+FEB5YLps=,tag:Etr/VBy6Zj4zpStQXJQQcQ==,type:str]
-    SPIKE_IP: ENC[AES256_GCM,data:D4U/Axugd3/iu/A=,iv:GwteN9703eKr/fRkE7jlwSLfIIgza8i7HeMMvHsAtT0=,tag:Ym3U8LilcdlRtW0PtMtM2Q==,type:str]
-    #ENC[AES256_GCM,data:41m9NmY=,iv:tkA2W4/TotiPy8kNBJ/l4JZK6j6G6SvC4Wkg8SvDdIk=,tag:uvnUVrzsd2S/7UBqqmBhuQ==,type:comment]
-    SPIKE_TAILSCALE_IP: ENC[AES256_GCM,data:abiu9wXrwKJ1PSESMw==,iv:e20KPfJYmNKtOzQ/AQRtBy8PDcU6zQUlCq9//jI67AE=,tag:/F7ii81sMDjZBp9AVxB1cg==,type:str]
-    #
-    TWILIGHT_SPARKLE_IP: ENC[AES256_GCM,data:B4BNWiazBE0fCsWC,iv:ta825mpvnqYFRH7pgvUyhcaVDuD8PclaZDmS9w+tJO8=,tag:rJBSxujkJauD2tBB/wUIuw==,type:str]
-    TWILIGHT_SPARKLE_TAILSCALE_IP: ENC[AES256_GCM,data:JC0VeC7iyNqo9ct+oNE=,iv:znStRxlWHi6MmP50/uqlSbEfotLU4/j9Z3+EiniqJtM=,tag:agJnrZFu2Clmbo3SV7k6jg==,type:str]
-    #
-    CELESTIA_IP: ENC[AES256_GCM,data:dnAYjXKhmxKRW11g,iv:VaIPkdCUBC3e5Fg2/B09AuHty1TxDLLyB1gPUY6UROQ=,tag:7sGsmYCDmSg8tLXhZsZoqg==,type:str]
-    CELESTIA_TAILSCALE_IP: ENC[AES256_GCM,data:QNYQ0XrDY9swyHmZqjM=,iv:8+NX1yU+V1eoOTwfb3jU56zHjDu6IJRbYEVp5nTlDzE=,tag:evFIpSZ/Wvt/VJXzAN9u1A==,type:str]
-    #
-    LUNA_IP: ENC[AES256_GCM,data:mlrrhZAIbW7REERk,iv:l9FiCCa9qHR4yBTn07Pe2jTHfAMbYZ86kG2hpgD+rAU=,tag:nJr6SLSWZyrwwszX72gvJg==,type:str]
-    LUNA_TAILSCALE_IP: ENC[AES256_GCM,data:LiPJq7vZcFBuS35qY2Q=,iv:90pr00xuNy/KOixpf//cmBdWfWatIni14wioV/BNLpo=,tag:dhj6U23JwbV3BDxOc7gFkg==,type:str]
-    #
-    EQUESTRIA_API_IP: ENC[AES256_GCM,data:W6YOuOcGjL/PoUkk1Q==,iv:K1WYCX6haBB4t5qFXs1sYTeSG5jZxIDLTU3oh7RmWkM=,tag:t1D+1QIHakj5BUK9YfBUOg==,type:str]
-    SGC_API_IP: ENC[AES256_GCM,data:V/rp01WXufIeWRgy6Q==,iv:xvXA8gjn7lA1n4Mrxl+kT0MoOyYUyE6v1VG9bpPe+BY=,tag:R87AMfntZ70ERAC0WJ0aXg==,type:str]
+  PUID: ENC[AES256_GCM,data:7e5n,iv:gmVNLAG0nGGL+ZV2yWOyY7lMOuYu+4wlZmlns5FnKDY=,tag:7vjYQnNEcsJuH1Yx6HrxCw==,type:str]
+  PGID: ENC[AES256_GCM,data:czDu,iv:w0W7X/zHjHMZOinL8R7FC/x856D8sa2j0Mob9dDaFyg=,tag:1BoZlnJhltuG/clcuzxWwg==,type:str]
+  #
+  TIMEZONE: ENC[AES256_GCM,data:ar7/tKtZnwGTcqK4DV4hbg==,iv:Yo89U5qRklHGTqOrNn9z4XBoukx0ygAxT7wMQbczx2Y=,tag:46pfEaQF4EAUSJhFzpjcGA==,type:str]
+  ROOT_DOMAIN: ENC[AES256_GCM,data:iJZw/0KAPUSxG5O+eQ==,iv:/v1wZKfNMuLJUc4i3mJDvV1Oltr1rEd5v/GdOXb36OM=,tag:SIUu0SETlL4RhNbllcdySA==,type:str]
+  TAILSCALE_DOMAIN: ENC[AES256_GCM,data:qbl4Q9RgXdnVhXdpwB8PaL8=,iv:EpEAY61bEXmTX7jsGeToXkx625fvkUesjUJQasnleHQ=,tag:HG8FBuDXqADy0pBLODoptA==,type:str]
+  BACKBLAZE_DOMAIN: ENC[AES256_GCM,data:wfTork9TjQ4hWfD0NgHB32GTh3iQ/K9KNSwmqbRC,iv:dEFVEKpFJVKNAjp6iWRPRJYhBgNoGKQtlUYQxpIV7g4=,tag:RJJ+01Wu/2FKjnRacRZETg==,type:str]
+  BACKBLAZE_KEY: ENC[AES256_GCM,data:JRAuLELvxkFWlhRi0Ey5maW/4rQGAeWggWwK20C+u4E=,iv:bmt9m7B8xMZTjXL3EyJ3uD+JcabrlekQM5V8UBmmcPs=,tag:T/HYsOAadWNx6/0vjsqsdg==,type:str]
+  INTERNAL_NETWORK: ENC[AES256_GCM,data:OsqU2nTtEZik7tGP,iv:KZqC/XzuJS3g8a8GK0iFcl5WYTElZvm113GAHW3XhQU=,tag:bxY8SwQ0pte34Zaq8NYwkQ==,type:str]
+  #ENC[AES256_GCM,data:2PPfRSDpkCG8wBI=,iv:0Ffl5NhRchr4y9iEXNCygB3c/Cr4oo8IEyO23DhZKUw=,tag:f14zGBmjEMi8xFwCWYO35A==,type:comment]
+  ALPHA_SITE_IP: ENC[AES256_GCM,data:EkfQUffpvdnQ2iLg,iv:tk0AmV15MHpSP33BnBcfs2/PR+3PX6Uq6z6fl+vrHk8=,tag:/08JPEKReUpLWsLBfoB6SA==,type:str]
+  ALPHA_SITE_TAILSCALE_IP: ENC[AES256_GCM,data:CauWMjIPDKAPQLqEr3g=,iv:aJuwG+KTN6W1FmUnXz1ikEn3D39vHkgV7YvVGVKmB6M=,tag:wnC45lfafAzRXiaXpPkxiQ==,type:str]
+  DOCKGE_DOMAIN: ENC[AES256_GCM,data:jkkPPQ3JIDgZQf6H0RuWQPzEA0vFK9Jj,iv:RQTc3aOsWQr/SCnEcfLxx3VF2pNwRRdcCH66NjgIuG0=,tag:/ikjOrEenC5jTnJc1gwLrQ==,type:str]
+  DOCKGE_IP: ENC[AES256_GCM,data:zyclP0EZFnLKuQ==,iv:c98VYPq5pZE8dE6nYiZ8kFy1JiV9QpJe6h0xT7mvrxs=,tag:ZS+NPWk/Gc19wRVK0pt+Rg==,type:str]
+  DOCKGE_TAILSCALE_IP: ENC[AES256_GCM,data:Du8tDijp/z+1Oh2E,iv:+ejS2FWwTMBNMQsjx+HYLZPvVArZsuUKbrrA9luz1KU=,tag:BEvmWBG+5kbqxyJxM0CihQ==,type:str]
+  #ENC[AES256_GCM,data:ovrXO02H,iv:vV+aOrloPZBA/TgClfO0ofgghH8ROh1t4PytHmNQDbI=,tag:k/03tGaQxO2UBtPG3xEQEw==,type:comment]
+  DISCORD_DOMAIN: ENC[AES256_GCM,data:1pV8Pf0LFaBJw3xPnxisGxyaZjKS,iv:mlBSYS4W2CwTS3kHyKJ2lUXswpRxbhYCutdbO5FTaQU=,tag:ydnhlscW5ch/mRVDiFPhmA==,type:str]
+  DISCORD_IP: ENC[AES256_GCM,data:2Hn0jJ3jf7ZH,iv:BhUFFDr2w/NIfRqCuT19potCgZhpO+1lcVMaDznDfmk=,tag:baAJVU/GkoILECpaHb7vpw==,type:str]
+  DISCORD_TAILSCALE_IP: ENC[AES256_GCM,data:KMdjKGgB8pbWH6Q=,iv:ghbrrxRKERSZhYaDx0EwrvEZXxnY+VkGDhePgBHVH30=,tag:BW8bsejNlLNKv6CMfTTSNw==,type:str]
+  #ENC[AES256_GCM,data:+XDaaj3y+QE=,iv:Mnb2f3Fo4T+2iYr3gbfD3Ozz7Gq5SERx6bUe9NyTJQY=,tag:75bmxqegu9ATYGQ5GZfHHw==,type:comment]
+  SPIKE_DOMAIN: ENC[AES256_GCM,data:Xwu5b4gEhQQLnk9mbtdKkMuwQw==,iv:cMROuA/3h/XCuqS8DiV/0XPNdWvrwOFP5m+FEB5YLps=,tag:Etr/VBy6Zj4zpStQXJQQcQ==,type:str]
+  SPIKE_IP: ENC[AES256_GCM,data:D4U/Axugd3/iu/A=,iv:GwteN9703eKr/fRkE7jlwSLfIIgza8i7HeMMvHsAtT0=,tag:Ym3U8LilcdlRtW0PtMtM2Q==,type:str]
+  #ENC[AES256_GCM,data:41m9NmY=,iv:tkA2W4/TotiPy8kNBJ/l4JZK6j6G6SvC4Wkg8SvDdIk=,tag:uvnUVrzsd2S/7UBqqmBhuQ==,type:comment]
+  SPIKE_TAILSCALE_IP: ENC[AES256_GCM,data:abiu9wXrwKJ1PSESMw==,iv:e20KPfJYmNKtOzQ/AQRtBy8PDcU6zQUlCq9//jI67AE=,tag:/F7ii81sMDjZBp9AVxB1cg==,type:str]
+  #
+  TWILIGHT_SPARKLE_IP: ENC[AES256_GCM,data:B4BNWiazBE0fCsWC,iv:ta825mpvnqYFRH7pgvUyhcaVDuD8PclaZDmS9w+tJO8=,tag:rJBSxujkJauD2tBB/wUIuw==,type:str]
+  TWILIGHT_SPARKLE_TAILSCALE_IP: ENC[AES256_GCM,data:JC0VeC7iyNqo9ct+oNE=,iv:znStRxlWHi6MmP50/uqlSbEfotLU4/j9Z3+EiniqJtM=,tag:agJnrZFu2Clmbo3SV7k6jg==,type:str]
+  #
+  CELESTIA_IP: ENC[AES256_GCM,data:dnAYjXKhmxKRW11g,iv:VaIPkdCUBC3e5Fg2/B09AuHty1TxDLLyB1gPUY6UROQ=,tag:7sGsmYCDmSg8tLXhZsZoqg==,type:str]
+  CELESTIA_TAILSCALE_IP: ENC[AES256_GCM,data:QNYQ0XrDY9swyHmZqjM=,iv:8+NX1yU+V1eoOTwfb3jU56zHjDu6IJRbYEVp5nTlDzE=,tag:evFIpSZ/Wvt/VJXzAN9u1A==,type:str]
+  #
+  LUNA_IP: ENC[AES256_GCM,data:mlrrhZAIbW7REERk,iv:l9FiCCa9qHR4yBTn07Pe2jTHfAMbYZ86kG2hpgD+rAU=,tag:nJr6SLSWZyrwwszX72gvJg==,type:str]
+  LUNA_TAILSCALE_IP: ENC[AES256_GCM,data:LiPJq7vZcFBuS35qY2Q=,iv:90pr00xuNy/KOixpf//cmBdWfWatIni14wioV/BNLpo=,tag:dhj6U23JwbV3BDxOc7gFkg==,type:str]
+  #
+  EQUESTRIA_API_IP: ENC[AES256_GCM,data:W6YOuOcGjL/PoUkk1Q==,iv:K1WYCX6haBB4t5qFXs1sYTeSG5jZxIDLTU3oh7RmWkM=,tag:t1D+1QIHakj5BUK9YfBUOg==,type:str]
+  SGC_API_IP: ENC[AES256_GCM,data:V/rp01WXufIeWRgy6Q==,iv:xvXA8gjn7lA1n4Mrxl+kT0MoOyYUyE6v1VG9bpPe+BY=,tag:R87AMfntZ70ERAC0WJ0aXg==,type:str]
 sops:
-    age:
-        - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSnNFeFRTMmxhbEZPNEdZ
-            UHpuMEFpZDl3bmwvemFNWDQ2VUFHT2NnMmxrCkhkL1pPMThWeDlRcE9JV3FQSzIv
-            cDE0UHZSeFpTRmIzdHZxT3liTzFadGsKLS0tIERxU3FscUsreU4ySldKZDFqaUN0
-            Mnd5aXBtc1RvbUFKSE0vV1JHdkprdzQKhP5X8jatDfMom13BwfY3tXwn1ZjoEW54
-            LGU5hq9G8nZTcv1/DetxpQOL1ww74xW5eDEX9WCrF2GkOCWtwPKk4w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0M01mNzE3U09NdDJvZWs5
-            c2I0ZUQ1MkEwdFpnY0xBMW9ENHd6WC9YcTBZCkxrSkgvUzRLMlpzZ1FFZ0lxZ2Ry
-            K3J2SjRINjlGSzMvWWlrUGlseHB4dUUKLS0tIGRvbUtQMFgrdlhka1UzM0xKZUVP
-            cFZ0cm54L0VDSmRqMUYwKy8yMDF6SW8KBUFluKIoQj0SVnMbJzqNM2BcUIRR3iBB
-            jYzqXKhzWbCZcE70ici1UIvzb9kU9rHAVPL0kjrw4G+kY4GHuggBcg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVW9sMFZnRmorWDJwOGJn
-            MktRVXJkL0cycDJ3ZnV6S2xjTVB3RytTeVhRCkdjakdBQ0lVL2NFNTVRUGloSEJ3
-            UDBlcWNHM0phL3I3ZFpYYy9oNTJmZEUKLS0tIDNuWnVnRTRtYk45bk1PUDRkcW1z
-            eU5ybDhRWWloVTZKcEZXR25JTUh1YjQKqafytasolE54+VsZqIMN2ZrgUirTteys
-            ZLLzYKjUsk6Y/Da4VBq/madFO+6HsIqzcnVIURbAAgt/r9Qho4DK1A==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-31T02:05:49Z"
-    mac: ENC[AES256_GCM,data:+qOlLOd0fpzPJ9IIP9tykD3dx90TLUPrBi0zk77vzeo89jKnRIXxAJlV7TuHHj2TaH2FTtRv37hLYuPO8ngaMz9Dn6TxwcP/ItHHls8v5GxFZwMQUWpBq9htQ/Uup4wCM61G0x5v7KgsoSZSNzKSwUApXyaaWBwR0xIaDdDWalc=,iv:pUMy/lw0OCkISmySR3E9f1MMfRU9FQTf/L4kEhCwPVM=,tag:qhHwgSE+qFboQ3yYTQkM/A==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    mac_only_encrypted: true
-    version: 3.10.2
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSnNFeFRTMmxhbEZPNEdZ
+        UHpuMEFpZDl3bmwvemFNWDQ2VUFHT2NnMmxrCkhkL1pPMThWeDlRcE9JV3FQSzIv
+        cDE0UHZSeFpTRmIzdHZxT3liTzFadGsKLS0tIERxU3FscUsreU4ySldKZDFqaUN0
+        Mnd5aXBtc1RvbUFKSE0vV1JHdkprdzQKhP5X8jatDfMom13BwfY3tXwn1ZjoEW54
+        LGU5hq9G8nZTcv1/DetxpQOL1ww74xW5eDEX9WCrF2GkOCWtwPKk4w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0M01mNzE3U09NdDJvZWs5
+        c2I0ZUQ1MkEwdFpnY0xBMW9ENHd6WC9YcTBZCkxrSkgvUzRLMlpzZ1FFZ0lxZ2Ry
+        K3J2SjRINjlGSzMvWWlrUGlseHB4dUUKLS0tIGRvbUtQMFgrdlhka1UzM0xKZUVP
+        cFZ0cm54L0VDSmRqMUYwKy8yMDF6SW8KBUFluKIoQj0SVnMbJzqNM2BcUIRR3iBB
+        jYzqXKhzWbCZcE70ici1UIvzb9kU9rHAVPL0kjrw4G+kY4GHuggBcg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVW9sMFZnRmorWDJwOGJn
+        MktRVXJkL0cycDJ3ZnV6S2xjTVB3RytTeVhRCkdjakdBQ0lVL2NFNTVRUGloSEJ3
+        UDBlcWNHM0phL3I3ZFpYYy9oNTJmZEUKLS0tIDNuWnVnRTRtYk45bk1PUDRkcW1z
+        eU5ybDhRWWloVTZKcEZXR25JTUh1YjQKqafytasolE54+VsZqIMN2ZrgUirTteys
+        ZLLzYKjUsk6Y/Da4VBq/madFO+6HsIqzcnVIURbAAgt/r9Qho4DK1A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-10T14:36:11Z"
+  mac: ENC[AES256_GCM,data:yrSaGDCkedAIxK6RnkzD5X5oNE2TDBVZkOEZpq/3o4kZAHO23uaR+IMOl6zXb7CEd2dfQT1Vwn6S0gpYXx5KF4fVKGMRM4I8BdB2X+SBj0sz5WiH8O86ZN/J7BZ5uHfZfQ19+AX93SlATTj/vMKjSskvHdNp57/kMijELgU4MOQ=,iv:NcHdKnTx9FmW/eVorNxAaX31Xd9p2voQZmL559PnA1E=,tag:7z1isk3xY5SfI7woR1evWw==,type:str]
+  mac_only_encrypted: true
+  version: 3.10.2


### PR DESCRIPTION
Phase 6 follow-up. Both variables held a 1Password item path (`vaults/Eris/items/<uuid>`) and existed only to be interpolated into a `OnePasswordItem` CR’s `itemPath`. Those CRs are ExternalSecrets now (#3099–#3102) and spell their OpenBao path literally, so nothing in this repo references either variable. Leaving a 1Password item path defined invites someone to re-adopt it.

### Reviewing the diff

It is large; **only two lines are substantive.** `sops unset` rewrites the whole document, and both files were stored with 4-space indentation while this repo’s own `.sops.yaml` declares `stores.yaml.indent: 2` — so sops normalised them on write.

Every remaining ciphertext is **byte-identical to HEAD**. Verified by comparing each file’s `KEY: ENC[...]` lines with leading whitespace stripped; the only difference in each is the removed key:

```
shared-secrets   28 -> 27 values, only diff: CLOUDFLARE_SECRET
cluster-secrets  43 -> 42 values, only diff: CLOUDFLARE_TUNNEL_SECRET
```

Both files still decrypt, and an unrelated value (`ROOT_DOMAIN`) round-trips to the same plaintext. `flate` is green.

### SGC keeps both

Its `OnePasswordItem` CRs still use them; they go with Phase 7. `shared-secrets.sops.yaml` is a hand-synced triplicate across equestria/sgc/home-operations, so it is **deliberately divergent** until then — please do not "fix" it by copying SGC’s copy back. Paired with home-operations#710.

<!-- crew:agent=claude -->