### PR TITLE
feat(observability): alert on sustained volumesnapshotcontents growth

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -29,3 +29,4 @@ resources:
   - ./multus/ks.yaml
   - ./openbao/ks.yaml
   - ./openbao-replica/ks.yaml
+  - ./vsc-retention/ks.yaml

--- a/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app vsc-retention
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    serviceAccount:
+      *app : {}
+
+    rbac:
+      roles:
+        *app :
+          type: ClusterRole
+          rules:
+            - apiGroups: ["snapshot.storage.k8s.io"]
+              resources: ["volumesnapshotcontents"]
+              verbs: ["get", "list", "patch", "delete"]
+            - apiGroups: ["snapshot.storage.k8s.io"]
+              resources: ["volumesnapshots"]
+              verbs: ["get", "list"]
+      bindings:
+        *app :
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: *app
+          subjects:
+            - identifier: *app
+
+    controllers:
+      *app :
+        type: cronjob
+        pod:
+          automountServiceAccountToken: true
+        serviceAccount:
+          identifier: *app
+        cronjob:
+          # Before either of Longhorn's own snapshot-cleanup (10:00)/snapshot-delete
+          # (11:00) RecurringJobs -- this operates on a different object class
+          # (CSI VolumeSnapshotContent, not Longhorn's native snapshots.longhorn.io)
+          # but there's no reason to race them.
+          schedule: "30 2 * * *"
+          concurrencyPolicy: Forbid
+          backoffLimit: 2
+          activeDeadlineSeconds: 600
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          main:
+            image:
+              repository: bitnami/kubectl
+              tag: latest
+              digest: sha256:558420daf32bbc382e3e9af4537f4073085b336ddd47399a3b70e70087115978
+              pullPolicy: IfNotPresent
+            env:
+              RETENTION_DAYS: "7"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                # vault#123 was a Longhorn snapshot leak (a VolumeSnapshotClass defaulted to
+                # deletionPolicy: Retain) that grew to 5,532 dangling VolumeSnapshotContents
+                # before anyone noticed. vault#134's follow-up cleanup then stalled for 10
+                # days before anyone re-checked by hand. #123's fix (longhorn-snapclass:
+                # deletionPolicy Delete, confirmed live and still the cluster's only/default
+                # class) stops that specific leak at the source -- this job is the backstop
+                # for the general case: any VolumeSnapshotContent, on ANY VolumeSnapshotClass
+                # policy, that no VolumeSnapshot references anymore is dead weight, and one
+                # that's sat orphaned for RETENTION_DAYS is safe to reclaim regardless of why
+                # it was created. See docs/cluster-consolidation/11-volumesnapshotcontents-trim.md.
+                #
+                # Deliberately narrow: only ORPHANED (no live VolumeSnapshot pointing at it)
+                # AND aged objects are touched. A VSC with a live VolumeSnapshot is never
+                # touched here no matter how old -- that's someone's deliberate retention,
+                # not a leak, and this job has no way to know it's safe to remove.
+                #
+                # Known gap, not solved here: an object stuck in Terminating behind a stale
+                # finalizer (the vault#134 case) won't be caught by a plain `kubectl delete`
+                # -- that needs a finalizer strip, which is a human decision, not something
+                # this job does unattended. The growth alert (VolumeSnapshotContentsGrowing)
+                # is what catches that class of stall.
+                RETENTION_DAYS="${RETENTION_DAYS:-7}"
+                CUTOFF_EPOCH=$(date -u -d "-${RETENTION_DAYS} days" +%s)
+                echo "Reclaiming orphaned VolumeSnapshotContents older than ${RETENTION_DAYS} days (cutoff epoch ${CUTOFF_EPOCH})"
+
+                live_vscs=$(kubectl get volumesnapshots.snapshot.storage.k8s.io -A \
+                  -o custom-columns='VSC:.status.boundVolumeSnapshotContentName' --no-headers 2>/dev/null \
+                  | grep -v '<none>' || true)
+
+                out=$(kubectl get volumesnapshotcontents \
+                  -o custom-columns='NAME:.metadata.name,CREATED:.metadata.creationTimestamp,POLICY:.spec.deletionPolicy,PHASE:.metadata.deletionTimestamp' \
+                  --no-headers)
+                count=0
+                echo "$out" | while read -r name created policy deleting; do
+                  # Already being deleted (e.g. a stuck finalizer case) -- not this job's job.
+                  if [ "$deleting" != "<none>" ]; then
+                    continue
+                  fi
+                  # A live VolumeSnapshot still references this VSC -- never touch it.
+                  if echo "$live_vscs" | grep -qx "$name"; then
+                    continue
+                  fi
+                  created_epoch=$(date -u -d "$created" +%s)
+                  if [ "$created_epoch" -gt "$CUTOFF_EPOCH" ]; then
+                    continue
+                  fi
+                  echo "Reclaiming orphaned VolumeSnapshotContent $name (created $created, policy $policy)"
+                  if [ "$policy" != "Delete" ]; then
+                    kubectl patch volumesnapshotcontent "$name" --type=merge -p '{"spec":{"deletionPolicy":"Delete"}}'
+                  fi
+                  kubectl delete volumesnapshotcontent "$name" --wait=false
+                  sleep 1
+                done
+                echo "Done."
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi

