### PR TITLE
fix(flux): protect cluster-secrets/shared-secrets/sops-age from prune

### DIFF
--- a/kubernetes/apps/cert-manager/home-operations.cert-manager.yaml
+++ b/kubernetes/apps/cert-manager/home-operations.cert-manager.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/cert-manager
   prune: true
+  # Unlike the granular per-app targets elsewhere (see
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md),
+  # this one protects the whole cert-manager namespace redirect -- TLS
+  # issuance underpins ingress across the entire estate.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -16,6 +16,10 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance
   prune: true
+  # See home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  # This is Flux itself -- never let a Kustomization ownership change
+  # cascade-delete the thing that reconciles everything else.
+  deletionPolicy: Orphan
   retryInterval: 2m
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -17,6 +17,8 @@ spec:
       namespace: *namespace
   path: ./kubernetes/apps/flux-system/flux-operator
   prune: true
+  # See flux-instance/ks.yaml.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/observability/alertmanager/ks.yaml
+++ b/kubernetes/apps/observability/alertmanager/ks.yaml
@@ -23,6 +23,9 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/observability/alertmanager
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/observability/alloy/ks.yaml
+++ b/kubernetes/apps/observability/alloy/ks.yaml
@@ -16,6 +16,9 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/observability/alloy
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/observability/crds/ks.yaml
+++ b/kubernetes/apps/observability/crds/ks.yaml
@@ -16,6 +16,9 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/observability/crds
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/observability/grafana-operator/ks.yaml
+++ b/kubernetes/apps/observability/grafana-operator/ks.yaml
@@ -19,6 +19,9 @@ spec:
       namespace: observability
   path: ./kubernetes/apps/observability/grafana-operator
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -19,6 +19,9 @@ spec:
   components:
     - ../../../components/postgres
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/observability/loki/ks.yaml
+++ b/kubernetes/apps/observability/loki/ks.yaml
@@ -15,6 +15,9 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/observability/priority-class/ks.yaml
+++ b/kubernetes/apps/observability/priority-class/ks.yaml
@@ -16,6 +16,9 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/observability/priority-class
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/observability/prometheus/ks.yaml
+++ b/kubernetes/apps/observability/prometheus/ks.yaml
@@ -23,6 +23,9 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/observability/prometheus
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/observability/silences/ks.yaml
+++ b/kubernetes/apps/observability/silences/ks.yaml
@@ -24,6 +24,9 @@ spec:
     - name: alertmanager
       namespace: observability
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/observability/tempo/ks.yaml
+++ b/kubernetes/apps/observability/tempo/ks.yaml
@@ -16,6 +16,9 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/observability/tempo
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/observability/thanos/ks.yaml
+++ b/kubernetes/apps/observability/thanos/ks.yaml
@@ -9,6 +9,9 @@ spec:
   targetNamespace: observability
   path: ./kubernetes/apps/observability/thanos
   prune: true
+  # Protects against deletion when piece 21's observability redirect
+  # migration lands -- see home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/flux/meta/cluster-secrets.sops.yaml
+++ b/kubernetes/flux/meta/cluster-secrets.sops.yaml
@@ -7,6 +7,7 @@ metadata:
     reloader.stakater.com/auto: "true"
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
   CLUSTER_CNAME: ENC[AES256_GCM,data:iTWIXLYcIkvm,iv:GsmJ9PrjOUVyhi56NTniArRiXwEb7/iUF8rS5OVVubo=,tag:BEe3mA/fRXKPB5YCLcwqdA==,type:str]
   CLUSTER_KEY: ENC[AES256_GCM,data:IW4XYVAcVSrR,iv:5mM5PY3yp5Gqd72ffTc5Ag2tixsPQiQWsXa4+vRo1VI=,tag:KxXiiAa6N2zl/2Uruj2BGw==,type:str]

--- a/kubernetes/flux/meta/shared-secrets.sops.yaml
+++ b/kubernetes/flux/meta/shared-secrets.sops.yaml
@@ -7,6 +7,7 @@ metadata:
     reloader.stakater.com/auto: "true"
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
   PUID: ENC[AES256_GCM,data:7e5n,iv:gmVNLAG0nGGL+ZV2yWOyY7lMOuYu+4wlZmlns5FnKDY=,tag:7vjYQnNEcsJuH1Yx6HrxCw==,type:str]
   PGID: ENC[AES256_GCM,data:czDu,iv:w0W7X/zHjHMZOinL8R7FC/x856D8sa2j0Mob9dDaFyg=,tag:1BoZlnJhltuG/clcuzxWwg==,type:str]

--- a/kubernetes/flux/meta/sops-age.sops.yaml
+++ b/kubernetes/flux/meta/sops-age.sops.yaml
@@ -7,6 +7,7 @@ metadata:
     reloader.stakater.com/auto: "true"
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
   age.agekey: ENC[AES256_GCM,data:NZaCuKDGV70neSSsoT6i+4XFVoPhB5i1p7Ub+2YY0b9wetm8/+tWNG/izZfA3KyzLa7BJZMjB2d370TQMiccbTIvSfqVcF6tj+A=,iv:j7RWqbhfZr7zut3+T1JXkS5goCckHy19EfLwL5meqCw=,tag:m1ZP99r7yiCJZCw/iXRiPg==,type:str]
 sops:


### PR DESCRIPTION
## What

Adds `kustomize.toolkit.fluxcd.io/prune: disabled` to all three `cluster-meta` Secrets (`cluster-secrets`, `shared-secrets`, `sops-age`).

Adds `spec.deletionPolicy: Orphan` to:
- `flux-system/flux-instance`, `flux-system/flux-operator` — Flux's own bootstrap chain
- the `cert-manager` namespace redirect — whole-namespace, since it's one Kustomization
- **the current native observability Kustomizations** (`alertmanager`, `alloy`, `crds`, `grafana`, `grafana-operator`, `loki`, `priority-class`, `prometheus`, `silences`, `tempo`, `thanos`) — these are the ones that will actually get pruned by `cluster-apps` the moment piece 21's observability redirect PR merges, so the protection has to live here, on the tree about to be deleted, not just on the post-migration replacement in home-operations

## Why

These are all direct fixes for live incidents on 2026-08-13 (`docs/cluster-consolidation/26` and `27` in home-operations), or proactive coverage for the same failure mode before it hits observability's still-pending migration. `deletionPolicy` is evaluated on the object actually being deleted — for the observability set specifically, that means the fix has to apply to *this* repo's current native copies, since `deletionPolicy: Orphan` on the future home-operations-side replacement wouldn't protect anything at the moment of the redirect flip itself.

## Verified safe

- `cluster-secrets`/`shared-secrets`/`sops-age`: confirmed with the (gitignored) `age.key` at repo root that each file still decrypts cleanly post-edit and the sops MAC is untouched. `.sops.yaml`'s `encrypted_regex: "^(data|stringData)$"` means only those fields are ever encrypted.
- All `kustomize build` targets validated clean, including the full `observability` namespace tree.

## Companion PRs

- david-driscoll/home-operations#778 (same `deletionPolicy: Orphan` treatment for cilium/coredns/traefik/traefik-crds/etc.)
- david-driscoll/home-operations#772 (the observability migration PR itself — already carries the post-migration side of this same fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)