### PR TITLE
fix(chrony): expose NTP over UDP instead of TCP

### DIFF
--- a/kubernetes/apps/stargate-command/chrony/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/chrony/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
         ports:
           ntp-port:
             port: &ntp-port 123
-            protocol: TCP
+            protocol: UDP
           other:
             port: 31880
             protocol: TCP


### PR DESCRIPTION
## What

Fixes one of two live defects found during the cluster-consolidation investigation, both documented in `docs/cluster-consolidation/15-migrate-apps.md` (home-operations repo) and tracked under [vault#84](https://github.com/david-driscoll/vault/issues/84).

**chrony's Service exposed NTP over TCP, not UDP** (namespace `stargate-command` on equestria — confirmed live, chrony has not moved namespaces since the SGC->equestria cutover). `chronyd` only speaks NTP over UDP/123; the `HelmRelease` declared `protocol: TCP` on the `ntp-port`, so the LoadBalancer VIP (`10.10.206.204`) accepted the port but never actually answered NTP queries. Flux/kubectl health (`Ready: True`, `1/1`) stayed green throughout because none of those checks touch the wire protocol.

Confirmed live before this change (context `admin@equestria`):
```
$ kubectl get svc -n stargate-command chrony -o yaml
  ports:
  - name: ntp-port
    port: 123
    protocol: TCP   # <- wrong, chronyd does not speak NTP over TCP
  - name: other
    port: 31880
    protocol: TCP
```

Fix: change `ntp-port`'s protocol from `TCP` to `UDP`. Nothing in the estate was found relying on TCP/123 against this Service, so this is a straight swap rather than an added port.

## What this PR does NOT fix

The second defect from the same investigation — **Home Assistant's MQTT integration pointing at the dead hostname `mosquitto.sgc.svc.cluster.local`** — is **not** included here. Investigated live (context `admin@equestria`, `home-assistant-695f96d685-x4tr7` in `stargate-command`):

```
$ kubectl exec -n stargate-command home-assistant-695f96d685-x4tr7 -c app -- \
    grep -o '"broker":[^,]*' /config/.storage/core.config_entries
"broker":"mosquitto.sgc.svc.cluster.local"
```

Unlike chrony's protocol flag, this is **not** a git-managed setting — there is no `configuration.yaml`, HelmRelease values block, or ConfigMap/Secret in this repo (or mounted into the pod) that holds the MQTT broker address. It lives entirely in Home Assistant's UI-managed integration storage on the app's PVC (`.storage/core.config_entries`), carried over byte-for-byte from the SGC restore. The plan doc is explicit that this should be fixed **via the HA UI** (Settings → Devices & Services → MQTT → Reconfigure, pointed at `mosquitto.stargate-command.svc.cluster.local` or the pinned `10.10.206.203`, which this session also confirmed live as mosquitto's current LoadBalancer IP) rather than by hand-editing the storage file on a live PVC — so it's out of scope for a code change/PR and needs a human (or an HA-API-driven follow-up with proper credentials) to do the reconfigure. Flagging here rather than silently skipping it.

## Verification

- `pulumi preview` is not applicable — this repo is Flux/Kustomize, no Pulumi stack involved.
- Post-merge, once Flux reconciles the `chrony` HelmRelease, expect: `kubectl get svc -n stargate-command chrony -o yaml` to show `ntp-port` as `123/UDP`, and `sntp -t 3 10.10.206.204` to return a real NTP reply instead of `Exchange failed: Timeout`. Not verified yet — this needs to happen after merge+reconcile, from a session that can retest.

Refs: `docs/cluster-consolidation/15-migrate-apps.md` (home-operations), [vault#84](https://github.com/david-driscoll/vault/issues/84)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>