### PR TITLE
fix(flux): deletionPolicy Orphan on the database and cloudnative-pg redirect stubs

### DIFF
--- a/kubernetes/apps/cloudnative-pg/home-operations.cloudnative-pg.yaml
+++ b/kubernetes/apps/cloudnative-pg/home-operations.cloudnative-pg.yaml
@@ -16,6 +16,8 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/cloudnative-pg
   prune: true
+  # See home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/database/home-operations.database.yaml
+++ b/kubernetes/apps/database/home-operations.database.yaml
@@ -16,6 +16,8 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/database
   prune: true
+  # See home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h


### PR DESCRIPTION
## What

Adds `spec.deletionPolicy: Orphan` to the `database` and `cloudnative-pg` namespace redirect stubs.

## Why

Companion to david-driscoll/home-operations#779. Same reasoning as the cert-manager redirect in #3161: `deletionPolicy` is evaluated on the object actually being deleted, so the redirect stubs need it too — not just the post-migration Kustomizations they point at.

These two namespaces were the ones #778/#3161 missed, and the 21:40Z 2026-08-13 cascade (external-secrets CRD deletion → CNPG Cluster CR + PVCs destroyed) landed squarely on them.

See `home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)