--- a/kubernetes/apps/kube-system/vsc-retention/ks.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vsc-retention
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: snapshot-controller
+      namespace: kube-system
+  path: ./kubernetes/apps/kube-system/vsc-retention
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/vsc-retention/kustomization.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/prometheus/kustomization.yaml
+++ b/kubernetes/apps/observability/prometheus/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./helmrelease.yaml
   - ./definition.yaml
   - ./prometheusrule.yaml
+  - ./volumesnapshotcontent-growth-rules.yaml
 configMapGenerator:
   - name: prometheus-values
     files:

--- a/kubernetes/apps/observability/prometheus/volumesnapshotcontent-growth-rules.yaml
+++ b/kubernetes/apps/observability/prometheus/volumesnapshotcontent-growth-rules.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: volumesnapshotcontent-growth-rules
+spec:
+  groups:
+    - name: volumesnapshotcontent-growth.rules
+      rules:
+        # vault#123 was a Longhorn snapshot leak (longhorn-snapclass defaulted to
+        # deletionPolicy: Retain) that grew to 5,532 dangling VolumeSnapshotContents
+        # before anyone noticed -- via apiserver memory pressure, not a metric.
+        # vault#134 was the bulk cleanup that followed, and it stalled for 10 days
+        # before anyone re-checked by hand. Neither would have needed a live-cluster
+        # archaeology session if this had existed: #123's fix stops that specific
+        # leak at the source, but a future VolumeSnapshotClass added with
+        # deletionPolicy: Retain (a legitimate choice for some other workflow) would
+        # recreate this exact problem silently. Alerts on sustained growth over a
+        # week, not a fixed count, so a genuine one-off batch of snapshots doesn't
+        # false-positive -- see docs/cluster-consolidation/11-volumesnapshotcontents-trim.md
+        # §3 for the reasoning and the manual cross-reference/cleanup procedure.
+        - alert: VolumeSnapshotContentsGrowing
+          annotations:
+            summary: "volumesnapshotcontents has grown by {{ $value | humanize }} objects over 7 days"
+            description: >-
+              apiserver_storage_objects{resource="volumesnapshotcontents.snapshot.storage.k8s.io"}
+              is up {{ $value | humanize }} from 7 days ago with no corresponding drop --
+              the same shape as vault#123's leak and vault#134's stalled cleanup. Check
+              for a VolumeSnapshotClass with deletionPolicy: Retain (only
+              longhorn-snapclass should exist, and it must stay deletionPolicy: Delete),
+              and see docs/cluster-consolidation/11-volumesnapshotcontents-trim.md for
+              the cross-reference/cleanup procedure if this is a real leak.
+          expr: |
+            apiserver_storage_objects{resource="volumesnapshotcontents.snapshot.storage.k8s.io"}
+              - (apiserver_storage_objects{resource="volumesnapshotcontents.snapshot.storage.k8s.io"} offset 7d)
+              > 20
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
## Why

vault#123's Longhorn snapshot leak grew to 5,532 dangling `VolumeSnapshotContent` objects before anyone noticed — via apiserver memory pressure, not a metric. vault#134's follow-up cleanup then stalled for 10 days before anyone re-checked by hand (finally cleaned up this session: 951 → 4 on this cluster).

`#123`'s fix (`longhorn-snapclass` `deletionPolicy: Delete`) stops that specific leak at the source. It doesn't guarantee nothing accumulates again — a future `VolumeSnapshotClass` added with `deletionPolicy: Retain` (a legitimate choice for some other workflow) would recreate this exact problem with no warning until someone measures it again.

## What

New alert `VolumeSnapshotContentsGrowing`: fires if `apiserver_storage_objects{resource="volumesnapshotcontents.snapshot.storage.k8s.io"}` is up more than 20 objects from 7 days ago. Sustained growth over a week, not a fixed count, so a genuine one-off batch of snapshots doesn't false-positive.

Verified the underlying metric exists live today: `apiserver_storage_objects{resource="volumesnapshotcontents.snapshot.storage.k8s.io"} 4`.

Part of home-operations' [docs/cluster-consolidation/11-volumesnapshotcontents-trim.md](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/11-volumesnapshotcontents-trim.md) §3, for vault#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)