### PR TITLE
fix(flux): disable prune on the LIVE roots before the Phase C flip

### DIFF
--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -12,7 +12,24 @@ spec:
       name: sops-age
   interval: 1h
   path: ./kubernetes/flux/meta
-  prune: true
+  # TEMPORARY, for the piece 21 Phase C root flip. Restored to `true` only
+  # after the flip is verified. See
+  # home-operations:docs/cluster-consolidation/21-repo-consolidation-flux-repoint.md.
+  #
+  # This MUST be live HERE, in equestria-cluster's copy, BEFORE the flip.
+  # home-operations' copy also carries it, but that copy does not become live
+  # until the flip itself -- which is too late. At the instant
+  # `instance.sync.url` changes, GitRepository/flux-system re-resolves and
+  # cluster-apps reconciles against a tree it has never read, using the spec it
+  # holds AT THAT MOMENT. The root Kustomization updating that spec is a
+  # separate reconcile, and the two race. Losing that race with prune enabled
+  # means cluster-apps garbage-collects everything it cannot find in the new
+  # tree.
+  #
+  # Setting it here removes the race entirely: prune is already disabled before
+  # the source moves, so whichever order the reconciles land in, nothing is
+  # pruned.
+  prune: false
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
@@ -38,7 +55,24 @@ spec:
       namespace: flux-system
   interval: 1h
   path: ./kubernetes/apps
-  prune: true
+  # TEMPORARY, for the piece 21 Phase C root flip. Restored to `true` only
+  # after the flip is verified. See
+  # home-operations:docs/cluster-consolidation/21-repo-consolidation-flux-repoint.md.
+  #
+  # This MUST be live HERE, in equestria-cluster's copy, BEFORE the flip.
+  # home-operations' copy also carries it, but that copy does not become live
+  # until the flip itself -- which is too late. At the instant
+  # `instance.sync.url` changes, GitRepository/flux-system re-resolves and
+  # cluster-apps reconciles against a tree it has never read, using the spec it
+  # holds AT THAT MOMENT. The root Kustomization updating that spec is a
+  # separate reconcile, and the two race. Losing that race with prune enabled
+  # means cluster-apps garbage-collects everything it cannot find in the new
+  # tree.
+  #
+  # Setting it here removes the race entirely: prune is already disabled before
+  # the source moves, so whichever order the reconciles land in, nothing is
+  # pruned.
+  prune: false
   retryInterval: 2m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
**This is the missing precondition for the flip.** Verification came back:

```
$ kubectl get kustomization -n flux-system cluster-meta cluster-apps
NAME           PRUNE   SRC           PATH
cluster-meta   true    flux-system   ./kubernetes/flux/meta
cluster-apps   true    flux-system   ./kubernetes/apps
```

`prune` is **still `true` live.** home-operations#803 put `prune: false` in *its* copy of `kubernetes/flux/cluster/ks.yaml` — but that copy doesn't become live until the flip, so it can't protect the flip. The live roots are still defined here.

## Why staging it in the destination isn't enough

At the instant `instance.sync.url` changes:

1. `GitRepository/flux-system` re-resolves to home-operations.
2. `cluster-apps` **watches that GitRepository**, so it reconciles against a tree it has never read — using the spec it holds *at that moment*, which is `prune: true`.
3. Separately, the root `flux-system` Kustomization reconciles and rewrites `cluster-apps`'s spec to `prune: false`.

**Steps 2 and 3 race.** Lose it, and `cluster-apps` garbage-collects every object it can't find in the new tree — at this cluster's scale, most of it. That is exactly the failure the `prune: false` step exists to prevent, and staging it only in the destination repo left it unprevented.

Setting it here removes the race: prune is already disabled *before* the source moves, so whichever order the reconciles land in, nothing is pruned.

## Cost during the window

No garbage collection from either root. Deletions in this tree won't be reaped until prune is restored — intended, and it ends at Phase C step 4, when `prune: true` goes back on home-operations' copy (the live one by then).

## Verify after merge, before flipping

```bash
kubectl get kustomization -n flux-system cluster-meta cluster-apps \
  -o custom-columns='NAME:.metadata.name,PRUNE:.spec.prune'
# both must read false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)