### PR TITLE
feat(flux): flip the root to home-operations (piece 21 Phase C)

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
@@ -15,7 +15,7 @@ instance:
   sync:
     name: flux-system
     kind: GitRepository
-    url: "https://github.com/david-driscoll/equestria-cluster.git"
+    url: "https://github.com/david-driscoll/home-operations.git"
     ref: "refs/heads/main"
     path: kubernetes/flux/cluster
   kustomize:


### PR DESCRIPTION
**One line.** This is the flip.

```diff
-    url: "https://github.com/david-driscoll/equestria-cluster.git"
+    url: "https://github.com/david-driscoll/home-operations.git"
```

`name`, `kind`, `ref` and `path` are untouched — Phase B copied the same relative layout. Merging this is the moment `GitRepository/flux-system` re-resolves and `cluster-meta`/`cluster-apps` start reading home-operations.

> **Merge david-driscoll/home-operations#809 first.** It is the last gap.

## Preconditions — all verified live, not merely merged

| Check | Status |
|---|---|
| `prune: false` **live** on both roots | ✅ #3171, confirmed via `kubectl` |
| Kustomizations Ready | ✅ 174 / 174 |
| Every equestria namespace dir exists in home-operations | ⏳ `stargate-command` closed by #809 |
| `kubernetes/flux/meta` byte-identical | ✅ `diff -r` clean |
| home-operations `cluster/ks.yaml` carries `prune: false` | ✅ #803 |
| `cluster-versions` resolves post-flip | ✅ `versions.env` + generator, #803 |

The `prune: false` one is what makes this safe. `cluster-apps` **watches** `GitRepository/flux-system`, so at the flip it reconciles against the new tree using the spec it holds *at that instant* — while the root Kustomization rewriting that spec to `prune: false` is a *separate* reconcile. Those race. Disabling prune in this repo first removes the race entirely.

Without #809, `stargate-command`'s five Kustomizations — live Home Assistant, Mosquitto, Matter, chrony — would resolve to paths that don't exist in home-operations and go `NotReady`. Nothing deleted, but 174/174 → 169/174 with the home-automation stack unmanaged.

## Not bundled here

**Re-enabling prune.** That's a separate, deliberate act after verification — and the 16 `-ref` Kustomizations should be deleted by hand first, one at a time, while prune is still off. See the revised Phase C section in the piece doc.

## Rollback

One revert of this commit. This repo's tree is intact — the `flux-system` namespace was never redirected (#3170 was closed in favour of the no-op approach), so reverting lands on a tree that still fully defines Flux.

## Verify immediately after merge

```bash
kubectl get gitrepository -n flux-system flux-system -o jsonpath='{.spec.url}{"\n"}'
kubectl get kustomization -A --no-headers | awk '$4!="True"'   # expect empty
flux get kustomizations -A | grep -c 'main@sha1'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)