### PR TITLE
fix(flux): blanket deletionPolicy Orphan ahead of the remaining piece 21 migrations

### DIFF
--- a/kubernetes/apps/coder/home-operations.coder.yaml
+++ b/kubernetes/apps/coder/home-operations.coder.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/coder
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/equestria/books/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/equestria/books/audiobookshelf/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/books/audiobookshelf
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/books/lazylibrarian/ks.yaml
+++ b/kubernetes/apps/equestria/books/lazylibrarian/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/books/lazylibrarian
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/books/openbooks/ks.yaml
+++ b/kubernetes/apps/equestria/books/openbooks/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/books/openbooks
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/books/readarr-audio/ks.yaml
+++ b/kubernetes/apps/equestria/books/readarr-audio/ks.yaml
@@ -22,6 +22,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/books/readarr-audio
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/books/readarr-ebook/ks.yaml
+++ b/kubernetes/apps/equestria/books/readarr-ebook/ks.yaml
@@ -22,6 +22,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/books/readarr-ebook
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/dns/technitium/ks.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/equestria/dns/technitium
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/equestria/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/autobrr/ks.yaml
@@ -27,6 +27,11 @@ spec:
       namespace: database
   path: ./kubernetes/apps/equestria/downloads/autobrr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/prowlarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/downloads/prowlarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/qbittorrent/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/downloads/qbittorrent
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/sabnzbd/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/downloads/sabnzbd
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/games/habitica/ks.yaml
+++ b/kubernetes/apps/equestria/games/habitica/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/equestria/games/habitica
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/games/playerr/ks.yaml
+++ b/kubernetes/apps/equestria/games/playerr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/games/playerr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/games/questarr/ks.yaml
+++ b/kubernetes/apps/equestria/games/questarr/ks.yaml
@@ -25,6 +25,11 @@ spec:
       namespace: database
   path: ./kubernetes/apps/equestria/games/questarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/games/retrom/ks.yaml
+++ b/kubernetes/apps/equestria/games/retrom/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/games/retrom
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/equestria/games/romm/ks.yaml
+++ b/kubernetes/apps/equestria/games/romm/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/equestria/games/romm
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/collabora/ks.yaml
+++ b/kubernetes/apps/equestria/home/collabora/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/collabora
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/dynacat/ks.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: kube-system
   path: ./dashboard
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/equestria/home/freshrss/ks.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/equestria/home/freshrss
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   force: false
   wait: true
   interval: 1h

--- a/kubernetes/apps/equestria/home/immich/ks.yaml
+++ b/kubernetes/apps/equestria/home/immich/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/immich
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/karakeep/ks.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/ks.yaml
@@ -19,6 +19,11 @@ spec:
       namespace: equestria
   path: ./kubernetes/apps/equestria/home/karakeep
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   force: false
   wait: true
   interval: 1h

--- a/kubernetes/apps/equestria/home/meilisearch/ks.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/meilisearch
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   timeout: 10m

--- a/kubernetes/apps/equestria/home/n8n/ks.yaml
+++ b/kubernetes/apps/equestria/home/n8n/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/n8n
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/obsidian-sync/ks.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/equestria/home/obsidian-sync
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/outline/ks.yaml
+++ b/kubernetes/apps/equestria/home/outline/ks.yaml
@@ -17,6 +17,11 @@ spec:
   dependsOn: []
   path: ./kubernetes/apps/equestria/home/outline
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   force: false
   wait: true
   interval: 1h

--- a/kubernetes/apps/equestria/home/rustdesk/ks.yaml
+++ b/kubernetes/apps/equestria/home/rustdesk/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/rustdesk
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/searxng/ks.yaml
+++ b/kubernetes/apps/equestria/home/searxng/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/equestria/home/searxng
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/super-productivity/ks.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/super-productivity
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/home/tandoor/ks.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/equestria/home/tandoor
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   force: false
   wait: true
   interval: 1h

--- a/kubernetes/apps/equestria/home/tududi/ks.yaml
+++ b/kubernetes/apps/equestria/home/tududi/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/tududi
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   force: false
   wait: true
   interval: 1h

--- a/kubernetes/apps/equestria/home/windmill/ks.yaml
+++ b/kubernetes/apps/equestria/home/windmill/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/home/windmill
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/idp/authentik-remote-cluster/ks.yaml
+++ b/kubernetes/apps/equestria/idp/authentik-remote-cluster/ks.yaml
@@ -16,6 +16,11 @@ spec:
   dependsOn: []
   path: ./kubernetes/apps/equestria/idp/authentik-remote-cluster
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/bazarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/bazarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/bazarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/emby/ks.yaml
+++ b/kubernetes/apps/equestria/media/emby/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/emby
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   timeout: 1h

