### PR TITLE
fix(tailscale-system): deletionPolicy Orphan ahead of the piece 21 redirect

### DIFF
--- a/kubernetes/apps/tailscale-system/golink/ks.yaml
+++ b/kubernetes/apps/tailscale-system/golink/ks.yaml
@@ -13,6 +13,12 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/golink
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -18,6 +18,12 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/iam
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/idp/ks.yaml
+++ b/kubernetes/apps/tailscale-system/idp/ks.yaml
@@ -18,6 +18,12 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/idp
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/operator/ks.yaml
+++ b/kubernetes/apps/tailscale-system/operator/ks.yaml
@@ -13,6 +13,12 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/operator
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/resources/ks.yaml
+++ b/kubernetes/apps/tailscale-system/resources/ks.yaml
@@ -13,6 +13,12 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/resources
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/services/ks.yaml
+++ b/kubernetes/apps/tailscale-system/services/ks.yaml
@@ -13,6 +13,12 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/services
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/taildrive/ks.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/ks.yaml
@@ -19,6 +19,12 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/taildrive
   prune: true
+  # Protects these from cascade-deletion when piece 21's redirect for
+  # this namespace lands. tailscale-system carries the operator and the
+  # egress Services OpenBao's unseal path runs through, so a prune here
+  # is far more expensive than most. See
+  # home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m


### PR DESCRIPTION
## What

Adds `spec.deletionPolicy: Orphan` to all seven `tailscale-system` Kustomizations: `operator`, `services`, `resources`, `golink`, `idp`, `iam`, and `taildrive`.

## Why this must land *before* the redirect

Same protective step that made the observability migration safe (#3161 landing before #3157). `deletionPolicy` is evaluated on **the object actually being deleted** — so it has to be live on *these* Kustomizations before the redirect prunes them, not on the home-operations copies that replace them.

Merging the redirect without this is what cascade-deleted live resources in `network` and `kube-system` earlier — see [26](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/26-bootstrap-apps-to-pulumi.md) and [27](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/27-migration-churn-failure-modes.md).

## Why this namespace especially

`tailscale-system` is a worse place than most to get this wrong:

- It carries the **Tailscale operator** — tailnet connectivity for the whole cluster
- It carries the **egress Services OpenBao's transit-unseal path runs through**. `kube-system/openbao/ks.yaml` explicitly `dependsOn` `tailscale-services` for exactly that reason (its comment block spells out that the pods reach `bao-transit` on alpha-site only via the dockge-as egress Service on port 8200)

A prune here doesn't churn one app — it can take the unseal path with it, which is precisely the failure we spent tonight recovering from.

`taildrive` is present on disk but not wired into `kustomization.yaml` `resources:` — carried for parity, inert either way.

Build validated. **Merge this before the tailscale-system redirect PRs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)