### PR TITLE
feat(tailscale-system): stage tsidp for cutover (vault#84 piece 13)

### DIFF
--- a/kubernetes/apps/tailscale-system/idp/definition.yaml
+++ b/kubernetes/apps/tailscale-system/idp/definition.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: tsidp
+spec:
+  name: Tailscale IDP
+  category: Infrastructure
+  description: Tailscale Identity Provider
+  url: &url https://idp.${TAILSCALE_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/tailscale.svg
+  access_policy:
+    groups:
+      - admins
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - group: "Applications"
+      url: https://idp.${TAILSCALE_DOMAIN}/.well-known/openid-configuration
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/tailscale-system/idp/ks.yaml
+++ b/kubernetes/apps/tailscale-system/idp/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tsidp
+  namespace: &namespace tailscale-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: tailscale-operator
+      namespace: tailscale-system
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/tailscale-system/idp
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    - ../../../components/failover/fast-node-eviction
+    - ../../../components/volsync
+    - ../../../components/volsync-restore
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+      # VOLSYNC_STORAGECLASS: longhorn-critical intentionally omitted — that
+      # StorageClass isn't live yet (piece 12 hasn't landed as of 2026-08-13).
+      # Falls back to the component's `longhorn` default; retag once 12 ships
+      # (see piece 13's "Storage tier" section for why retagging in place
+      # isn't a one-line edit once the PVC is Bound).

--- a/kubernetes/apps/tailscale-system/idp/kustomization.yaml
+++ b/kubernetes/apps/tailscale-system/idp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./tsidp.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/tailscale-system/idp/tsidp.yaml
+++ b/kubernetes/apps/tailscale-system/idp/tsidp.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tsidp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 0 # staging: piece 14 flips this to 1 at cutover
+        pod:
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: NotIn
+                        values:
+                          - othalla
+        initContainers:
+          fix-permissions:
+            image:
+              repository: busybox
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+            command:
+              - /bin/sh
+              - -c
+              - |
+                chown -R 1000:1000 /data
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add:
+                  - CHOWN
+                  - FOWNER
+
+        containers:
+          *app :
+            nameOverride: *app
+            image:
+              repository: ghcr.io/tailscale/tsidp
+              tag: v0.0.14@sha256:b3e7baf8dc0d309b8b34bedc286e38fd275daa302663e1b10f2ae774dff26b4a
+            env:
+              TS_HOSTNAME: &idp idp
+              TS_STATE_DIR: /data
+              TSIDP_HOSTNAME: *idp
+              TSIDP_STATE_DIR: /data
+              TAILSCALE_USE_WIP_CODE: "1"
+              TS_AUTHKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: tailscale-authkey
+                    key: authkey
+              TSIDP_ENABLE_STS: "1"
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+
+    defaultPodOptions:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      shareProcessNamespace: true
+
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/tailscale-system/kustomization.yaml
+++ b/kubernetes/apps/tailscale-system/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./services/ks.yaml
   - ./resources/ks.yaml
   - ./golink/ks.yaml
+  - ./idp/ks.yaml


### PR DESCRIPTION
## What

Stages `tsidp` in equestria's Flux tree per [docs/cluster-consolidation/13-stage-sgc-apps.md](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/13-stage-sgc-apps.md) — the one app of the original four (chrony, mosquitto, tsidp, home-assistant) not already migrated ahead of schedule.

Re-verified live before starting: `tsidp` is still running only on SGC (`tailscale-system` ns, `1/1`), not present anywhere in equestria's git tree or live cluster, `longhorn-critical` StorageClass still doesn't exist. All matches the doc's 2026-08-13 snapshot.

Copies the four `idp/` files verbatim from `stargate-command-cluster` (untouched there, no archaeology needed):

- `tsidp.yaml`: `replicas: 1 → 0` — the staging gate, per the doc's "staged is a replica count, not a Flux suspension" rule (suspending the Kustomization would also stop the VolSync restore from running).
- `ks.yaml`: added `../../../components/volsync-restore` (source had `fast-node-eviction` + `volsync` already, just missing `volsync-restore` for the first-deploy bind — the doc's "the copied file has none" is slightly off vs. what's actually in git today, corrected here). Kept the existing `dependsOn: [tailscale-operator, volsync-system/volsync]`. Left out `VOLSYNC_STORAGECLASS: longhorn-critical` since that StorageClass isn't live yet (piece 12 hasn't landed) — falls back to the component's `longhorn` default, per the doc's own documented fallback.
- Wired `./idp/ks.yaml` into `tailscale-system/kustomization.yaml`.

No secret work: equestria's `tailscale-system` already has its own `tailscale-authkey` Secret (verified live, reflected since 2026-06-04).

## Exit criteria (verify post-merge)

- `kubectl get kustomization -n tailscale-system tsidp` → `Ready: True`
- `kubectl get deploy -n tailscale-system tsidp` → `0/0`
- `kubectl get pvc -n tailscale-system tsidp` → `Bound`
- Once confirmed, remove `volsync-restore` from `components:` in a follow-up (don't repeat the home-assistant vault#120 recurrence flagged in the same doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)