--- a/kubernetes/apps/equestria/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/equestria/media/jellyfin/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/jellyfin
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   timeout: 1h

--- a/kubernetes/apps/equestria/media/jellyseerr/ks.yaml
+++ b/kubernetes/apps/equestria/media/jellyseerr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/jellyseerr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/kapowarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/kapowarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/kapowarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/kometa/ks.yaml
+++ b/kubernetes/apps/equestria/media/kometa/ks.yaml
@@ -22,6 +22,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/equestria/media/kometa
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/lidarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/lidarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/lidarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/mylar/ks.yaml
+++ b/kubernetes/apps/equestria/media/mylar/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/mylar
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/pinepods/ks.yaml
+++ b/kubernetes/apps/equestria/media/pinepods/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/media/pinepods
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   timeout: 10m

--- a/kubernetes/apps/equestria/media/plex/ks.yaml
+++ b/kubernetes/apps/equestria/media/plex/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/plex
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/pulsarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/pulsarr/ks.yaml
@@ -25,6 +25,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/pulsarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/radarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/radarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/radarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/seerr/ks.yaml
+++ b/kubernetes/apps/equestria/media/seerr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/seerr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/sonarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/sonarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/sonarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/stremio/ks.yaml
+++ b/kubernetes/apps/equestria/media/stremio/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/stremio
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/tautulli/ks.yaml
+++ b/kubernetes/apps/equestria/media/tautulli/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/media/tautulli
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/media/tdarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/tdarr/ks.yaml
@@ -18,6 +18,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/equestria/media/tdarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/equestria/media/watchstate/ks.yaml
+++ b/kubernetes/apps/equestria/media/watchstate/ks.yaml
@@ -19,6 +19,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/equestria/media/watchstate
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/dispatcharr/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/dispatcharr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/dispatcharr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/ecm/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/ecm/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/ecm
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/ersatztv/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/ersatztv/ks.yaml
@@ -20,6 +20,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/ersatztv
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/game-thumbs/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/game-thumbs/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/game-thumbs
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/identifiarr/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/identifiarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/identifiarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/iptv-sync/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/iptv-sync/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/iptv-sync
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/kptv-fast/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/kptv-fast/ks.yaml
@@ -19,6 +19,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/kptv-fast
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/strmgen/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/strmgen/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/strmgen
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/teamarr/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/teamarr/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: tailscale-system
   path: ./kubernetes/apps/equestria/pvr/teamarr
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/pvr/xcproxy/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/xcproxy/ks.yaml
@@ -21,6 +21,11 @@ spec:
     - name: external-secrets
       namespace: kube-system
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   suspend: false

