### PR TITLE
feat(plex): gatus token reference moves from 1Password to OpenBao

### DIFF
--- a/kubernetes/apps/equestria/media/plex/definition.yaml
+++ b/kubernetes/apps/equestria/media/plex/definition.yaml
@@ -14,7 +14,7 @@ spec:
       - friends
       - family
   gatus:
-    - url: https://${APP}.${ROOT_DOMAIN}/connections?X-Plex-Token=op://Eris/Media Management Secrets/plex_token
+    - url: https://${APP}.${ROOT_DOMAIN}/connections?X-Plex-Token=ref+openbao://secrets/shared/media-management-secrets#/plex_token
       group: *category
       method: GET
       conditions:


### PR DESCRIPTION
Companion to home-operations#722 (Phase 8 of the OpenBao migration, PLAN §D.1). This is the **last `op://` reference in any ApplicationDefinition** — the plex Gatus check's `X-Plex-Token`.

## Merge gate

**Merge home-operations#722 first** and let the `applications/equestria` stack pick it up. Until that code is what the operator runs, a `ref+openbao://` reference passes through the old resolver verbatim and the literal string lands in the rendered Gatus config (a broken uptime check, not a leak). The reverse order is safe for 1Password: #722 keeps the `op://` resolver chained, so this file's current form keeps working before this PR merges.

Target verified live before the change: `secrets/shared/media-management-secrets` carries `plex_token` (with 18 sibling fields).

Once this merges, no file in any repo carries `op://` into the Gatus path, which unblocks deleting `replaceOnePasswordPlaceholders` in the `dynamic/1password` retirement slice (STATUS.md: treat as one decision with Phase 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)