--- a/kubernetes/apps/equestria/shared/secrets/ks.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/ks.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/equestria/shared/secrets
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/shared/volumes/ks.yaml
+++ b/kubernetes/apps/equestria/shared/volumes/ks.yaml
@@ -21,6 +21,11 @@ spec:
       namespace: nfs-system
   path: ./kubernetes/apps/equestria/shared/volumes
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/equestria/utils/librespeed/ks.yaml
+++ b/kubernetes/apps/equestria/utils/librespeed/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/utils/librespeed
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/equestria/utils/openspeedtest/ks.yaml
+++ b/kubernetes/apps/equestria/utils/openspeedtest/ks.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/equestria/utils/openspeedtest
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/equestria/utils/whoami/ks.yaml
+++ b/kubernetes/apps/equestria/utils/whoami/ks.yaml
@@ -19,6 +19,11 @@ spec:
       namespace: network
   path: ./kubernetes/apps/equestria/utils/whoami
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/flux-system/repositories/ks.yaml
+++ b/kubernetes/apps/flux-system/repositories/ks.yaml
@@ -16,6 +16,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/flux-system/repositories
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   retryInterval: 2m
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/github-actions/home-operations.github-actions.yaml
+++ b/kubernetes/apps/github-actions/home-operations.github-actions.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/github-actions
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/kube-system/home-operations.kube-system.yaml
+++ b/kubernetes/apps/kube-system/home-operations.kube-system.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/kube-system
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/longhorn-system/home-operations.longhorn-system.yaml
+++ b/kubernetes/apps/longhorn-system/home-operations.longhorn-system.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/longhorn-system
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/network/home-operations.network.yaml
+++ b/kubernetes/apps/network/home-operations.network.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/network
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/nfs-system/home-operations.nfs-system.yaml
+++ b/kubernetes/apps/nfs-system/home-operations.nfs-system.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/nfs-system
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/openebs-system/home-operations.openebs-system.yaml
+++ b/kubernetes/apps/openebs-system/home-operations.openebs-system.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/openebs-system
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/pulumi/home-operations.pulumi.yaml
+++ b/kubernetes/apps/pulumi/home-operations.pulumi.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/pulumi
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/stargate-command/chrony/ks.yaml
+++ b/kubernetes/apps/stargate-command/chrony/ks.yaml
@@ -18,6 +18,11 @@ spec:
       namespace: *namespace
   path: ./kubernetes/apps/stargate-command/chrony
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/stargate-command/home-assistant/ks.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/ks.yaml
@@ -15,6 +15,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/stargate-command/home-assistant
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/stargate-command/matter/ks.yaml
+++ b/kubernetes/apps/stargate-command/matter/ks.yaml
@@ -15,6 +15,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/stargate-command/matter
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/stargate-command/mosquitto/ks.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/ks.yaml
@@ -15,6 +15,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/stargate-command/mosquitto
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/stargate-command/secrets/ks.yaml
+++ b/kubernetes/apps/stargate-command/secrets/ks.yaml
@@ -17,6 +17,11 @@ spec:
       namespace: kube-system
   path: ./kubernetes/apps/stargate-command/secrets
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/system-upgrade/home-operations.system-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/home-operations.system-upgrade.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/system-upgrade
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/golink/ks.yaml
+++ b/kubernetes/apps/tailscale-system/golink/ks.yaml
@@ -13,6 +13,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/golink
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -18,6 +18,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/iam
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/idp/ks.yaml
+++ b/kubernetes/apps/tailscale-system/idp/ks.yaml
@@ -18,6 +18,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/idp
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/operator/ks.yaml
+++ b/kubernetes/apps/tailscale-system/operator/ks.yaml
@@ -13,6 +13,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/operator
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/resources/ks.yaml
+++ b/kubernetes/apps/tailscale-system/resources/ks.yaml
@@ -13,6 +13,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/resources
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/services/ks.yaml
+++ b/kubernetes/apps/tailscale-system/services/ks.yaml
@@ -13,6 +13,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/tailscale-system/services
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h

--- a/kubernetes/apps/tailscale-system/taildrive/ks.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/ks.yaml
@@ -19,6 +19,11 @@ spec:
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/taildrive
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   interval: 1h
   retryInterval: 2m

--- a/kubernetes/apps/volsync-system/home-operations.volsync-system.yaml
+++ b/kubernetes/apps/volsync-system/home-operations.volsync-system.yaml
@@ -16,6 +16,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/volsync-system
   prune: true
+  # Blanket protection for the piece 21 migration sweep: a Kustomization
+  # ownership change must never cascade-delete live resources. Removed
+  # again on the home-operations side once each namespace has landed.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: false
   force: false
   interval: 1h


### PR DESCRIPTION
## Phase 1 of 2 for finishing the repo consolidation

Every Kustomization ownership change during this migration is a **delete-then-recreate** of whatever that Kustomization manages. On 2026-08-13 that cost us twice:

- the `network` redirect cascade-deleted **every Traefik/Gateway API CRD cluster-wide**
- the `kube-system`/`database` churn took the **CNPG Cluster CR and its PVCs**

Both written up in [26](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/26-bootstrap-apps-to-pulumi.md) and [27](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/27-migration-churn-failure-modes.md).

`deletionPolicy: Orphan` turns that prune into a no-op for the managed resources — they survive and the replacement Kustomization adopts them. **It has to be live on the object before the redirect prunes it**, which is why this is a separate, earlier PR rather than folded into each migration. That ordering is exactly what made the observability migration (#3161 → #3157) uneventful.

## Coverage — all 87 remaining unprotected Kustomizations

| Count | Scope |
|---|---|
| 64 | `equestria/*` — the last big namespace to migrate |
| 7 | `tailscale-system/*` — operator + the egress Services OpenBao's transit-unseal path depends on |
| 5 | `stargate-command/*` — chrony, mosquitto, home-assistant, matter, secrets (**home-assistant is Tier 1**) |
| 1 | `flux-system/*` |
| 10 | `home-operations.<ns>.yaml` redirect stubs for already-migrated namespaces, so the eventual Phase C root flip can't prune them either |

## Deliberately blunt, deliberately temporary

Orphan trades away Flux's normal cleanup guarantee. That's an acceptable trade *during* a migration and a bad default afterwards — so the home-operations copies **drop it again as each namespace lands**, keeping it only where genuinely warranted (CRDs, cilium, coredns, traefik, openbao and friends, per home-operations#778).

All 18 namespaces validated with `kustomize build`.

**Supersedes #3166**, which did the tailscale-system subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)